### PR TITLE
Fix dkrmui alias (delete untagged images)

### DIFF
--- a/aliases/available/docker.aliases.bash
+++ b/aliases/available/docker.aliases.bash
@@ -9,7 +9,7 @@ alias dkpsa='docker ps -a'  # List all Docker containers
 alias dki='docker images'  # List Docker images
 alias dkrmac='docker rm $(docker ps -a -q)'  # Delete all Docker containers
 alias dkrmlc='docker-remove-most-recent-container'  # Delete most recent (i.e., last) Docker container
-alias dkrmui='docker rmi $(docker images | grep "^<none>" | awk "{print $3}")'  # Delete all untagged Docker images
+alias dkrmui='docker images -q -f dangling=true |xargs -r docker rmi'  # Delete all untagged Docker images
 alias dkrmli='docker-remove-most-recent-image'  # Delete most recent (i.e., last) Docker image
 alias dkrmi='docker-remove-images'  # Delete images for supplied IDs or all if no IDs are passed as arguments
 alias dkideps='docker-image-dependencies'  # Output a graph of image dependencies using Graphiz


### PR DESCRIPTION
The docker images subcommand was returning all columns due to unescaped
'$3' in awk filter.  This was throwing a lot of errors as rmi tried to
remove non-existent images.

In any case docker images has a flag to filter and only show dangling
image IDs which makes this simpler.