### PR TITLE
Fix for issue #108 that restores xterm plugin functionality on OS X.

### DIFF
--- a/plugins/available/xterm.plugin.bash
+++ b/plugins/available/xterm.plugin.bash
@@ -1,17 +1,9 @@
-# This plugin is known to cause issues on OS X with the evaluation of
-# colors.  Please read [issue 108] for more information.
-#
-# You can manually turn this on by symlinking it into your
-# plugins/enabled/ directory.
-#
-# [issue 108]: https://github.com/revans/bash-it/issues/108
-
 cite about-plugin
 about-plugin 'automatically set your xterm title with host and location info'
 
 set_xterm_title () {
     local title="$1"
-    echo -ne "\e]0;$title\007"
+    echo -ne "\033]0;$title\007"
 }
 
 


### PR DESCRIPTION
Use '\033' instead of '\e' as escape character in set_xterm_title.