### PR TITLE
Added aliases for Vagrant

### DIFF
--- a/aliases/available/vagrant.aliases.bash
+++ b/aliases/available/vagrant.aliases.bash
@@ -1,0 +1,17 @@
+cite 'about-alias'
+about-alias 'vagrant aliases'
+
+# Aliases
+alias vup="vagrant up"
+alias vh="vagrant halt"
+alias vs="vagrant suspend"
+alias vr="vagrant resume"
+alias vrl="vagrant reload"
+alias vssh="vagrant ssh"
+alias vst="vagrant status"
+alias vp="vagrant provision"
+alias vdstr="vagrant destroy"
+# requires vagrant-list plugin
+alias vl="vagrant list"
+# requires vagrant-hostmanager plugin
+alias vhst="vagrant hostmanager"


### PR DESCRIPTION
A bit surprised these didn't already exist. Not sure what kind of rules you guys have around addons/plugins, but I find I use the `list` and `hostmanager` aliases quite often so I included them.
