### PR TITLE
Homebrew upgrade command wants --all flag

### DIFF
--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -3,7 +3,7 @@
 cite 'about-alias'
 about-alias 'homebrew abbreviations'
 
-alias bup='brew update && brew upgrade'
+alias bup='brew update && brew upgrade --all'
 alias bout='brew outdated'
 alias bin='brew install'
 alias brm='brew uninstall'


### PR DESCRIPTION
Homebrew currently gives a warning about how this flag will be required in the future, as merged in Homebrew/homebrew#38572