### PR TITLE
Fix for bookmark and jekyll plugin

### DIFF
--- a/plugins/available/dirs.plugin.bash
+++ b/plugins/available/dirs.plugin.bash
@@ -80,7 +80,7 @@ S () {				# SAVE a BOOKMARK
     about 'save a bookmark'
     group 'dirs'
 
-    sed "/$@/d" ~/.dirs > ~/.dirs1;
+    sed "/^$@=/d" ~/.dirs > ~/.dirs1;
     \mv ~/.dirs1 ~/.dirs;
     echo "$@"=\"`pwd`\" >> ~/.dirs;
     source ~/.dirs ;
@@ -90,7 +90,7 @@ R () {				# remove a BOOKMARK
     about 'remove a bookmark'
     group 'dirs'
 
-    sed "/$@/d" ~/.dirs > ~/.dirs1;
+    sed "/^$@=/d" ~/.dirs > ~/.dirs1;
     \mv ~/.dirs1 ~/.dirs;
 }
 

--- a/plugins/available/jekyll.plugin.bash
+++ b/plugins/available/jekyll.plugin.bash
@@ -67,12 +67,6 @@ newpost() {
     return 1
   fi
 
-  if [ -z "$SITE" ]
-  then
-    echo "No such site."
-    return 1
-  fi
-
   loc=0
 
   for site in ${SITES[@]}
@@ -85,6 +79,12 @@ newpost() {
     fi
     loc=$(($loc+1))
   done
+
+  if [ -z "$SITE" ]
+  then
+    echo "No such site."
+    return 1
+  fi
 
   # 'builtin cd' into the local jekyll root
 
@@ -294,7 +294,7 @@ function testsite() {
   fi
 
   builtin cd $SITE
-  jekyll --server --auto
+  jekyll serve
 }
 
 function buildsite() {
@@ -327,7 +327,7 @@ function buildsite() {
 
   builtin cd $SITE
   rm -rf _site
-  jekyll --no-server
+  jekyll build
 }
 
 function deploysite() {


### PR DESCRIPTION
Bookmark fix
~/abc/def/g> S g
~/abc/def/gh> S gh
~/abc/def/ghi> S ghi
~/abc/def/ghi> D g
At this point all of those bookmarks will be deleted because ''/g/d" matches all of them.  The fix is to match only "/^g=/d".

Jekyll plugin fix
1. $SITE should be defined before checked.  Otherwise, it will always fail.
2. Jekyll new uses subcommands.
"Deprecation: Jekyll now uses subcommands instead of just switches. Run `jekyll --help' to find out more."
