### PR TITLE
add support for rbenv gemset command to bash prompt

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -132,6 +132,7 @@ function rvm_version_prompt {
 function rbenv_version_prompt {
   if which rbenv &> /dev/null; then
     rbenv=$(rbenv version-name) || return
+    $(rbenv commands | grep -q gemset) && gemset=$(rbenv gemset active) && rbenv="$rbenv@${gemset%% *}"
     echo -e "$RBENV_THEME_PROMPT_PREFIX$rbenv$RBENV_THEME_PROMPT_SUFFIX"
   fi
 }


### PR DESCRIPTION
This pull request adds support for the "rbenv gemset" command. If the rbenv has the gemset plugin installed, then this updates the rbenv_version_prompt to contain the gemset name, similar to how rvm works.
