### PR TITLE
[allow faster install] clone bash-it with depth=1 instead of whole git h...

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Bash it provides a solid framework for using, developing and maintaining shell s
 
 ## Install
 
-1. Check a clone of this repo: `git clone https://github.com/Bash-it/bash-it.git ~/.bash_it`
+1. Check a clone of this repo: `git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it`
 2. Run `~/.bash_it/install.sh` (it automatically backs up your `~/.bash_profile` or `~/.bashrc`, depends on your OS)
 3. Edit your modified config (`~/.bash_profile` or `~/.bashrc`) file in order to customize bash it.
 


### PR DESCRIPTION
...istory - it allows to reduce install

users who want to only install "bash-it" without contributing will win with speedy install and smaller directory size

BEFORE
```
○ → time git clone https://github.com/Bash-it/bash-it.git ~/.Trash/bashit
Cloning into '/Users/ipoval/.Trash/bashit'...
remote: Counting objects: 4066, done.
remote: Total 4066 (delta 0), reused 0 (delta 0), pack-reused 4066
Receiving objects: 100% (4066/4066), 33.61 MiB | 2.75 MiB/s, done.
Resolving deltas: 100% (1514/1514), done.
Checking connectivity... done.

real	0m16.140s
user	0m0.908s
sys	0m0.635s
```

AFTER
```
○ → time git clone --depth 1 https://github.com/Bash-it/bash-it.git ~/.Trash/bashit
Cloning into '/Users/ipoval/.Trash/bashit'...
remote: Counting objects: 199, done.
remote: Compressing objects: 100% (159/159), done.
remote: Total 199 (delta 4), reused 148 (delta 1), pack-reused 0
Receiving objects: 100% (199/199), 147.13 KiB | 0 bytes/s, done.
Resolving deltas: 100% (4/4), done.
Checking connectivity... done.

real	0m1.829s
user	0m0.076s
sys	0m0.052s
```