### PR TITLE
Add git-subrepo plugin

### DIFF
--- a/plugins/available/git-subrepo.plugin.bash
+++ b/plugins/available/git-subrepo.plugin.bash
@@ -1,0 +1,6 @@
+# Load git-subrepo if you are using it, and initialize completions
+
+cite about-plugin
+about-plugin 'load git-subrepo if you are using it, and initialize completions'
+
+[[ -e "${GIT_SUBREPO_ROOT:=~/.git-subrepo}/init" ]] && source "$GIT_SUBREPO_ROOT/init"


### PR DESCRIPTION
For [git-subrepo](https://github.com/ingydotnet/git-subrepo), an excellent replacement for git-submodule and git-subtree.