### PR TITLE
Add Sublime Text CLI to path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib/custom.bash
 plugins/custom.plugins.bash
 *.swp
 .*.un~
+.subl-*/*

--- a/plugins/available/subl.plugin.bash
+++ b/plugins/available/subl.plugin.bash
@@ -1,4 +1,13 @@
 cite about-plugin
 about-plugin 'Add Sublime Text cli binary "subl" to path'
 
-export PATH=$PATH:/Applications/Sublime\ Text\ 2.app/Contents/SharedSupport/bin/subl
+SUBL_BIN="/Applications/Sublime Text 2.app/Contents/SharedSupport/bin/subl"
+SUBL_LOCAL_DIR=$BASH_IT/.subl-bin/
+SUBL_LOCAL_BIN=$BASH_IT/.subl-bin/subl
+
+if [ ! -f $SUBL_LOCAL_BIN ]; then
+  mkdir -p $SUBL_LOCAL_DIR
+  ln -s "$SUBL_BIN" $SUBL_LOCAL_BIN
+fi
+
+export PATH=$PATH:$SUBL_LOCAL_DIR


### PR DESCRIPTION
**Sublime Text 2** asks users to symlink the `subl` CLI binary into their path [1].

This plugin automates that task.

[1] http://www.sublimetext.com/docs/2/osx_command_line.html
