### PR TITLE
added custom aliases to bash-it help aliases <custom>

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -292,10 +292,21 @@ _help-aliases()
     _example '$ alias-help'
     _example '$ alias-help git'
 
+    typeset custom="$BASH_IT/aliases/custom.aliases.bash"
     if [ -n "$1" ]; then
-        cat $BASH_IT/aliases/available/$1.aliases.bash | metafor alias | sed "s/$/'/"
+        printf '\n'
+        if [ $1 == 'custom' ] && [ -e $custom ]; then
+            cat $custom | metafor alias | sed "s/$/'/"            
+        else
+            cat $BASH_IT/aliases/available/$1.aliases.bash | metafor alias | sed "s/$/'/"
+        fi
+        printf '\n'
     else
         typeset f
+        if [ -e $custom ]; then
+            printf '\n\n%s:\n' 'custom'
+            cat $custom | metafor alias | sed "s/$/'/"
+        fi
         for f in $BASH_IT/aliases/enabled/*
         do
             typeset file=$(basename $f)


### PR DESCRIPTION
Added the ability to show custom aliases with `bash-it help aliases` with the ability to filter by custom such as `bash-it help aliases custom`
