### PR TITLE
plugin-specific metadata

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-# For generic functions.
+cite about-plugin
+about-plugin generic and miscellaneous tools
 
 ips ()
 {
     about display all ip addresses for this host
+    group base
     ifconfig | grep "inet " | awk '{ print $2 }'
 }
 
@@ -13,12 +15,14 @@ down4me ()
     about checks whether a website is down for you, or everybody
     param 1: website url
     example '$ down4me http://www.google.com'
+    group base
     curl -s "http://www.downforeveryoneorjustme.com/$1" | sed '/just you/!d;s/<[^>]*>//g'
 }
 
 myip ()
 {
     about displays your ip address, as seen by the Internet
+    group base
     res=$(curl -s checkip.dyndns.org | grep -Eo '[0-9\.]+')
     echo -e "Your public IP is: ${echo_bold_green} $res ${echo_normal}"
 }
@@ -29,6 +33,7 @@ pickfrom ()
     about picks random line from file
     param 1: filename
     example '$ pickfrom /usr/share/dict/words'
+    group base
     local file=$1
     [ -z "$file" ] && reference $FUNCNAME && return
     length=$(cat $file | wc -l)
@@ -43,6 +48,7 @@ pass ()
     param if unset, defaults to 4
     example '$ pass'
     example '$ pass 6'
+    group base
     local i pass length=${1:-4}
     pass=$(echo $(for i in $(eval echo "{1..$length}"); do pickfrom /usr/share/dict/words; done))
     echo "With spaces (easier to memorize): $pass"
@@ -54,6 +60,7 @@ pmdown ()
     about preview markdown file in a browser
     param 1: markdown file
     example '$ pmdown README.md'
+    group base
     if command -v markdown &>/dev/null
     then
       markdown $1 | browser
@@ -68,6 +75,7 @@ mkcd ()
     param path to create
     example '$ mkcd foo'
     example '$ mkcd /tmp/img/photos/large'
+    group base
     mkdir -p "$*"
     cd "$*"
 }
@@ -75,6 +83,7 @@ mkcd ()
 lsgrep ()
 {
     about search through directory contents with grep
+    group base
     ls | grep "$*"
 }
 
@@ -84,6 +93,7 @@ pman ()
     about view man documentation in Preview
     param 1: man page to view
     example '$ pman bash'
+    group base
     man -t "${1}" | open -f -a $PREVIEW
 }
 
@@ -93,6 +103,7 @@ pcurl ()
     about download file and Preview it
     param 1: download URL
     example '$ pcurl http://www.irs.gov/pub/irs-pdf/fw4.pdf'
+    group base
     curl "${1}" | open -f -a $PREVIEW
 }
 
@@ -101,17 +112,21 @@ pri ()
     about display information about Ruby classes, modules, or methods, in Preview
     param 1: Ruby method, module, or class
     example '$ pri Array'
+    group base
     ri -T "${1}" | open -f -a $PREVIEW
 }
 
 quiet ()
 {
+    about 'what *does* this do?'
+    group base
 	$* &> /dev/null &
 }
 
 banish-cookies ()
 {
     about redirect .adobe and .macromedia files to /dev/null
+    group base
 	rm -r ~/.macromedia ~/.adobe
 	ln -s /dev/null ~/.adobe
 	ln -s /dev/null ~/.macromedia
@@ -121,6 +136,7 @@ usage ()
 {
     about disk usage per directory, in Mac OS X and Linux
     param 1: directory name
+    group base
     if [ $(uname) = "Darwin" ]; then
         if [ -n $1 ]; then
             du -hd $1
@@ -142,6 +158,7 @@ t ()
     about one thing todo
     param if not set, display todo item
     param 1: todo text
+    group base
 	if [[ "$*" == "" ]] ; then
 	    cat ~/.t
 	else
@@ -154,25 +171,23 @@ command_exists ()
     about checks for existence of a command
     param 1: command to check
     example '$ command_exists ls && echo exists'
+    group base
     type "$1" &> /dev/null ;
 }
 
 plugins-help ()
 {
     about list all plugins and functions defined by bash-it
-    echo "bash-it Plugins Help-Message"
-    echo
-
-    set | grep "()" \
-    | sed -e "/^_/d" | grep -v "BASH_ARGC=()" \
-    | sed -e "/^\s/d" | grep -v "BASH_LINENO=()" \
-    | grep -v "BASH_ARGV=()" \
-    | grep -v "BASH_SOURCE=()" \
-    | grep -v "DIRSTACK=()" \
-    | grep -v "GROUPS=()" \
-    | grep -v "BASH_CMDS=()" \
-    | grep -v "BASH_ALIASES=()" \
-    | grep -v "COMPREPLY=()" | sed -e "s/()//"
+    group base
+    printf '%s\n' "bash-it plugins help"
+    printf '\n'
+    typeset group
+    for group in $(all_groups)
+    do
+        printf '%s\n' "group: $group"
+        glossary $group
+        printf '\n'
+    done
 }
 
 # useful for administrators and configs
@@ -180,7 +195,22 @@ buf ()
 {
     about back up file with timestamp
     param filename
+    group base
     local filename=$1
     local filetime=$(date +%Y%m%d_%H%M%S)
     cp ${filename} ${filename}_${filetime}
+}
+
+all_groups ()
+{
+    about displays all unique metadata groups
+    group base
+    typeset func
+    typeset file=$(mktemp /tmp/composure.XXXX)
+    for func in $(typeset_functions)
+    do
+        typeset -f $func | metafor group >> $file
+    done
+    cat $file | sort | uniq
+    rm $file
 }


### PR DESCRIPTION
cite about-plugin metadata.  This could be retrieved later, say by an
install script or other helper function, with:

``` bash
cat ~/.bash_it/plugins/enabled/base.plugin.bash | metafor about-plugin
```

In this way, summaries of each plugin may be provided to give newcomers
(like me!) an overview.

also, rewrote plugins-help(), which didn't work very well on my system.
It now dynamically queries composure metadata.
