### PR TITLE
Fixes in demula theme

### DIFF
--- a/themes/demula/demula.theme.bash
+++ b/themes/demula/demula.theme.bash
@@ -82,6 +82,14 @@ ${D_BRANCH_COLOR}%b %r ${D_CHANGES_COLOR}%m%u ${D_DEFAULT_COLOR}"
   fi
 }
 
+# checks if the plugin is installed before calling battery_charge
+safe_battery_charge() {
+  if [ -e "${BASH_IT}/plugins/enabled/battery.plugin.bash" ];
+  then
+    battery_charge
+  fi
+}
+
 # -------------------------------------------------------------- PROMPT OUTPUT
 prompt() {
   local LAST_COMMAND_FAILED=$(mitsuhikos_lastcommandfailed)
@@ -94,7 +102,7 @@ prompt() {
   then
     PS1="${TITLEBAR}
 ${SAVE_CURSOR}${MOVE_CURSOR_RIGHTMOST}${MOVE_CURSOR_5_LEFT}\
-$(battery_charge)${RESTORE_CURSOR}\
+$(safe_battery_charge)${RESTORE_CURSOR}\
 ${D_USER_COLOR}\u ${D_INTERMEDIATE_COLOR}\
 at ${D_MACHINE_COLOR}\h ${D_INTERMEDIATE_COLOR}\
 in ${D_DIR_COLOR}\w ${D_INTERMEDIATE_COLOR}\
@@ -110,7 +118,7 @@ in ${D_DIR_COLOR}\w ${D_INTERMEDIATE_COLOR}\
 ${LAST_COMMAND_FAILED}\
 $(demula_vcprompt)\
 $(is_vim_shell)\
-$(battery_charge)
+$(safe_battery_charge)
 ${D_INTERMEDIATE_COLOR}$ ${D_DEFAULT_COLOR}"
   fi
 


### PR DESCRIPTION
1.  The function that outputs the exit code of the last failed command uses the exit code of any command executed 
    before. That means that currently it is using the exit code of the last command executed inside the prompt 
    function (in my case I noticed it when the battery_charge function failed).
   
    By calling the mitsuhikos_lastcommandfailed function in the first line of the prompt function, we make sure the exit 
    code corresponds to the last executed command, and not the commands executed before inside the function.
2.  battery_charge failed because I hadn't installed the battery plugin and so the function wasn't available. Now I 
    check that the plugin is installed before calling the function.
