### PR TITLE
Add Python version and Conda environment prompt functions.

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -250,6 +250,22 @@ function virtualenv_prompt {
   fi
 }
 
+function condaenv_prompt {
+  if [[ $CONDA_DEFAULT_ENV ]]; then
+    echo -e "${CONDAENV_THEME_PROMPT_PREFIX}${CONDA_DEFAULT_ENV}${CONDAENV_THEME_PROMPT_SUFFIX}"
+  fi
+}
+
+function py_interp_prompt {
+  py_version=$(python --version 2>&1 | awk '{print "py-"$2;}') || return
+  echo -e "${PYTHON_THEME_PROMPT_PREFIX}${py_version}${PYTHON_THEME_PROMPT_SUFFIX}"
+}
+
+function python_version_prompt {
+  echo -e "$(virtualenv_prompt)$(condaenv_prompt)$(py_interp_prompt)"
+}
+
+
 # backwards-compatibility
 function git_prompt_info {
   git_prompt_vars

--- a/themes/bobby-python/bobby-python.theme.bash
+++ b/themes/bobby-python/bobby-python.theme.bash
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+SCM_THEME_PROMPT_DIRTY=" ${red}✗"
+SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓"
+SCM_THEME_PROMPT_PREFIX=" |"
+SCM_THEME_PROMPT_SUFFIX="${green}|"
+
+GIT_THEME_PROMPT_DIRTY=" ${red}✗"
+GIT_THEME_PROMPT_CLEAN=" ${bold_green}✓"
+GIT_THEME_PROMPT_PREFIX=" ${green}|"
+GIT_THEME_PROMPT_SUFFIX="${green}|"
+
+CONDAENV_THEME_PROMPT_SUFFIX="|"
+
+function prompt_command() {
+    #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(ruby_version_prompt) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
+    PS1="\n${yellow}$(python_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
+}
+
+PROMPT_COMMAND=prompt_command;


### PR DESCRIPTION
Added prompt functions for the version of the Python interpreter and the name of the current Conda package manager environment (http://conda.pydata.org similar to rbenv) to base.theme.bash.

The final python_version_prompt function to be used in themes includes these and the Virtualenv name to cover both Conda and Virtualenv usage.