### PR TITLE
OS X tab command fix

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -11,7 +11,7 @@ function tab() {
     end
     tell application "Terminal"
       activate
-      do script with command " cd \"$PWD\"; $*" in window 1
+      do script with command " cd \"$PWD\"; $*" in window 0
     end tell
 EOF
 }


### PR DESCRIPTION
Fixed script execution to always use the frontmost window, instead of window 1.

If you had multiple terminal windows open, there was a chance that the command was sent to another window (the one with index 1). Using index 0 will execute it in the currently visible window.
