### PR TITLE
Added check for OS X update_terminal_cwd

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -1,6 +1,15 @@
 cite about-plugin
 about-plugin 'osx-specific functions'
 
+# OS X: Open new tabs in same directory
+if [ $(uname) = "Darwin" ]; then
+  if type update_terminal_cwd > /dev/null 2>&1 ; then
+    if ! [[ $PROMPT_COMMAND =~ (^|;)update_terminal_cwd($|;) ]] ; then
+      export PROMPT_COMMAND="update_terminal_cwd;$PROMPT_COMMAND"
+    fi
+  fi
+fi
+
 function tab() {
   about 'opens a new terminal tab'
   group 'osx'


### PR DESCRIPTION
This will allow to open new terminal tabs in the same directory as the
current terminal. Uses the fact that plugins are loaded after the
selected theme. Themes often manipulate the $PROMPT_COMMAND variable.

Implementation inspired by the pathmunge function.