### PR TITLE
bash_it.sh: Patched changes made to support custom.*.bash files.

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -38,11 +38,15 @@ do
   source $config_file
 done
 
-# Load enabled and custom aliases, completion, plugins
+# Load enabled aliases, completion, plugins
 for file_type in "aliases" "completion" "plugins"
 do
   _load_bash_it_files $file_type
+done
 
+# Load custom aliases, completion, plugins
+for file_type in "aliases" "completion" "plugins"
+do
   if [ -e "${BASH_IT}/${file_type}/custom.${file_type}.bash" ]
   then
     source "${BASH_IT}/${file_type}/custom.${file_type}.bash"


### PR DESCRIPTION
Code was added to support loading
custom.{aliases,completion,plugins}.bash from their respective
directories in 46f6701a3. The change made in that commit does not wait
until the enabled {aliases,completion,plugins}/_.bash files are loaded
before sourcing the custom._.bash files, which was the case before. This
patch fixes any issues caused by that change by loading the enabled
*.bash files and custom *.bash files in two successive for loops.
