### PR TITLE
I have always had the red/green arrow/x as the marker for nonzero status...

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -5,6 +5,8 @@ SCM_THEME_PROMPT_DIRTY=' ✗'
 SCM_THEME_PROMPT_CLEAN=' ✓'
 SCM_THEME_PROMPT_PREFIX=' |'
 SCM_THEME_PROMPT_SUFFIX='|'
+SCM_THEME_COLOR_CLEAN=''
+SCM_THEME_COLOR_DIRTY=''
 
 SCM_GIT='git'
 SCM_GIT_CHAR='±'
@@ -72,10 +74,12 @@ function scm_prompt_info {
 function git_prompt_vars {
   if [[ -n $(git status -s 2> /dev/null |grep -v ^# |grep -v "working directory clean") ]]; then
     SCM_DIRTY=1
-     SCM_STATE=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
+    SCM_THEME_COLOR=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_COLOR_DIRTY}
+    SCM_STATE=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
   else
     SCM_DIRTY=0
-     SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
+    SCM_THEME_COLOR=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_COLOR_CLEAN}
+    SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
   fi
   SCM_PREFIX=${GIT_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
   SCM_SUFFIX=${GIT_THEME_PROMPT_SUFFIX:-$SCM_THEME_PROMPT_SUFFIX}
@@ -87,9 +91,11 @@ function git_prompt_vars {
 function svn_prompt_vars {
   if [[ -n $(svn status 2> /dev/null) ]]; then
     SCM_DIRTY=1
+    SCM_THEME_COLOR=${SVN_THEME_PROMPT_DIRTY:-$SCM_THEME_COLOR_DIRTY}
       SCM_STATE=${SVN_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
   else
     SCM_DIRTY=0
+    SCM_THEME_COLOR=${SVN_THEME_PROMPT_CLEAN:-$SCM_THEME_COLOR_CLEAN}
       SCM_STATE=${SVN_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
   fi
   SCM_PREFIX=${SVN_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
@@ -101,9 +107,11 @@ function svn_prompt_vars {
 function hg_prompt_vars {
     if [[ -n $(hg status 2> /dev/null) ]]; then
       SCM_DIRTY=1
+      SCM_THEME_COLOR=${HG_THEME_PROMPT_DIRTY:-$SCM_THEME_COLOR_DIRTY}
         SCM_STATE=${HG_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     else
       SCM_DIRTY=0
+      SCM_THEME_COLOR=${HG_THEME_PROMPT_DIRTY:-$SCM_THEME_COLOR_DIRTY}
         SCM_STATE=${HG_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
     fi
     SCM_PREFIX=${HG_THEME_PROMPT_PREFIX:-$SCM_THEME_PROMPT_PREFIX}
@@ -146,17 +154,17 @@ function virtualenv_prompt {
 # backwards-compatibility
 function git_prompt_info {
   git_prompt_vars
-  echo -e "$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
+  echo -e "$SCM_PREFIX$SCM_THEME_COLOR$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
 }
 
 function svn_prompt_info {
   svn_prompt_vars
-  echo -e "$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
+  echo -e "$SCM_PREFIX$SCM_THEME_COLOR$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
 }
 
 function hg_prompt_info() {
   hg_prompt_vars
-  echo -e "$SCM_PREFIX$SCM_BRANCH:${SCM_CHANGE#*:}$SCM_STATE$SCM_SUFFIX"
+  echo -e "$SCM_PREFIX$SCM_THEME_COLOR$SCM_BRANCH:${SCM_CHANGE#*:}$SCM_STATE$SCM_SUFFIX"
 }
 
 function scm_char {

--- a/themes/worm/worm.theme.bash
+++ b/themes/worm/worm.theme.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+SCM_THEME_PROMPT_DIRTY=""
+SCM_THEME_PROMPT_CLEAN=""
+SCM_THEME_COLOR_DIRTY="${bold_red}"
+SCM_THEME_COLOR_CLEAN="${green}"
+SCM_THEME_PROMPT_PREFIX=" ${white}("
+SCM_THEME_PROMPT_SUFFIX="${white})"
+
+SUCCESS_PROMPT="${bold_green}→"
+ERROR_PROMPT="${bold_red}✗"
+
+function prompt_command() {
+		if [ $? = 0 ]; then RESULT_PROMPT=$SUCCESS_PROMPT; else RESULT_PROMPT=$ERROR_PROMPT; fi
+    PS1="${bold_cyan}\u@\h ${bold_blue}\w${reset_color}$(scm_prompt_info) $RESULT_PROMPT${normal} ";
+}
+
+PROMPT_COMMAND=prompt_command;


### PR DESCRIPTION
... code. This change just allows coloring of the SCM branch to show state, not require a separate symbol.  New "worm" theme shows the way
