### PR TITLE
Add theme_change command helper to easily change or refresh your themes

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -167,3 +167,15 @@ function scm_char {
 function prompt_char {
     scm_char
 }
+
+function theme_change () {
+  if [ "$1" == '--complete' ]; then
+    for d in $(find "${BASH_IT}/themes" -maxdepth 1 -type d -name "$3*" ! -iname "*themes"); do
+      echo ${d##*/};
+    done
+    exit
+  fi
+  sed -i '' 's/\(.*BASH_IT_THEME=\).*/\1"'$1'"/'  ~/.bash_profile
+  source ~/.bash_profile
+}
+complete -o default -C 'theme_change --complete $@' theme_change


### PR DESCRIPTION
This simple patch adds a `theme_change` command which take a single theme name, which it will autocomplete  for you based on the installed themes.

It goes something like this

```
 hybridXT in ~/.bash_it
± |theme_change ✗| → theme_change 
bobby                        candy                        clean
demula                       dos                          doubletime
doubletime_multiline         doubletime_multiline_pyonly  envy
hawaii50                     mbriggs                      minimal
modern                       modern-t                     n0qorg
pete                         phpenv                       rainbowbrite
rjorgenson                   simple                       sirup
standard                     tonka                        tylenol
zitron                       zork

 hybridXT in ~/.bash_it
± |theme_change ✗| → theme_change c
candy  clean

 hybridXT in ~/.bash_it
± |theme_change ✗| → theme_change clean 
insperion:.bash_it/  |theme_change ✗|$ theme_change mo
modern    modern-t
insperion:.bash_it/  |theme_change ✗|$ theme_change modern-t 
┌─[4][±][ |theme_change ✗|][.bash_it]
└─▪ 
┌─[4][±][ |theme_change ✗|][.bash_it]
└─▪ theme_change z
zitron  zork
± |theme_change ✗| → theme_change zork 
┌─[insperion][hybridXT][±][ |theme_change ✗|][~/.bash_it]
└─▪ theme_change pete
```

nJoy!
