### PR TITLE
fix textmate path on some platforms

### DIFF
--- a/plugins/available/textmate.plugin.bash
+++ b/plugins/available/textmate.plugin.bash
@@ -1,0 +1,5 @@
+cite about-plugin
+about-plugin 'set textmate as a default editor'
+
+export EDITOR="$(which mate) -w"
+export GIT_EDITOR=$EDITOR

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -16,10 +16,6 @@ export BASH_IT_THEME='bobby'
 # Your place for hosting Git repos. I use this for private repos.
 export GIT_HOSTING='git@git.domain.com'
 
-# Set my editor and git editor
-export EDITOR="/usr/bin/mate -w"
-export GIT_EDITOR='/usr/bin/mate -w'
-
 # Set the path nginx
 export NGINX_PATH='/opt/nginx'
 


### PR DESCRIPTION
often `which mate` will be different from hardcoded `/usr/bin/mate`
```
uname -a
Darwin ipovalmac.local 14.1.0 Darwin Kernel Version 14.1.0: Thu Feb 26 19:26:47 PST 2015; root:xnu-2782.10.73~1/RELEASE_X86_64 x86_64
```
```
which mate
/usr/local/bin/mate
```