### PR TITLE
Added alias for rake db:migrate

### DIFF
--- a/aliases/rails.aliases.bash
+++ b/aliases/rails.aliases.bash
@@ -10,6 +10,7 @@ alias rd='rails dbconsole'
 alias rp='rails plugin'
 alias ra='rails application'
 alias rd='rails destroy'
+alias dbm='rake db:migrate'
 
 alias ss='script/server'
 alias ts="thin start"     # thin server


### PR DESCRIPTION
`dbm` is a useful alias for `rake db:migrate`
