### PR TITLE
Adds git prompt support below the root of the repository

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -22,6 +22,7 @@ RVM_THEME_PROMPT_SUFFIX='|'
 
 function scm {
   if [[ -d .git ]]; then SCM=$GIT
+  elif [[ -n "$(git symbolic-ref HEAD 2> /dev/null)" ]]; then SCM=$GIT
   elif [[ -d .hg ]]; then SCM=$HG
   elif [[ -d .svn ]]; then SCM=$SVN
   else SCM='NONE'


### PR DESCRIPTION
I made a change to allow git prompt support below the root of the repository.  If you are in a directory below the root, you still get branch and status info.

I added this to my master branch too quickly.  If you'd prefer me to add to a feature branch and redo the pull request, I can.  Just let me know.

Jeff
