### PR TITLE
Create plugins/enabled directory if it doesn't already exist

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -277,6 +277,8 @@ _enable-thing ()
             return
         fi
 
+        mkdir -p $BASH_IT/$subdirectory/enabled
+
         ln -s $BASH_IT/$subdirectory/available/$plugin $BASH_IT/$subdirectory/enabled/$plugin
     fi
 


### PR DESCRIPTION
- This fixes a bug I saw after installing bash-it on Mac OS X 10.6.8.
  During bash-it installation I chose not to install any plugins. After
  install, when `bash-it enable plugin foo` was complaining that the
  enabled directory did not exist.
