### PR TITLE
Fix ips command for platforms without ifconfig

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -5,7 +5,15 @@ function ips ()
 {
     about 'display all ip addresses for this host'
     group 'base'
-    ifconfig | awk '/inet /{ print $2 }'
+    if command -v ifconfig &>/dev/null
+    then
+        ifconfig | awk '/inet /{ print $2 }'
+    elif command -v ip &>/dev/null
+    then
+        ip addr | grep -oP 'inet \K[\d.]+'
+    else
+        echo "You don't have ifconfig or ip command installed!"
+    fi
 }
 
 function down4me ()


### PR DESCRIPTION
Some platforms (e.g. Arch Linux) don't have `ifconfig` by default. They use `ip` instead.