### PR TITLE
Support for ignoring untracked files for git status

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -73,8 +73,12 @@ function git_prompt_vars {
   SCM_GIT_AHEAD=''
   SCM_GIT_BEHIND=''
   SCM_GIT_STASH=''
+  SCM_GIT_ARGUMENTS='--porcelain'
+  if [ "$DISABLE_UNTRACKED_FILES_DIRTY" == true ]; then
+    SCM_GIT_ARGUMENTS="$SCM_GIT_ARGUMENTS -uno"
+  fi
   if [[ "$(git config --get bash-it.hide-status)" != "1" ]]; then
-    local status="$(git status -b --porcelain 2> /dev/null || git status --porcelain 2> /dev/null)"
+    local status="$(git status -b $SCM_GIT_ARGUMENTS 2> /dev/null || git status $SCM_GIT_ARGUMENTS 2> /dev/null)"
     if [[ -n "${status}" ]] && [[ "${status}" != "\n" ]] && [[ -n "$(grep -v ^# <<< "${status}")" ]]; then
       SCM_DIRTY=1
       SCM_STATE=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}


### PR DESCRIPTION
on oh-my-zsh is a switch you can enable if you want to disable marking untracked files as dirty.
this is a port of the switch
oh-my-zsh also claims that this makes repository status check for large repositories faster.

it's a 1:1 port, so i kept the name of the variable. to enable this just add 
```
export DISABLE_UNTRACKED_FILES_DIRTY=true
```
to your .bash_profile