### PR TITLE
Permit custom dir for bash-it.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-BASH_IT="$HOME/.bash_it"
+BASH_IT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 test -w $HOME/.bash_profile &&
   cp $HOME/.bash_profile $HOME/.bash_profile.bak &&
   echo "Your original .bash_profile has been backed up to .bash_profile.bak"
 
-cp $HOME/.bash_it/template/bash_profile.template.bash $HOME/.bash_profile
+sed "s/__BASH_IT__/$(echo $BASH_IT | sed 's/\//\\\//g')/g" $BASH_IT/template/bash_profile.template.bash > $HOME/.bash_profile
 
 echo "Copied the template .bash_profile into ~/.bash_profile, edit this file to customize bash-it"
 

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -7,7 +7,7 @@
 export PATH=$PATH:~/.gem/ruby/1.8/bin:/opt/nginx/sbin
 
 # Path to the bash it configuration
-export BASH_IT=$HOME/.bash_it
+export BASH_IT=__BASH_IT__
 
 # Lock and Load a custom theme file
 # location /.bash_it/themes/


### PR DESCRIPTION
I try not to populate my $HOME root with hidden dirs and files. This is a patch that permits to install bash-it in any dir, not only in $HOME/.bash-it

Thanks for the work!
