### PR TITLE
Change name of ip function to remove masking of ip command in bash

### DIFF
--- a/themes/hawaii50/hawaii50.theme.bash
+++ b/themes/hawaii50/hawaii50.theme.bash
@@ -83,7 +83,7 @@ IP_SEPARATOR=', '
 
 # FUNCS =======================================================================
 
-function ip {
+function get_ip_info {
     myip=$(curl -s checkip.dyndns.org | grep -Eo '[0-9\.]+')
     echo -e "$(ips | sed -e :a -e '$!N;s/\n/${IP_SEPARATOR}/;ta' | sed -e 's/127\.0\.0\.1\${IP_SEPARATOR}//g'), ${myip}"
 }
@@ -91,7 +91,7 @@ function ip {
 # Displays ip prompt 
 function ip_prompt_info() {
     if [[ $IP_ENABLED == 1 ]]; then
-        echo -e " ${DEFAULT_COLOR}(${IP_COLOR}$(ip)${DEFAULT_COLOR})"
+        echo -e " ${DEFAULT_COLOR}(${IP_COLOR}$(get_ip_info)${DEFAULT_COLOR})"
     fi 
 }
 


### PR DESCRIPTION
Hi there,
I would like to contribute this change. It occured that using the hawaii50 theme results in masking the `ip` command. Hence, `ip addr` resulted in something unexpected like: 

``` bash
$ ip addr
addr:123.123.123.123${IP_SEPARATOR}addr:123.123.123.123${IP_SEPARATOR}addr:127.0.0.1, 123.123.123.123
```

Hence, I changed the function name in `hawaii50.theme.bash` to `get_ip_info`.
Hope this helps. My local problem is solved using this approach.
Kind regards!
Eike
