### PR TITLE
Show rbenv's active ruby rather than global ruby in theme

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -121,7 +121,7 @@ function rvm_version_prompt {
 
 function rbenv_version_prompt {
   if which rbenv &> /dev/null; then
-    rbenv=$(rbenv global) || return
+    rbenv=$(rbenv version-name) || return
     echo -e "$RBENV_THEME_PROMPT_PREFIX$rbenv$RBENV_THEME_PROMPT_SUFFIX"
   fi
 }


### PR DESCRIPTION
Currently the rbenv_version_prompt always displays the global version of ruby, even if a different shell/local version is active.
