### PR TITLE
Update appearance.bash for grep v2.21

### DIFF
--- a/lib/appearance.bash
+++ b/lib/appearance.bash
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# colored grep
-export GREP_OPTIONS='--color=auto'
-export GREP_COLOR='1;33'
-
 # colored ls
 export LSCOLORS='Gxfxcxdxdxegedabagacad'
 


### PR DESCRIPTION
gnu grep v2.21 depracates GREP_OPTIONS use.
