### PR TITLE
skip myip() function test - it is not determenistic, probably because of...

### DIFF
--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -16,8 +16,8 @@ load ../../plugins/available/base.plugin
 }
 
 @test 'plugins base: myip()' {
-  if [[ ! $CI ]]; then
-    skip 'myip is slow - run only on CI'
+  if [[ ! $SLOW_TESTS ]]; then
+    skip 'myip is slow - run only with SLOW_TESTS=true'
   fi
 
   run myip


### PR DESCRIPTION
... the network latency,

@nwinkler, this PR skips the myip() test which is not deterministic on CI runs from time to time 