### PR TITLE
Load bash_profile.bak

### DIFF
--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Load previous profile
+source $HOME/.bash_profile.bak
+
 # Path to the bash it configuration
 export BASH_IT="$HOME/.bash_it"
 


### PR DESCRIPTION
Current `bash-it` template does not load its backed up `.bash_profile.bak` file.
