### PR TITLE
Use ls --color=auto

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -13,7 +13,7 @@ alias _="sudo"
 
 if [ $(uname) = "Linux" ]
 then
-  alias ls="ls --color=always"
+  alias ls="ls --color=auto"
 fi
 which gshuf &> /dev/null
 if [ $? -eq 1 ]


### PR DESCRIPTION
Fixes issue #189, changes ls alias to use

``` bash
ls="ls --color=auto"
```
