### PR TITLE
Improved prompt speed when hg is not installed.

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -32,7 +32,7 @@ RBFU_THEME_PROMPT_SUFFIX='|'
 
 function scm {
   if [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
-  elif [[ -n "$(git symbolic-ref HEAD 2> /dev/null)" ]]; then SCM=$SCM_GIT
+  elif which git &> /dev/null && [[ -n "$(git symbolic-ref HEAD 2> /dev/null)" ]]; then SCM=$SCM_GIT
   elif [[ -d .hg ]]; then SCM=$SCM_HG
   elif which hg &> /dev/null && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
   elif [[ -d .svn ]]; then SCM=$SCM_SVN
@@ -90,7 +90,7 @@ function git_prompt_vars {
   local behind_re='.+behind ([0-9]+).+'
   [[ "${status}" =~ ${ahead_re} ]] && SCM_GIT_AHEAD=" ${SCM_GIT_AHEAD_CHAR}${BASH_REMATCH[1]}"
   [[ "${status}" =~ ${behind_re} ]] && SCM_GIT_BEHIND=" ${SCM_GIT_BEHIND_CHAR}${BASH_REMATCH[1]}"
-  local stash_count="$(git stash list | wc -l | tr -d ' ')"
+  local stash_count="$(git stash list 2> /dev/null | wc -l | tr -d ' ')"
   [[ "${stash_count}" -gt 0 ]] && SCM_GIT_STASH=" {${stash_count}}"
 }
 


### PR DESCRIPTION
Prevented bash from walking the path looking for hg when it is not
installed during each prompt refresh.
