### PR TITLE
minor fix in Readme to add completion/custom.completion.bash to the customization list

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ bash-it help plugins        # shows help for installed plugins
 For custom scripts, and aliases, just create the following files (they'll be ignored by the git repo):
 
 * `aliases/custom.aliases.bash`
+* `completion/custom.completion.bash`
 * `lib/custom.bash`
 * `plugins/custom.plugins.bash`
 

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -26,9 +26,7 @@ export NGINX_PATH='/opt/nginx'
 # Don't check mail when opening terminal.
 unset MAILCHECK
 
-
 # Change this to your console based IRC client of choice.
-
 export IRC_CLIENT='irssi'
 
 # Set this to the command you use for todo.txt-cli


### PR DESCRIPTION
this adds `completion/custom.completion.bash` to the customization list for consistency with other list items