### PR TITLE
Added sudo indicator to the Powerline-Multiline Theme

### DIFF
--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -5,6 +5,7 @@ THEME_PROMPT_LEFT_SEPARATOR=""
 
 SHELL_SSH_CHAR=${SHELL_SSH_CHAR:=" "}
 SHELL_THEME_PROMPT_COLOR=32
+SHELL_THEME_PROMPT_COLOR_SUDO=202
 
 VIRTUALENV_CHAR=${POWERLINE_VIRTUALENV_CHAR:="❲p❳ "}
 CONDA_VIRTUALENV_CHAR=${POWERLINE_CONDA_VIRTUALENV_CHAR:="❲c❳ "}
@@ -53,6 +54,11 @@ function set_rgb_color {
 }
 
 function powerline_shell_prompt {
+    SHELL_PROMPT_COLOR=${SHELL_THEME_PROMPT_COLOR}
+    CAN_I_RUN_SUDO=$(sudo -n uptime 2>&1 | grep "load" | wc -l)
+    if [ ${CAN_I_RUN_SUDO} -gt 0 ]; then
+        SHELL_PROMPT_COLOR=${SHELL_THEME_PROMPT_COLOR_SUDO}
+    fi
     SEGMENT_AT_RIGHT=0
     if [[ -n "${SSH_CLIENT}" ]]; then
         SHELL_PROMPT="${SHELL_SSH_CHAR}${USER}@${HOSTNAME}"
@@ -60,8 +66,8 @@ function powerline_shell_prompt {
         SHELL_PROMPT="${USER}"
     fi
     RIGHT_PROMPT_LENGTH=$(( ${RIGHT_PROMPT_LENGTH} + ${#SHELL_PROMPT} + 2 ))
-    SHELL_PROMPT="$(set_rgb_color - ${SHELL_THEME_PROMPT_COLOR}) ${SHELL_PROMPT} ${normal}"
-    LAST_THEME_COLOR=${SHELL_THEME_PROMPT_COLOR}
+    SHELL_PROMPT="$(set_rgb_color - ${SHELL_PROMPT_COLOR}) ${SHELL_PROMPT} ${normal}"
+    LAST_THEME_COLOR=${SHELL_PROMPT_COLOR}
     (( SEGMENT_AT_RIGHT += 1 ))
 }
 


### PR DESCRIPTION
If the user is currently in a valid sudo session (sudo currently does not require a password), then the last part of the left prompt will use a different color (orange). This gives an indication to the user that sudo commands will not require a password at the moment. One example for this might be that the user is reminded to run a `sudo -k` to terminate the current sudo session before stepping away from the screen.

This is what it looks like:
![image](https://cloud.githubusercontent.com/assets/907063/7202109/6b13d58a-e50f-11e4-907f-02c0989d3480.png)

@tswicegood @edubxb @ifosch - would like to get your opinion on that. Let me know what you think.