### PR TITLE
Fix #546: infinite loop when $PS4 calls external command

### DIFF
--- a/themes/colors.theme.bash
+++ b/themes/colors.theme.bash
@@ -5,54 +5,54 @@ function __ {
 }
 
 function __make_ansi {
-  next=$1 && shift
+  next=$1; shift
   echo "\[\e[$(__$next $@)m\]"
 }
 
 function __make_echo {
-  next=$1 && shift
+  next=$1; shift
   echo "\033[$(__$next $@)m"
 }
 
 
 function __reset {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "0${out:+;${out}}"
 }
 
 function __bold {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "${out:+${out};}1"
 }
 
 function __faint {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "${out:+${out};}2"
 }
 
 function __italic {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "${out:+${out};}3"
 }
 
 function __underline {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "${out:+${out};}4"
 }
 
 function __negative {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "${out:+${out};}7"
 }
 
 function __crossed {
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "${out:+${out};}8"
 }
@@ -114,18 +114,18 @@ function __color_rgb {
 }
 
 function __color {
-  color=$1 && shift
+  color=$1; shift
   case "$1" in
-    fg|bg) side="$1" && shift ;;
+    fg|bg) side="$1"; shift ;;
     *) side=fg;;
   esac
   case "$1" in
-    normal|bright) mode="$1" && shift;;
+    normal|bright) mode="$1"; shift;;
     *) mode=normal;;
   esac
-  [[ $color == "rgb" ]] && rgb="$1 $2 $3" && shift 3
+  [[ $color == "rgb" ]] && rgb="$1 $2 $3"; shift 3
 
-  next=$1 && shift
+  next=$1; shift
   out="$(__$next $@)"
   echo "$(__color_${mode}_${side} $(__color_${color} $rgb))${out:+;${out}}"
 }
@@ -169,7 +169,7 @@ function __rgb {
 
 
 function __color_parse {
-  next=$1 && shift
+  next=$1; shift
   echo "$(__$next $@)"
 }
 


### PR DESCRIPTION
When using `set -x` with a `$PS4` variable which calls a external
command (e.g. `PS4='+ $(true)'`) the color functions end in a infite
loop.

The solution is `shift` the arguments unconditionally in the color
funtions.

This fixes #546