### PR TITLE
Backup with cp dash a

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ case $OSTYPE in
 esac
 
 test -w $HOME/$CONFIG_FILE &&
-  cp $HOME/$CONFIG_FILE $HOME/$CONFIG_FILE.bak &&
+  cp -a $HOME/$CONFIG_FILE $HOME/$CONFIG_FILE.bak &&
   echo "Your original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak"
 
 cp $HOME/.bash_it/template/bash_profile.template.bash $HOME/$CONFIG_FILE

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -213,5 +213,5 @@ function buf ()
     group 'base'
     local filename=$1
     local filetime=$(date +%Y%m%d_%H%M%S)
-    cp "${filename}" "${filename}_${filetime}"
+    cp -a "${filename}" "${filename}_${filetime}"
 }

--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -34,3 +34,11 @@ load ../../plugins/available/base.plugin
   assert_success
   [[ $output == l? ]]
 }
+
+@test 'plugins base: buf()' {
+  mkdir -p $BASH_IT_ROOT
+  declare -r file="${BASH_IT_ROOT}/file"
+  touch $file
+  run buf $file
+  [[ -e ${file}_$(date +%Y%m%d_%H%M%S) ]]
+}


### PR DESCRIPTION
[-] preserve attributes of $CONFIG_FILE on backup (attributes may incl. modification time, access time, file flags, ...)
[-] make buf() to respect file attributes on file backup
