### PR TITLE
Fixed conversion when the battery percentage is in the single digits.

### DIFF
--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -66,7 +66,7 @@ battery_percentage(){
     # http://hints.macworld.com/article.php?story=20100130123935998
     #local IOREG_OUTPUT_10_6=$(ioreg -l | grep -i capacity | tr '\n' ' | ' | awk '{printf("%.2f%%", $10/$5 * 100)}')
     #local IOREG_OUTPUT_10_5=$(ioreg -l | grep -i capacity | grep -v Legacy| tr '\n' ' | ' | awk '{printf("%.2f%%", $14/$7 * 100)}')
-    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
+    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
     case $IOREG_OUTPUT in
       100*)
         echo '99'


### PR DESCRIPTION
The previous version was printing an error when the battery percentage was in the single digits, e.g. "7.04%". The code cuts returns the first two digits, which in the case of "7.04%" are "7.". Any code that tries to use that, e.g. the powerline-multiline theme will fail with an error.

This change corrects that by zero padding single digits, i.e. "07.04%" instead of "7.04%".