### PR TITLE
Adding functions to rename os x terminal tab and window titles

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -16,6 +16,16 @@ function tab() {
 EOF
 }
 
+# renames the current os x terminal tab title
+function tabname {
+  printf "\e]1;$1\a"
+}
+
+# renames the current os x terminal window title
+function winname {
+  printf "\e]2;$1\a"
+}
+
 # this one switches your os x dock between 2d and 3d
 # thanks to savier.zwetschge.org
 function dock-switch() {


### PR DESCRIPTION
This functions well known and works on 10.9, 10.8, 10.7 and maybe even on older version of OS X.

Original code is from http://thelucid.com/2012/01/04/naming-your-terminal-tabs-in-osx-lion/
