### PR TITLE
implicit function declaration fails

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -153,7 +153,7 @@ usage ()
 
 if [ ! -e $BASH_IT/plugins/enabled/todo.plugin.bash ]; then
 # if user has installed todo plugin, skip this...
-    t ()
+    function t ()
     {
         about 'one thing todo'
         param 'if not set, display todo item'


### PR DESCRIPTION
03651fd0718 
I hate implicit function declarations, but it turns out bash doesn't even know what they are if they come after "then", so I made it explicit.

f91c470119 
Also, My personal, pimped-up, thinned-down prompt.
