### PR TITLE
Added "hg_prompt_info" to base theme

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -82,6 +82,20 @@ function svn_prompt_info {
   echo -e "$prefix$ref$state$suffix"
 }
 
+function hg_prompt_info() {
+    if [[ -n $(hg status 2> /dev/null) ]]; then
+        state=${HG_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
+    else
+        state=${HG_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
+    fi
+    prefix=${HG_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
+    suffix=${HG_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
+    branch=$(hg summary 2> /dev/null | grep branch | awk '{print $2}')
+    changeset=$(hg summary 2> /dev/null | grep parent | awk '{print $2}')
+
+    echo -e "$prefix${REF_COLOR}${branch}${DEFAULT_COLOR}:${changeset#*:}$state$suffix"
+}
+
 function rvm_version_prompt {
   if which rvm &> /dev/null; then
     rvm=$(rvm tools identifier) || return


### PR DESCRIPTION
In the base theme, `hg_prompt_info` is used by `scm_prompt_info` but is not defined. This results in an error when running `hg status`
