### PR TITLE
The installer is currently broken on my setup when selecting all. This patch should fix it.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,16 @@ done
 function load_all() {
   file_type=$1
   [ ! -d "$BASH_IT/$file_type/enabled" ] && mkdir "$BASH_IT/${file_type}/enabled"
-  ln -s $BASH_IT/${file_type}/[^_]available/* "${BASH_IT}/${file_type}/enabled"
+  for src in $BASH_IT/${file_type}/available/*; do
+      filename="$(basename ${src})"
+      [ ${filename:0:1} = "_" ] && continue
+      dest="${BASH_IT}/${file_type}/enabled/${filename}"
+      if [ ! -e "${dest}" ]; then
+          ln -s "${src}" "${dest}"
+      else
+          echo "File ${dest} exists, skipping"
+      fi
+  done
 }
 
 function load_some() {


### PR DESCRIPTION
When selecting all, I get the following in my plugins/enabled directory

$ cd ~/.bash_it/plugins/enabled && ls -l
<snip fileinfo>          \* -> ~/.bash_it/plugins/[^_]available/*

In other words, the regexp is not being expanded, and I don't think bash
has ever had this capability (I am running 4.2.24) . Looking at the commit
24431627ab24c1c97bf3fb5796037e198f465e25, this line was added so as to disable
some plugins starting with a "_". In this circumstance, this line is
wrong anyway as it skips the directory "_available", rather than
available/_whatever.

This commit aims to fix this to the installer's intended purpose.
It also does a sanity check that no file exists already in enabled and
skips otherwise. ln -s does the right thing however more human error
message might be more desirable.
