### PR TITLE
Update pure.theme.bash

### DIFF
--- a/themes/pure/pure.theme.bash
+++ b/themes/pure/pure.theme.bash
@@ -28,7 +28,7 @@ pure_prompt() {
     ps_user="${green}\u${normal}";
     ps_user_mark="${green} $ ${normal}";
     ps_root="${red}\u${red}";
-    ps_root="${red} # ${normal}"
+    ps_root_mark="${red} # ${normal}"
     ps_path="${yellow}\w${normal}";
 
     # make it work


### PR DESCRIPTION
Fixed an issue, where ps_root_mark was not defined and therefore the root-user-name was not shown after a root-login.
