### PR TITLE
Vagrant autocompletion plugin

### DIFF
--- a/plugins/vagrant.plugins.bash
+++ b/plugins/vagrant.plugins.bash
@@ -3,23 +3,29 @@ _vagrant()
 {
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-
+    commands="box destroy halt help init package provision reload resume ssh ssh_config status suspend up version"
 
     if [ $COMP_CWORD == 1 ]
     then
-      commands="box destroy halt help init package provision reload resume ssh ssh_config status suspend up version"
       COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
       return 0
     fi
 
     if [ $COMP_CWORD == 2 ]
     then
-      if [ $prev == 'box' ]
-      then
-          commands="add help list remove repackage"
-          COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
-          return 0
-      fi
+        case "$prev" in
+            "box")
+              box_commands="add help list remove repackage"
+              COMPREPLY=($(compgen -W "${box_commands}" -- ${cur}))
+              return 0
+            ;;
+            "help")
+              COMPREPLY=($(compgen -W "${commands}" -- ${cur}))
+              return 0
+            ;;
+            *)
+            ;;
+        esac
     fi
 
     if [ $COMP_CWORD == 3 ]
@@ -29,8 +35,8 @@ _vagrant()
       then
         case "$prev" in
             "remove"|"repackage")
-              local vagrantlist=$(find $HOME/.vagrant/boxes/* -maxdepth 0 -type d -printf '%f ')
-              COMPREPLY=($(compgen -W "${vagrantlist}" -- ${cur}))
+              local box_list=$(find $HOME/.vagrant/boxes/* -maxdepth 0 -type d -printf '%f ')
+              COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
               ;;
             *)


### PR DESCRIPTION
Hi Mark and Robert!
Thanks for a great project!

I really like it and want to contribute back. Here is plugin for Vagrant(http://vagrantup.com/).

Vagrant is a tool for building and distributing virtualized development environments. This project is gaining lots of attention these days. So I hope oh-my-zsh will benefit because of that plugin.

Here is what it does:
- supports autocompletion for vagrant basic documentation(all commands, nested including)
- supports autocompletion of environment-specific data.

It was well tested(all paths, fresh install of vagrant with no data) - all seems to work fine.
What do you think?
