### PR TITLE
Fixed battery conversion

### DIFF
--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -172,9 +172,9 @@ function powerline_battery_status_prompt {
     if [[ -z "${BATTERY_STATUS}" ]] || [[ "${BATTERY_STATUS}" = "-1" ]] || [[ "${BATTERY_STATUS}" = "no" ]]; then
         BATTERY_PROMPT=""
     else
-        if [[ "${BATTERY_STATUS}" -le 5 ]]; then
+        if [[ "$((10#${BATTERY_STATUS}))" -le 5 ]]; then
              BATTERY_STATUS_THEME_PROMPT_COLOR="${BATTERY_STATUS_THEME_PROMPT_CRITICAL_COLOR}"
-        elif [[ "${BATTERY_STATUS}" -le 25 ]]; then
+        elif [[ "$((10#${BATTERY_STATUS}))" -le 25 ]]; then
             BATTERY_STATUS_THEME_PROMPT_COLOR="${BATTERY_STATUS_THEME_PROMPT_LOW_COLOR}"
         else
             BATTERY_STATUS_THEME_PROMPT_COLOR="${BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR}"


### PR DESCRIPTION
For battery percentages of 08 and 09 percent, the `-le` would fail with
an error ("value too great for base"), since the numbers with leading
zeros are treated as octal numbers when using double brackets.

The solution is to force base 10 for the numbers. More details here:
http://stackoverflow.com/a/24777667/1228454