### PR TITLE
Fix startup error with enabled docker alias file

### DIFF
--- a/aliases/available/docker.aliases.bash
+++ b/aliases/available/docker.aliases.bash
@@ -3,7 +3,7 @@ about-alias 'docker abbreviations'
 
 alias dklc='docker ps -l'  # List last Docker container
 alias dklcid='docker ps -l -q'  # List last Docker container ID
-alias dklcip="docker inspect `dklcid` | grep IPAddress | cut -d '\"' -f 4"  # Get IP of last Docker container
+alias dklcip="docker inspect `docker ps -l -q` | grep IPAddress | cut -d '\"' -f 4"  # Get IP of last Docker container
 alias dkps='docker ps'  # List running Docker containers
 alias dkpsa='docker ps -a'  # List all Docker containers
 alias dki='docker images'  # List Docker images


### PR DESCRIPTION
I get an error at startup from the docker aliases file. Enclosed change fixes this so there is no error on startup.