### PR TITLE
Fixed error handling in less-pretty-cat plugin

### DIFF
--- a/plugins/available/less-pretty-cat.plugin.bash
+++ b/plugins/available/less-pretty-cat.plugin.bash
@@ -1,32 +1,28 @@
-cite about-plugin                                                                                        
-about-plugin 'pygmentize instead of cat to terminal if possible'                                         
+cite about-plugin
+about-plugin 'pygmentize instead of cat to terminal if possible'
 
-if [ -z $(which pygmentize) ]
-then
-    echo "Pygments is required to use this plugin"
-    echo "Install it by doing 'pip install Pygments' as the superuser"
+if $(command -v pygmentize &> /dev/null) ; then
+  # get the full paths to binaries
+  CAT_BIN=$(which cat)
+  LESS_BIN=$(which less)
+
+  # pigmentize cat and less outputs
+  function cat()
+  {
+      about 'runs either pygmentize or cat on each file passed in'
+      param '*: files to concatenate (as normally passed to cat)'
+      example 'cat mysite/manage.py dir/text-file.txt'
+      for var;
+      do
+          pygmentize "$var" 2>/dev/null || "$CAT_BIN" "$var";
+      done
+  }
+
+  function less()
+  {
+      about 'it pigments the file passed in and passes it to less for pagination'
+      param '$1: the file to paginate with less'
+      example 'less mysite/manage.py'
+      pygmentize "$*" | "$LESS_BIN" -R
+  }
 fi
-
-# get the full paths to binaries
-CAT_BIN=$(which cat)
-LESS_BIN=$(which less)
-
-# pigmentize cat and less outputs
-cat()
-{
-    about 'runs either pygmentize or cat on each file passed in'
-    param '*: files to concatenate (as normally passed to cat)'
-    example 'cat mysite/manage.py dir/text-file.txt'
-    for var;
-    do
-        pygmentize "$var" 2>/dev/null || "$CAT_BIN" "$var";
-    done
-}
-
-less()
-{
-    about 'it pigments the file passed in and passes it to less for pagination'
-    param '$1: the file to paginate with less'
-    example 'less mysite/manage.py'
-    pygmentize "$*" | "$LESS_BIN" -R
-}


### PR DESCRIPTION
When pygmentize is not installed, the functions less/cat are not
defined, the native commands will be used instead. Also removed the
error message that was shown when the command was not found.

Using `command -v` instead of `which` to check for the existence of the
executable - this works better as it does not print an error message if
the executable is not found.