### PR TITLE
Growl notification for OS X commands

### DIFF
--- a/aliases/available/osx.aliases.bash
+++ b/aliases/available/osx.aliases.bash
@@ -19,4 +19,5 @@ if [ -s /usr/bin/firefox ] ; then
   unalias firefox
 fi
 
+# Requires growlnotify, which can be found in the Growl DMG under "Extras"
 alias grnot='growlnotify -s -t Terminal -m "Done"'


### PR DESCRIPTION
Added alias `grnot` for notifying via Growl once a command has completed. 

Usage:

```
$ make install ; grnot
```

Requires `growlnotify`, which can be found in the _Extras_ folder of the Growl DMG.
