### PR TITLE
Add alias 'E' for sudo-editing with emacsclient

### DIFF
--- a/aliases/available/emacs.aliases.bash
+++ b/aliases/available/emacs.aliases.bash
@@ -5,7 +5,7 @@ case $OSTYPE in
   linux*)
     alias em='emacs'
     alias e='emacsclient -n'
-    alias E="SUDO_EDITOR=\"emacsclient -c -a emacs\" sudoedit"
+    alias E='SUDO_EDITOR="emacsclient" sudo -e'
     ;;
   darwin*)
     alias em='open -a emacs'


### PR DESCRIPTION
Simple "sudo e" fails to open emacsclient to edit file with root previlege. Alias named 'E' is the common solution of many emacs users.

More description available at 
- http://emacs-fu.blogspot.com/2011/12/system-administration-with-emacs.html
- http://stackoverflow.com/questions/10190358/is-there-some-way-to-open-file-with-emacsclient-user-but-with-root-permission
