### PR TITLE
fix for issue #136

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -74,7 +74,7 @@ disable-plugin ()
             fi
         done
     else
-        typeset plugin=$(ls $BASH_IT/plugins/enabled/$1.*bash 2>/dev/null | head -1)
+        typeset plugin=$(command ls $BASH_IT/plugins/enabled/$1.*bash 2>/dev/null | head -1)
         if [ ! -h $plugin ]; then
             printf '%s\n' 'sorry, that does not appear to be an enabled plugin.'
             return
@@ -107,7 +107,7 @@ enable-plugin ()
             fi
         done
     else
-        typeset plugin=$(ls $BASH_IT/plugins/available/$1.*bash 2>/dev/null | head -1)
+        typeset plugin=$(command ls $BASH_IT/plugins/available/$1.*bash 2>/dev/null | head -1)
         if [ -z "$plugin" ]; then
             printf '%s\n' 'sorry, that does not appear to be an available plugin.'
             return


### PR DESCRIPTION
issue #136 was found to be caused by an aliased 'ls' command that
generated rogue values for 'plugin' in the enable/disable-plugin()
functions. this commit fixes that by forcing the shell to disregard
aliased 'ls' commands.
