### PR TITLE
Add vagrant up log alias

### DIFF
--- a/aliases/available/vagrant.aliases.bash
+++ b/aliases/available/vagrant.aliases.bash
@@ -3,6 +3,7 @@ about-alias 'vagrant aliases'
 
 # Aliases
 alias vup="vagrant up"
+alias vupl="vagrant up 2>&1 | tee vagrant.log"
 alias vh="vagrant halt"
 alias vs="vagrant suspend"
 alias vr="vagrant resume"


### PR DESCRIPTION
A single line addition to the vagrant aliases file... a Vagrant up alias that logs output to vagrant.log file.