### PR TITLE
Using $VIRTUAL_ENV to set virtualenv prompt

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -137,8 +137,8 @@ function ruby_version_prompt {
 }
 
 function virtualenv_prompt {
-  if which virtualenv &> /dev/null; then
-    virtualenv=$([ ! -z "$VIRTUAL_ENV" ] && echo "`basename $VIRTUAL_ENV`") || return
+  if [[ -n "$VIRTUAL_ENV" ]]; then
+    virtualenv=`basename "$VIRTUAL_ENV"`
     echo -e "$VIRTUALENV_THEME_PROMPT_PREFIX$virtualenv$VIRTUALENV_THEME_PROMPT_SUFFIX"
   fi
 }


### PR DESCRIPTION
Previous prompt was looking for virtualenv and setting the prompt.

virtualenv may not be on PATH, for example, when you use pythonbrew.

Seeing if $VIRTUAL_ENV is set would be good check for this.
