### PR TITLE
fix path to commands installed by gem install --user-install

### DIFF
--- a/plugins/available/ruby.plugin.bash
+++ b/plugins/available/ruby.plugin.bash
@@ -1,5 +1,11 @@
 cite about-plugin
-about-plugin 'adds "remove_gem" function'
+about-plugin 'ruby and rubygems specific functions and settings'
+
+# Make commands installed with 'gem install --user-install' available
+# ~/.gem/ruby/${RUBY_VERSION}/bin/
+if which ruby >/dev/null && which gem >/dev/null; then
+  PATH="$PATH:$(ruby -e 'print Gem.user_dir')/bin";
+fi
 
 function remove_gem {
   about 'removes installed gem'

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -3,8 +3,10 @@
 # Load RVM, if you are using it
 [[ -s $HOME/.rvm/scripts/rvm ]] && source $HOME/.rvm/scripts/rvm
 
-# Add rvm gems and nginx to the path
-export PATH=$PATH:~/.gem/ruby/1.8/bin:/opt/nginx/sbin
+# Add nginx to the path
+PATH=$PATH:/opt/nginx/sbin
+
+export PATH
 
 # Path to the bash it configuration
 export BASH_IT=$HOME/.bash_it


### PR DESCRIPTION
This path `~/.gem/ruby/1.8/bin` used to work only for version of ruby 1.8, which is EOL, together with 1.9; 
make the path work for many versions of ruby including the latest one:

reference: http://guides.rubygems.org/faqs/#user-install