### PR TITLE
[Discussion] Simplify & consolidate Ruby version reporting.

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -18,17 +18,8 @@ SCM_SVN_CHAR='⑆'
 SCM_NONE='NONE'
 SCM_NONE_CHAR='○'
 
-RVM_THEME_PROMPT_PREFIX=' |'
-RVM_THEME_PROMPT_SUFFIX='|'
-
-VIRTUALENV_THEME_PROMPT_PREFIX=' |'
-VIRTUALENV_THEME_PROMPT_SUFFIX='|'
-
-RBENV_THEME_PROMPT_PREFIX=' |'
-RBENV_THEME_PROMPT_SUFFIX='|'
-
-RBFU_THEME_PROMPT_PREFIX=' |'
-RBFU_THEME_PROMPT_SUFFIX='|'
+RUBY_THEME_PROMPT_PREFIX=' |'
+RUBY_THEME_PROMPT_SUFFIX='|'
 
 function scm {
   if [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
@@ -112,28 +103,8 @@ function hg_prompt_vars {
     SCM_CHANGE=$(hg summary 2> /dev/null | grep parent | awk '{print $2}')
 }
 
-function rvm_version_prompt {
-  if which rvm &> /dev/null; then
-    rvm=$(rvm tools identifier) || return
-    echo -e "$RVM_THEME_PROMPT_PREFIX$rvm$RVM_THEME_PROMPT_SUFFIX"
-  fi
-}
-
-function rbenv_version_prompt {
-  if which rbenv &> /dev/null; then
-    rbenv=$(rbenv version-name) || return
-    echo -e "$RBENV_THEME_PROMPT_PREFIX$rbenv$RBENV_THEME_PROMPT_SUFFIX"
-  fi
-}
-
-function rbfu_version_prompt {
-  if [[ $RBFU_RUBY_VERSION ]]; then
-    echo -e "${RBFU_THEME_PROMPT_PREFIX}${RBFU_RUBY_VERSION}${RBFU_THEME_PROMPT_SUFFIX}"
-  fi
-}
-
 function ruby_version_prompt {
-  echo -e "$(rbfu_version_prompt)$(rbenv_version_prompt)$(rvm_version_prompt)"
+  echo -e "${RUBY_THEME_PROMPT_PREFIX}$(ruby -v | awk '{print $2}')${RUBY_THEME_PROMPT_SUFFIX}"
 }
 
 function virtualenv_prompt {


### PR DESCRIPTION
I'm trying to simplify the way bash-it prompts report the current version of Ruby. The problem was that there's a multitude of Ruby environment managers out there, each of which reports the currently activated Ruby differently, resulting in code that, well, [isn't all that great](https://github.com/revans/bash-it/blob/master/themes/base.theme.bash#L115-L137).

I'm trying to figure out a way to simplify this. My current approach is a simple one: instead of sourcing the current Ruby version from an environment variable or similar, **I just run `ruby -v` as part of the prompt**. This isn't mean to be final (thinking of performance considerations etc.), but I'd still be happy to hear some feedback and suggestions.
- Just how bad is this idea, really?
- Will it work with RVM and rbenv? (I've successfully tested chruby and rbfu, the latter of which I'm the maintainer of.)
- How can we make this optional? Not everybody is that interested in having the current Ruby version reported as part of the prompt.

Thanks,
Hendrik
