### PR TITLE
Get rid of "Fatal error: not a git repository…" errors

### DIFF
--- a/themes/doubletime/doubletime.theme.bash
+++ b/themes/doubletime/doubletime.theme.bash
@@ -17,11 +17,12 @@ fi
 
 doubletime_scm_prompt() {
   CHAR=$(scm_char)
-  if [ $CHAR = $SCM_NONE_CHAR ]
-  then
+  if [ $CHAR = $SCM_NONE_CHAR ]; then
     return
-  else
+  elif [ $CHAR = $SCM_GIT_CHAR ]; then
     echo "$(git_prompt_status)"
+  else
+    echo "[$(scm_prompt_info)]"
   fi
 }
 


### PR DESCRIPTION
The doubletime theme improves the SCM status prompt for git. However, it accomplishes this at the expense of other SCM systems. This delegates prompt to the default bash-it prompt function when the SCM is not git.

Previous to this commit, entering a project that is checked out from SVN for example results in multiple errors:

Saturday, Jun 25, 10:16 ○ [jcarouth@setesh.local] ~
 $ cd projects/mobile/
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
fatal: Not a git repository (or any of the parent directories): .git
