### PR TITLE
add argument presence check for functions in dirs plugin to bad usage

### DIFF
--- a/plugins/available/dirs.plugin.bash
+++ b/plugins/available/dirs.plugin.bash
@@ -67,7 +67,8 @@ fi
 
 alias L='cat ~/.dirs'
 
-G () {				# goes to distination dir otherwise , stay in the dir
+# goes to distination dir otherwise, stay in the dir
+G () {
     about 'goes to destination dir'
     param '1: directory'
     example '$ G ..'
@@ -76,9 +77,13 @@ G () {				# goes to distination dir otherwise , stay in the dir
     cd "${1:-$(pwd)}" ;
 }
 
-S () {				# SAVE a BOOKMARK
+S () {
     about 'save a bookmark'
+    param '1: bookmark name'
+    example '$ S mybkmrk'
     group 'dirs'
+
+    [[ $# -eq 1 ]] || { echo "${FUNCNAME[0]} function requires 1 argument"; return 1; }
 
     sed "/$@/d" ~/.dirs > ~/.dirs1;
     \mv ~/.dirs1 ~/.dirs;
@@ -86,9 +91,13 @@ S () {				# SAVE a BOOKMARK
     source ~/.dirs ;
 }
 
-R () {				# remove a BOOKMARK
+R () {
     about 'remove a bookmark'
+    param '1: bookmark name'
+    example '$ R mybkmrk'
     group 'dirs'
+
+    [[ $# -eq 1 ]] || { echo "${FUNCNAME[0]} function requires 1 argument"; return 1; }
 
     sed "/$@/d" ~/.dirs > ~/.dirs1;
     \mv ~/.dirs1 ~/.dirs;


### PR DESCRIPTION
prevent usage of functions `S` and `R` without a single argument
before:
```
S
sed: first RE may not be empty
-bash: =/Users/ipoval/.bash_it: No such file or directory

R
sed: first RE may not be empty
```
after:
```
S function requires 1 argument
```