### PR TITLE
Fix unicode line wrap problem (issue #409)

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -71,7 +71,7 @@ done
 
 unset config_file
 if [[ $PROMPT ]]; then
-    export PS1=$PROMPT
+    export PS1="\["$PROMPT"\]"
 fi
 
 # Adding Support for other OSes


### PR DESCRIPTION
This seems to fix the unicode line wrap issue mentioned in #409
Nota bene, This fixed the problem for me on Fedora 21 and Ubuntu 15.04
Needs to be tested on other systems