### PR TITLE
Easily 'enter' the installation process

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,32 +1,38 @@
 #!/usr/bin/env bash
 BASH_IT="$HOME/.bash_it"
 
-cp $HOME/.bash_profile $HOME/.bash_profile.bak
-
-echo "Your original .bash_profile has been backed up to .bash_profile.bak"
+if [ -e $HOME/.bash_profile ]; then
+  cp $HOME/.bash_profile $HOME/.bash_profile.orig
+  echo "Your original .bash_profile has been backed up to .bash_profile.orig"
+fi
 
 cp $HOME/.bash_it/template/bash_profile.template.bash $HOME/.bash_profile
-
 echo "Copied the template .bash_profile into ~/.bash_profile, edit this file to customize bash-it"
 
-while true
-do
-  read -p "Do you use Jekyll? (If you don't know what Jekyll is, answer 'n') [Y/N] " RESP
-
-  case $RESP
-    in
-    [yY])
-      cp $HOME/.bash_it/template/jekyllconfig.template.bash $HOME/.jekyllconfig
-      echo "Copied the template .jekyllconfig into your home directory. Edit this file to customize bash-it for using the Jekyll plugins"
-      break
-      ;;
-    [nN])
-      break
-      ;;
-    *)
-      echo "Please enter Y or N"
-  esac
-done
+if [ -e $HOME/.bash_profile.orig ]; then
+  while true
+  do
+    echo ""
+    echo "Would you like to append your original .bash_profile (currently .bash_profile.orig) to the bash-it configuration?"
+    echo "Be advised that therefore you maybe overwrite existing bash-it configurations"
+    read -p "Append? [y/N]" RESP
+    case $RESP
+      in
+      [yY])
+        echo -e "# Load original .bash_profile\nsource $HOME/.bash_profile.orig" >> $HOME/.bash_profile
+        echo "Appended .bash_profile.orig (your former .bash_profile) to .bash_profile (the current bash-it one)"
+        break
+        ;;
+      "")
+        ;&
+      [nN])
+        break
+        ;;
+      *)
+        echo "Please enter Y or N"
+    esac
+  done
+fi
 
 function load_all() {
   file_type=$1
@@ -54,8 +60,10 @@ function load_some() {
       file_name=$(basename "$path")
       while true
       do
-        read -p "Would you like to enable the ${file_name%%.*} $file_type? [Y/N] " RESP
+        read -p "Would you like to enable the ${file_name%%.*} $file_type? [Y/n] " RESP
         case $RESP in
+        "")
+          ;&
         [yY])
           ln -s "$path" "$BASH_IT/$file_type/enabled"
           break


### PR DESCRIPTION
In many Bash scripts it is possible to only press 'Enter' when there is a default yes/no answer. So just write one letter capitalized and this is the default if 'enter' is pressed. 

An example here from aptitude:

```
 Do you want to continue? [Y/n/?]
```

Here  'Enter' means yes.
