### PR TITLE
Added two useful git aliases

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -36,6 +36,11 @@ alias gg="git log --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %
 alias ggs="gg --stat"
 alias gsl="git shortlog -sn"
 alias gw="git whatchanged"
+# From http://blogs.atlassian.com/2014/10/advanced-git-aliases/
+# Show commits since last pull
+alias gnew="git log HEAD@{1}..HEAD@{0}"
+# Add uncommitted and unstaged changes to the last commit
+alias gcaa="git commit -a --amend -C HEAD"
 
 if [ -z "$EDITOR" ]; then
     case $OSTYPE in


### PR DESCRIPTION
Found here: http://blogs.atlassian.com/2014/10/advanced-git-aliases/
- `gnew`: Shows the commits since the last `pull`
- `gcaa`: Adds uncommitted and unstaged changes to the last commit - incredibly useful
