### PR TITLE
Avoid clash of edit alias with TextWrangler.app edit command

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -28,6 +28,11 @@ alias cls='clear'
 alias edit="$EDITOR"
 alias pager="$PAGER"
 
+#Avoid clashes with TextWrangler's command line tools on OS X
+if [ -s /usr/local/bin/edit ] ; then
+  unalias edit
+fi
+
 alias q='exit'
 
 alias irc="$IRC_CLIENT"


### PR DESCRIPTION
**Problem**

The OS X editor [TextWrangler](http://www.barebones.com/products/textwrangler/) allows to install a command line tool (/usr/local/bin/edit) which allows to open files in TextWrangler from the command line. Unfortunately, the 'edit' alias' of bash-it defined in aliases/available/general.aliases.bash clashes with TextWranglers edit command. 

**Solution**

The fix in the pull request just unaliases 'edit' if an edit command of TextWrangler is encountered in the before-mentioned path. I fixed the problem in a similar fashion to the firefox unaliasing in osx.aliases.bash.
