### PR TITLE
fix bug in fasd init

### DIFF
--- a/plugins/available/fasd.plugin.bash
+++ b/plugins/available/fasd.plugin.bash
@@ -584,7 +584,8 @@ fasd [-A|-D] [paths ...]
 fasd --init env
 
 case $- in
-  *i*) alias fasd=$BASH_IT'/plugins/enabled/fasd.bash'
+  *i*) cite about-plugin
+       about-plugin 'navigate "frecently" used files and directories'
        eval "$(fasd --init auto)"
       ;;
   *) # assume being executed as an executable


### PR DESCRIPTION
Three quick fixes:
1. rename fasd.bash to fasd.plugin.bash to bring it inline with the other
   plugin scripts
2. since we're sourcing this as a plugin, which loads the function, it's
   counterproductive to also define the 'fasd' alias
3. moving the about-plugin metadata into the case block makes this script
   safe for execution even if composure metadata isn't exported and
   available
