### PR TITLE
Open new OS X tab change: Ignore command in history

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -11,7 +11,7 @@ function tab() {
     end
     tell application "Terminal"
       activate
-      do script with command "cd \"$PWD\"; $*" in window 1
+      do script with command " cd \"$PWD\"; $*" in window 1
     end tell
 EOF
 }


### PR DESCRIPTION
Subtle change: Added a space in front of the command that's run in the new tab. If you use `export HISTIGNORE=' *'` in your shell, this will ensure that commands starting with a space will not be included in the history. Since the command sent to the new tab by the `tab` command probably shouldn't show up in the history, I added a leading space character.
