### PR TITLE
Show git prompt when in a detached HEAD state

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -47,7 +47,7 @@ RBFU_THEME_PROMPT_SUFFIX='|'
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE
   elif [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
-  elif which git &> /dev/null && [[ -n "$(git symbolic-ref HEAD 2> /dev/null)" ]]; then SCM=$SCM_GIT
+  elif which git &> /dev/null && [[ -n "$(git rev-parse 2> /dev/null)" ]]; then SCM=$SCM_GIT
   elif [[ -d .hg ]]; then SCM=$SCM_HG
   elif which hg &> /dev/null && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
   elif [[ -d .svn ]]; then SCM=$SCM_SVN


### PR DESCRIPTION
The current check of `git symbolic-ref HEAD` does not detect git
repositories in the 'detached HEAD' state. This is the state a
repository is in if HEAD is not pointing to a valid branch or tag (e.g.
you are in a recently-initiated submodule).