### PR TITLE
Adds write permission test on ~/.bash_profile prior to backup attempt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 BASH_IT="$HOME/.bash_it"
 
-cp $HOME/.bash_profile $HOME/.bash_profile.bak
-
-echo "Your original .bash_profile has been backed up to .bash_profile.bak"
+test -w $HOME/.bash_profile &&
+  cp $HOME/.bash_profile $HOME/.bash_profile.bak &&
+  echo "Your original .bash_profile has been backed up to .bash_profile.bak"
 
 cp $HOME/.bash_it/template/bash_profile.template.bash $HOME/.bash_profile
 


### PR DESCRIPTION
The install script attempts to backup ~/.bash_profile when it does not exist.

```
$ ~/.bash_it/install.sh 
cp: /Users/sgerrand/.bash_profile: No such file or directory
Your original .bash_profile has been backed up to .bash_profile.bak
```

This adds a test for write permission (and implicitly the existence of) on `~/.bash_profile` prior to attempting a backup.
