### PR TITLE
Fix exit code check when setting alias for gshuf.

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -16,7 +16,7 @@ then
   alias ls="ls --color=auto"
 fi
 which gshuf &> /dev/null
-if [ $? -eq 1 ]
+if [ $? -eq 0 ]
 then
   alias shuf=gshuf
 fi


### PR DESCRIPTION
The `shuf` alias should get set if `which gshuf` exit code is 0, not 1.
