### PR TITLE
Fix dklcip alias

### DIFF
--- a/aliases/available/docker.aliases.bash
+++ b/aliases/available/docker.aliases.bash
@@ -3,7 +3,7 @@ about-alias 'docker abbreviations'
 
 alias dklc='docker ps -l'  # List last Docker container
 alias dklcid='docker ps -l -q'  # List last Docker container ID
-alias dklcip="docker inspect `docker ps -l -q` | grep IPAddress | cut -d '\"' -f 4"  # Get IP of last Docker container
+alias dklcip='docker inspect -f "{{.NetworkSettings.IPAddress}}" $(docker ps -l -q)'  # Get IP of last Docker container
 alias dkps='docker ps'  # List running Docker containers
 alias dkpsa='docker ps -a'  # List all Docker containers
 alias dki='docker images'  # List Docker images


### PR DESCRIPTION
Due to use of double-quotes ``docker ps`` was executed when the aliases
were loaded and as a consequence ``dklcip`` would always show IP of a
container that was last then instead of at runtime.

This changes the alias to use single quotes which fixes that.

It also changes the alias to use docker's ``--format`` option so
there's no need of parsing the output using grep and cut.