### PR TITLE
Moved some functions

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -99,33 +99,6 @@ function lsgrep ()
     ls | grep "$*"
 }
 
-function pman ()
-{
-    about 'view man documentation in Preview'
-    param '1: man page to view'
-    example '$ pman bash'
-    group 'base'
-    man -t "${1}" | open -f -a $PREVIEW
-}
-
-function pcurl ()
-{
-    about 'download file and Preview it'
-    param '1: download URL'
-    example '$ pcurl http://www.irs.gov/pub/irs-pdf/fw4.pdf'
-    group 'base'
-    curl "${1}" | open -f -a $PREVIEW
-}
-
-function pri ()
-{
-    about 'display information about Ruby classes, modules, or methods, in Preview'
-    param '1: Ruby method, module, or class'
-    example '$ pri Array'
-    group 'base'
-    ri -T "${1}" | open -f -a $PREVIEW
-}
-
 function quiet ()
 {
     about 'what *does* this do?'

--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -63,8 +63,25 @@ function dock-switch() {
     fi
 }
 
-# Download a file and open it in Preview
+function pman ()
+{
+    about 'view man documentation in Preview'
+    param '1: man page to view'
+    example '$ pman bash'
+    group 'osx'
+    man -t "${1}" | open -fa $PREVIEW
+}
 
+function pri ()
+{
+    about 'display information about Ruby classes, modules, or methods, in Preview'
+    param '1: Ruby method, module, or class'
+    example '$ pri Array'
+    group 'osx'
+    ri -T "${1}" | open -fa $PREVIEW
+}
+
+# Download a file and open it in Preview
 function prevcurl() {
   about 'download a file and open it in Preview'
   param '1: url'
@@ -75,5 +92,8 @@ function prevcurl() {
     echo "This function only works with Mac OS X"
     return 1
   fi
-  curl "$*" | open -fa "Preview"
+  curl "$*" | open -fa $PREVIEW
 }
+
+# Make this backwards compatible
+alias pcurl='prevcurl'


### PR DESCRIPTION
Some functions were specific to OS X, but were defined in the `base` plugin. I have moved them to the `osx` plugin:

* pman
* pcurl
* pri

As for `pcurl`, the `osx` plugin already had an existing `prevcurl` function, which was doing the same thing. I've aliased `pcurl` to simply call `prevcurl` to avoid breaking existing installations.

As far as I know the `open -fa $PREVIEW` thing only works on OS X, which means that these functions have only worked on OS X anyway.