### PR TITLE
fix bash-it running on zh_CN locale

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -80,7 +80,7 @@ _is_function ()
     _about 'sets $? to true if parameter is the name of a function'
     _param '1: name of alleged function'
     _group 'lib'
-    [ -n "$(type -a $1 2>/dev/null | grep 'is a function')" ]
+    [ -n "$(type -a $1 2>/dev/null | egrep 'is a function')|是函数" ]
 }
 
 _bash-it-aliases ()


### PR DESCRIPTION
My locale is zh_CN. So there is a bug when I use bash-it in shell. It always say  "oops! XXX is not a valid option!". also i put in the examples. 
i found the difference on my pc.

```
± |luw2007 ✓| → type bash-it
bash-it 是函数
bash-it () 
......
```

"是函数" is Chinese. It meaning is  "this a function" in english.

PS: my locale

```
± |luw2007 ✓| → locale
LANG=zh_CN.utf8
LC_CTYPE="zh_CN.utf8"
    ...
```
