### PR TITLE
[theme:zork]Make $HOSTNAME not necessary for hostname.

### DIFF
--- a/themes/zork/zork.theme.bash
+++ b/themes/zork/zork.theme.bash
@@ -53,6 +53,8 @@ prompt() {
             ;;
     "pandora") my_ps_host="${red}\h${normal}";
             ;;
+    * ) my_ps_host="${green}\h${normal}";
+            ;;
     esac
 
     my_ps_user="\[\033[01;32m\]\u\[\033[00m\]";


### PR DESCRIPTION
In zork theme, $HOSTNAME determine the color of hostname part.
but if $HOSTNAME not found, not display hostname.

I made it displayed as green, if there are not $HOSTNAME.
