### PR TITLE
Bash it for all dirs

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -183,3 +183,18 @@ buf ()
     local filetime=$(date +%Y%m%d_%H%M%S)
     cp ${filename} ${filename}_${filetime}
 }
+
+for_all_dirs ()
+{
+	about 'loops through all subdirectories of the current directory and executes the specified command in each of them'
+	param 'command'
+	group 'base'
+	example '$ for_all_dirs svn up'
+	for dir in */
+	do
+		echo "Processing $dir"
+		cd "$dir"
+		$*
+		cd ..
+	done
+}


### PR DESCRIPTION
Added for_all_dirs function to loop through all subdirectories of the current directory and run a command there.

Example: $ for_all_dirs svn up
This will update each subdirectory's content from Subversion. Useful in case you have multiple separate Subversion projects from different roots in the directory that you want to update using one command.

Can be used for all other commands as well, e.g. for several separate git repositories under the same root directory:
$ for_all_dirs git pull
