### PR TITLE
Fixed missing comment symbols in base.plugin.bash

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -4,21 +4,21 @@
 
 ips ()
 {
-    about display all ip addresses for this host
+    # about display all ip addresses for this host
     ifconfig | grep "inet " | awk '{ print $2 }'
 }
 
 down4me ()
 {
-    about checks whether a website is down for you, or everybody
-    param 1: website url
+    # about checks whether a website is down for you, or everybody
+    # param 1: website url
     example $ down4me http://www.google.com
     curl -s "http://www.downforeveryoneorjustme.com/$1" | sed '/just you/!d;s/<[^>]*>//g'
 }
 
 myip ()
 {
-    about displays your ip address, as seen by the Internet
+    # about displays your ip address, as seen by the Internet
     res=$(curl -s checkip.dyndns.org | grep -Eo '[0-9\.]+')
     echo -e "Your public IP is: ${echo_bold_green} $res ${echo_normal}"
 }
@@ -26,9 +26,9 @@ myip ()
 
 pickfrom ()
 {
-    about picks random line from file
-    param 1: filename
-    example $ pickfrom /usr/share/dict/words
+    # about picks random line from file
+    # param 1: filename
+    # example $ pickfrom /usr/share/dict/words
     local file=$1
     [ -z "$file" ] && reference $FUNCNAME && return
     length=$(cat $file | wc -l)
@@ -38,11 +38,11 @@ pickfrom ()
 
 pass ()
 {
-    about generates random password from dictionary words
-    param optional integer length
-    param if unset, defaults to 4
-    example $ pass
-    example $ pass 6
+    # about generates random password from dictionary words
+    # param optional integer length
+    # param if unset, defaults to 4
+    # example $ pass
+    # example $ pass 6
     local i pass length=${1:-4}
     pass=$(echo $(for i in $(eval echo "{1..$length}"); do pickfrom /usr/share/dict/words; done))
     echo "With spaces (easier to memorize): $pass"
@@ -51,9 +51,9 @@ pass ()
 
 pmdown ()
 {
-    about preview markdown file in a browser
-    param 1: markdown file
-    example $ pmdown README.md
+    # about preview markdown file in a browser
+    # param 1: markdown file
+    # example $ pmdown README.md
     if command -v markdown &>/dev/null
     then
       markdown $1 | browser
@@ -64,63 +64,63 @@ pmdown ()
 
 mkcd ()
 {
-    about make a directory and cd into it
-    param path to create
-    example $ mkcd foo
-    example $ mkcd /tmp/img/photos/large
+    # about make a directory and cd into it
+    # param path to create
+    # example $ mkcd foo
+    # example $ mkcd /tmp/img/photos/large
     mkdir -p "$*"
     cd "$*"
 }
 
 lsgrep ()
 {
-    about search through directory contents with grep
+    # about search through directory contents with grep
     ls | grep "$*"
 }
 
 
 pman ()
 {
-    about view man documentation in Preview
-    param 1: man page to view
-    example $ pman bash
+    # about view man documentation in Preview
+    # param 1: man page to view
+    # example $ pman bash
     man -t "${1}" | open -f -a $PREVIEW
 }
 
 
 pcurl ()
 {
-    about download file and Preview it
-    param 1: download URL
-    example $ pcurl http://www.irs.gov/pub/irs-pdf/fw4.pdf
+    # about download file and Preview it
+    # param 1: download URL
+    # example $ pcurl http://www.irs.gov/pub/irs-pdf/fw4.pdf
     curl "${1}" | open -f -a $PREVIEW
 }
 
 pri ()
 {
-    about display information about Ruby classes, modules, or methods, in Preview
-    param 1: Ruby method, module, or class
-    example $ pri Array
+    # about display information about Ruby classes, modules, or methods, in Preview
+    # param 1: Ruby method, module, or class
+    # example $ pri Array
     ri -T "${1}" | open -f -a $PREVIEW
 }
 
 quiet ()
 {
-	$* &> /dev/null &
+    $* &> /dev/null &
 }
 
 banish-cookies ()
 {
-    about redirect .adobe and .macromedia files to /dev/null
-	rm -r ~/.macromedia ~/.adobe
-	ln -s /dev/null ~/.adobe
-	ln -s /dev/null ~/.macromedia
+    # about redirect .adobe and .macromedia files to /dev/null
+    rm -r ~/.macromedia ~/.adobe
+    ln -s /dev/null ~/.adobe
+    ln -s /dev/null ~/.macromedia
 }
 
 usage ()
 {
-    about disk usage per directory, in Mac OS X and Linux
-    param 1: directory name
+    # about disk usage per directory, in Mac OS X and Linux
+    # param 1: directory name
     if [ $(uname) = "Darwin" ]; then
         if [ -n $1 ]; then
             du -hd $1
@@ -139,27 +139,27 @@ usage ()
 
 t ()
 {
-    about one thing todo
-    param if not set, display todo item
-    param 1: todo text
-	if [[ "$*" == "" ]] ; then
-	    cat ~/.t
-	else
-	    echo "$*" > ~/.t
-	fi
+    # about one thing todo
+    # param if not set, display todo item
+    # param 1: todo text
+    if [[ "$*" == "" ]] ; then
+        cat ~/.t
+    else
+        echo "$*" > ~/.t
+    fi
 }
 
 command_exists ()
 {
-    about checks for existence of a command
-    param 1: command to check
-    example $ command_exists ls && echo 'exists'
+    # about checks for existence of a command
+    # param 1: command to check
+    # example $ command_exists ls && echo 'exists'
     type "$1" &> /dev/null ;
 }
 
 plugins-help ()
 {
-    about list all plugins and functions defined by bash-it
+    # about list all plugins and functions defined by bash-it
     echo "bash-it Plugins Help-Message"
     echo
 
@@ -178,8 +178,8 @@ plugins-help ()
 # useful for administrators and configs
 buf ()
 {
-    about back up file with timestamp
-    param filename
+    # about back up file with timestamp
+    # param filename
     local filename=$1
     local filetime=$(date +%Y%m%d_%H%M%S)
     cp ${filename} ${filename}_${filetime}


### PR DESCRIPTION
The # symbols in all the functions in base.plugin.bash had disappeared which made most functions fail. I've readded them. 
