### PR TITLE
fix bug where "no active gemsets" displayed to STDERR

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -132,7 +132,7 @@ function rvm_version_prompt {
 function rbenv_version_prompt {
   if which rbenv &> /dev/null; then
     rbenv=$(rbenv version-name) || return
-    $(rbenv commands | grep -q gemset) && gemset=$(rbenv gemset active) && rbenv="$rbenv@${gemset%% *}"
+    $(rbenv commands | grep -q gemset) && gemset=$(rbenv gemset active 2> /dev/null) && rbenv="$rbenv@${gemset%% *}"
     echo -e "$RBENV_THEME_PROMPT_PREFIX$rbenv$RBENV_THEME_PROMPT_SUFFIX"
   fi
 }


### PR DESCRIPTION
There was a bug in my rbenv gemset support pull request from a couple of days ago, which causes a status message to get printed out to STDERR if the user didn't have a global gemset defined.
