### PR TITLE
Fix bug in the battery plugin

### DIFF
--- a/plugins/battery.plugin.bash
+++ b/plugins/battery.plugin.bash
@@ -6,13 +6,37 @@ battery_percentage(){
     local ACPI_OUTPUT=$(acpi -b)
     case $ACPI_OUTPUT in
       *" Unknown"*) 
-        echo $ACPI_OUTPUT | head -c 22 | tail -c 2
+        local PERC_OUTPUT=$(echo $ACPI_OUTPUT | head -c 22 | tail -c 2)
+        case $PERC_OUTPUT in
+          *%)
+            echo "0${PERC_OUTPUT}" | head -c 2
+            ;;
+          *)
+            echo ${PERC_OUTPUT}
+            ;;
+        esac
         ;;
       *" Discharging"*) 
-        echo $ACPI_OUTPUT | head -c 26 | tail -c 2
+        local PERC_OUTPUT=$(echo $ACPI_OUTPUT | head -c 26 | tail -c 2)
+        case $PERC_OUTPUT in
+          *%)
+            echo "0${PERC_OUTPUT}" | head -c 2
+            ;;
+          *)
+            echo ${PERC_OUTPUT}
+            ;;
+        esac
         ;;
       *" Charging"*) 
-        echo $ACPI_OUTPUT | head -c 23 | tail -c 2
+        local PERC_OUTPUT=$(echo $ACPI_OUTPUT | head -c 23 | tail -c 2)
+        case $PERC_OUTPUT in
+          *%)
+            echo "0${PERC_OUTPUT}" | head -c 2
+            ;;
+          *)
+            echo ${PERC_OUTPUT}
+            ;;
+        esac
         ;;
       *" Full"*) 
         echo '99'


### PR DESCRIPTION
I notice that the function battery_percentage was giving output in a wrong format when the battery was below 10%. I fix it in Linux but I need someone to tell me if it happens the same on the macs.

Basically the battery_charge function needs a two-digit value to work and it was getting 9% instead of 09. I don't know if the ioreg we'll behave the same or not.
