### PR TITLE
Remove variables from hg_prompt_info specific to hawaii50 theme

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -93,7 +93,7 @@ function hg_prompt_info() {
     branch=$(hg summary 2> /dev/null | grep branch | awk '{print $2}')
     changeset=$(hg summary 2> /dev/null | grep parent | awk '{print $2}')
 
-    echo -e "$prefix${REF_COLOR}${branch}${DEFAULT_COLOR}:${changeset#*:}$state$suffix"
+    echo -e "$prefix$branch:${changeset#*:}$state$suffix"
 }
 
 function rvm_version_prompt {


### PR DESCRIPTION
There were a few variables from the merge in dbbd69ed6e8b32d17bdbd5624747cc4480547180 that shouldn't be in the base theme.
