### PR TITLE
Uninstall script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,14 @@ Alternatively, you can preview the themes in your own shell using `BASH_PREVIEW=
 
 ## Uninstalling
 
-There is no automatic uninstall process. To return to your old, boring bash experience, do `rm -rf ~/.bash_it`, followed by `mv ~/.bashrc.bak ~/.bashrc` (on Linux), or `mv ~/.bash_profile.bak ~/.bash_profile` (on Mac). Start a new shell, and Bash it will be gone...
+To uninstall Bash it, run the `uninstall.sh` script found in the `$BASH_IT` directory:
+
+```
+cd $BASH_IT
+./uninstall.sh
+```
+
+This will restore your previous Bash profile. After the uninstall script finishes, remove the Bash it directory from your machine (`rm -rf $BASH_IT`) and start a new shell.
 
 ## Misc
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+BASH_IT="$HOME/.bash_it"
+
+case $OSTYPE in
+  darwin*)
+    CONFIG_FILE=.bash_profile
+    ;;
+  *)
+    CONFIG_FILE=.bashrc
+    ;;
+esac
+
+BACKUP_FILE=$CONFIG_FILE.bak
+
+if [ ! -e "$HOME/$BACKUP_FILE" ]; then
+  echo -e "\033[0;33mBackup file "$HOME/$BACKUP_FILE" not found.\033[0m" >&2
+
+  test -w "$HOME/$CONFIG_FILE" &&
+    mv "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.uninstall" &&
+    echo -e "\033[0;32mMoved your $HOME/$CONFIG_FILE to $HOME/$CONFIG_FILE.uninstall.\033[0m"
+else
+  test -w "$HOME/$BACKUP_FILE" &&
+    cp -a "$HOME/$BACKUP_FILE" "$HOME/$CONFIG_FILE" &&
+    rm "$HOME/$BACKUP_FILE" &&
+    echo -e "\033[0;32mYour original $CONFIG_FILE has been restored.\033[0m"
+fi
+
+echo ""
+echo -e "\033[0;32mUninstallation finished successfully! Sorry to see you go!\033[0m"
+echo ""
+echo "Final steps to complete the uninstallation:"
+echo "  -> Remove the $BASH_IT folder"
+echo "  -> Open a new shell/tab/terminal"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-BASH_IT="$HOME/.bash_it"
+if [ -z "$BASH_IT" ];
+then
+  BASH_IT="$HOME/.bash_it"
+fi
 
 case $OSTYPE in
   darwin*)


### PR DESCRIPTION
Added an uninstall script and instructions. The script does the following:

* Restores the previous Bash profile (`~/.bash_profile.bak` or `~/.bashrc.bak`).
* If the backup file was not found, it simply renames the current profile. It also prints out a message in this case.
* Prints a goodbye message and next steps: Remove the `$BASH_IT` folder, open a new shell
