### PR TITLE
Add git config option bash-it.hide-status to decide whether check git st...

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -73,10 +73,15 @@ function git_prompt_vars {
   SCM_GIT_AHEAD=''
   SCM_GIT_BEHIND=''
   SCM_GIT_STASH=''
-  local status="$(git status -bs --porcelain 2> /dev/null)"
-  if [[ -n "$(grep -v ^# <<< "${status}")" ]]; then
-    SCM_DIRTY=1
-    SCM_STATE=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
+  if [[ "$(git config --get bash-it.hide-status)" != "1" ]]; then
+    local status="$(git status -bs --porcelain 2> /dev/null)"
+    if [[ -n "$(grep -v ^# <<< "${status}")" ]]; then
+      SCM_DIRTY=1
+      SCM_STATE=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
+    else
+      SCM_DIRTY=0
+      SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
+    fi
   else
     SCM_DIRTY=0
     SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}


### PR DESCRIPTION
In big source tree, command `git status` is very time-consuming, 1min or even longer sometimes. Add a git config option `bash-it.hide-status` to configure whether check or not. Borrowed from oh-my-zsh.
