### PR TITLE
Add chruby and chruby-auto plugins

### DIFF
--- a/plugins/available/chruby-auto.bash
+++ b/plugins/available/chruby-auto.bash
@@ -1,0 +1,5 @@
+cite about-plugin
+about-plugin 'load chruby + auto-switching (from /usr/local/share/chruby)'
+
+source /usr/local/share/chruby/chruby.sh
+source /usr/local/share/chruby/auto.sh

--- a/plugins/available/chruby.bash
+++ b/plugins/available/chruby.bash
@@ -1,0 +1,4 @@
+cite about-plugin
+about-plugin 'load chruby                  (from /usr/local/share/chruby)'
+
+source /usr/local/share/chruby/chruby.sh

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -132,8 +132,18 @@ function rbfu_version_prompt {
   fi
 }
 
+function chruby_version_prompt {
+  if declare -f -F chruby &> /dev/null; then
+    if declare -f -F chruby_auto &> /dev/null; then
+      chruby_auto
+    fi
+    chruby=$(ruby --version | awk '{print $1, $2;}') || return
+    echo -e "$CHRUBY_THEME_PROMPT_PREFIX$chruby$CHRUBY_THEME_PROMPT_SUFFIX"
+  fi
+}
+
 function ruby_version_prompt {
-  echo -e "$(rbfu_version_prompt)$(rbenv_version_prompt)$(rvm_version_prompt)"
+  echo -e "$(rbfu_version_prompt)$(rbenv_version_prompt)$(rvm_version_prompt)$(chruby_version_prompt)"
 }
 
 function virtualenv_prompt {


### PR DESCRIPTION
- chruby.bash loads chruby
- chruby-auto.bash loads chruby and enables auto-switching
- add chruby_version_prompt() function for displaying ruby version
- inspired by https://gist.github.com/rssvihla/6153455
