### PR TITLE
Docker plugin --> boot2docker, docker-machine plugins

### DIFF
--- a/plugins/available/boot2docker.bash
+++ b/plugins/available/boot2docker.bash
@@ -1,0 +1,15 @@
+cite about-plugin
+about-plugin 'Helpers to get Docker setup correctly for boot2docker'
+
+# Note, this might need to be different if you have an older version
+# of boot2docker, or its configured for a different IP
+if [[ `uname -s` == "Darwin" ]]; then
+  export DOCKER_HOST="tcp://192.168.59.103:2376"
+  export DOCKER_CERT_PATH="~/.boot2docker/certs/boot2docker-vm"
+  export DOCKER_TLS_VERIFY=1
+
+  docker-enter() {
+    boot2docker ssh '[ -f /var/lib/boot2docker/nsenter ] || docker run --rm -v /var/lib/boot2docker/:/target jpetazzo/nsenter'
+    boot2docker ssh -t sudo "/var/lib/boot2docker/docker-enter \"$1\""
+  }
+fi

--- a/plugins/available/docker-machine.bash
+++ b/plugins/available/docker-machine.bash
@@ -1,0 +1,11 @@
+cite about-plugin
+about-plugin 'Helpers to get Docker setup correctly for docker-machine'
+
+# Note, this might need to be different if you use a machine other than 'dev',
+# or its configured for a different IP
+if [[ `uname -s` == "Darwin" ]]; then
+  export DOCKER_HOST="tcp://192.168.99.100:2376"
+  export DOCKER_CERT_PATH="~/.docker/machine/machines/dev"
+  export DOCKER_TLS_VERIFY=1
+  export DOCKER_MACHINE_NAME="dev"
+fi

--- a/plugins/available/docker.plugin.bash
+++ b/plugins/available/docker.plugin.bash
@@ -1,18 +1,5 @@
 cite about-plugin
-about-plugin 'Helpers to get Docker setup correctly for boot2docker and to more easily work with Docker'
-
-# Note, this might need to be different if you have an older version
-# of boot2docker, or its configured for a different IP
-if [[ `uname -s` == "Darwin" ]]; then
-  export DOCKER_HOST=tcp://192.168.59.103:2376
-  export DOCKER_CERT_PATH=~/.boot2docker/certs/boot2docker-vm
-  export DOCKER_TLS_VERIFY=1
-
-  docker-enter() {
-    boot2docker ssh '[ -f /var/lib/boot2docker/nsenter ] || docker run --rm -v /var/lib/boot2docker/:/target jpetazzo/nsenter'
-    boot2docker ssh -t sudo "/var/lib/boot2docker/docker-enter \"$1\""
-  }
-fi
+about-plugin 'Helpers to more easily work with Docker'
 
 function docker-remove-most-recent-container() {
   about 'attempt to remove the most recent container from docker ps -a'


### PR DESCRIPTION
Moved boot2docker functionality to its own file. Also added a docker-machine plugin, which sets the same variables for docker-machine.

This will allow an easier transition from boot2docker to docker-machine.