### PR TITLE
colorized output of ips()

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -5,7 +5,11 @@ ips ()
 {
     about 'display all ip addresses for this host'
     group 'base'
-    ifconfig | grep "inet " | awk '{ print $2 }'
+    resp=$(ifconfig | grep "inet " | awk '{ print $2 }')
+    for r in $resp
+    do
+        echo -e "`echo $r | cut -d: -f1`: ${echo_bold_green}`echo $r | cut -d: -f2` ${echo_normal}"
+    done
 }
 
 down4me ()


### PR DESCRIPTION
Makes the IP related functions in the base plugins consistent with both having bold green IPs.

![ips](https://cloud.githubusercontent.com/assets/2999202/3422169/408f42b8-ff1e-11e3-8d06-67c625756edf.png)
