### PR TITLE
More precise Git test expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ aliases/custom.aliases.bash
 lib/custom.bash
 plugins/custom.plugins.bash
 *.swp
+.*.un~

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -31,7 +31,7 @@ RBFU_THEME_PROMPT_PREFIX=' |'
 RBFU_THEME_PROMPT_SUFFIX='|'
 
 function scm {
-  if [[ -d .git ]]; then SCM=$SCM_GIT
+  if [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
   elif [[ -n "$(git symbolic-ref HEAD 2> /dev/null)" ]]; then SCM=$SCM_GIT
   elif [[ -d .hg ]]; then SCM=$SCM_HG
   elif [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG


### PR DESCRIPTION
Hi, sometimes directory which has the `.git` doesn't mean it's the real Git repository, e.g. `~/.git/hooks`. So I change the test expression for Git, may it help.
