### PR TITLE
Fixed #157: Made 'type' command using default LANG (not system LANG) to ...

### DIFF
--- a/lib/composure.sh
+++ b/lib/composure.sh
@@ -235,7 +235,7 @@ draft ()
     fi
 
     # aliases bind tighter than function names, disallow them
-    if [ -n "$(type -a $func 2>/dev/null | grep 'is.*alias')" ]; then
+    if [ -n "$(LANG=C type -t $func 2>/dev/null | grep 'alias')" ]; then
         printf '%s\n' "sorry, $(type -a $func). please choose another name."
         return
     fi

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -80,7 +80,7 @@ _is_function ()
     _about 'sets $? to true if parameter is the name of a function'
     _param '1: name of alleged function'
     _group 'lib'
-    [ -n "$(type -a $1 2>/dev/null | grep 'is a function')" ]
+    [ -n "$(LANG=C type -t $1 2>/dev/null | grep 'function')" ]
 }
 
 _bash-it-aliases ()


### PR DESCRIPTION
Made 'type' command using default LANG (not system LANG) to check if function or alias.

Calling 'type -a' delivers localized text which then is used for grep, e.g. "...  is a function"

Two changes are provided:

1) Use paramter t which just delivers "function", "alias", etc. which makes it more clear what to grep for. See http://linuxcommand.org/lc3_man_pages/typeh.html
2) Use type's default language by setting LANG=C, just in case someone maintaining 'type' will also localize return values "function", "alias", etc. 
