### PR TITLE
Check for PTY before attempting to use bind

### DIFF
--- a/plugins/available/history.plugin.bash
+++ b/plugins/available/history.plugin.bash
@@ -1,4 +1,7 @@
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history
-bind '"[A":history-search-backward'
-bind '"[B":history-search-forward'
+if [ -t 1 ]; 
+then
+    bind '"[A":history-search-backward'
+    bind '"[B":history-search-forward'
+fi


### PR DESCRIPTION
After running a dist upgrade on one of my Ubuntu 14.04 test workstations I started receiving errors after a graphical login. This should also fix remote ssh login problems as seen in http://superuser.com/questions/892658/remote-ssh-commands-bash-bind-warning-line-editing-not-enabled