### PR TITLE
Changed type checking func to be locale independent

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -44,6 +44,7 @@ bash-it ()
     typeset component=${1:-}
     shift
     typeset func
+
     case $verb in
          show)
              func=_bash-it-$component;;
@@ -80,7 +81,7 @@ _is_function ()
     _about 'sets $? to true if parameter is the name of a function'
     _param '1: name of alleged function'
     _group 'lib'
-    [ -n "$(type -a $1 2>/dev/null | grep 'is a function')" ]
+    [ -n "$(type -t $1 2>/dev/null | grep 'function')" ]
 }
 
 _bash-it-aliases ()


### PR DESCRIPTION
After I changed locale to Swedish bash-it suddenly stopped working. This patch addresses the issue by eliminating English locale dependency.
