### PR TITLE
Moved docker-enter function to docker plugin

### DIFF
--- a/plugins/available/boot2docker.bash
+++ b/plugins/available/boot2docker.bash
@@ -7,9 +7,4 @@ if [[ `uname -s` == "Darwin" ]]; then
   export DOCKER_HOST="tcp://192.168.59.103:2376"
   export DOCKER_CERT_PATH="~/.boot2docker/certs/boot2docker-vm"
   export DOCKER_TLS_VERIFY=1
-
-  docker-enter() {
-    boot2docker ssh '[ -f /var/lib/boot2docker/nsenter ] || docker run --rm -v /var/lib/boot2docker/:/target jpetazzo/nsenter'
-    boot2docker ssh -t sudo "/var/lib/boot2docker/docker-enter \"$1\""
-  }
 fi

--- a/plugins/available/docker.plugin.bash
+++ b/plugins/available/docker.plugin.bash
@@ -13,6 +13,15 @@ function docker-remove-most-recent-image() {
   docker images | head -2 | tail -1 | awk '{print $3}' | xargs docker rmi
 }
 
+function docker-enter() {
+  about 'enter the specified docker container using bash'
+  group 'docker'
+  param '1: Name of the container to enter'
+  example 'docker-enter oracle-xe'
+
+  docker exec -it "$@" /bin/bash;
+}
+
 function docker-remove-images() {
   about 'attempt to remove images with supplied tags or all if no tags are supplied'
   group 'docker'


### PR DESCRIPTION
Using the recommended enter approach (exec) instead of the previously used nsenter.