### PR TITLE
fasd is using fixed path instead of BASH_IT variable

### DIFF
--- a/plugins/available/fasd.bash
+++ b/plugins/available/fasd.bash
@@ -584,7 +584,7 @@ fasd [-A|-D] [paths ...]
 fasd --init env
 
 case $- in
-  *i*) alias fasd='$BASH_IT/plugins/enabled/fasd.bash'
+  *i*) alias fasd=$BASH_IT'/plugins/enabled/fasd.bash'
        eval "$(fasd --init auto)"
       ;;
   *) # assume being executed as an executable


### PR DESCRIPTION
Fixed the fasd path by using the $BASH_IT variable instead of the fixed path.
