### PR TITLE
Indicator if running bash in vim

### DIFF
--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -42,6 +42,10 @@ BATTERY_STATUS_THEME_PROMPT_CRITICAL_COLOR=160
 
 THEME_PROMPT_CLOCK_FORMAT=${THEME_PROMPT_CLOCK_FORMAT:="%H:%M:%S"}
 
+IN_VIM_PROMPT_COLOR=35
+IN_VIM_PROMPT_TEXT="vim"
+
+
 function set_rgb_color {
     if [[ "${1}" != "-" ]]; then
         fg="38;5;${1}"
@@ -191,6 +195,22 @@ function powerline_battery_status_prompt {
     fi
 }
 
+function powerline_in_vim_prompt {
+  if [ -z "$MYVIMRC" ]; then
+    IN_VIM_PROMPT=""
+  else
+    IN_VIM_PROMPT="$(set_rgb_color - ${IN_VIM_PROMPT_COLOR}) ${IN_VIM_PROMPT_TEXT} "
+    if [[ "${SEGMENT_AT_RIGHT}" -gt 0 ]]; then
+      IN_VIM_PROMPT+=$(set_rgb_color ${LAST_THEME_COLOR} ${IN_VIM_PROMPT_COLOR})${THEME_PROMPT_LEFT_SEPARATOR}${normal}
+      (( RIGHT_PROMPT_LENGTH += SEGMENT_AT_RIGHT ))
+    fi
+    RIGHT_PROMPT_LENGTH=$(( ${RIGHT_PROMPT_LENGTH} + ${#IN_VIM_PROMPT_TEXT} ))
+    LAST_THEME_COLOR=${IN_VIM_PROMPT_COLOR}
+    (( SEGMENT_AT_RIGHT += 1 ))
+  fi
+}
+
+
 function powerline_prompt_command() {
     local LAST_STATUS="$?"
     local MOVE_CURSOR_RIGHTMOST='\033[500C'
@@ -210,11 +230,12 @@ function powerline_prompt_command() {
     powerline_shell_prompt
     powerline_battery_status_prompt
     powerline_clock_prompt
+    powerline_in_vim_prompt
 
     [[ "${SEGMENT_AT_RIGHT}" -eq 1 ]] && (( RIGHT_PROMPT_LENGTH-=1 ))
 
     RIGHT_PROMPT="\033[${RIGHT_PROMPT_LENGTH}D$(set_rgb_color ${LAST_THEME_COLOR} -)${THEME_PROMPT_LEFT_SEPARATOR}${normal}"
-    RIGHT_PROMPT+="${CLOCK_PROMPT}${BATTERY_PROMPT}${SHELL_PROMPT}${normal}"
+    RIGHT_PROMPT+="${IN_VIM_PROMPT}${CLOCK_PROMPT}${BATTERY_PROMPT}${SHELL_PROMPT}${normal}"
 
     PS1="${LEFT_PROMPT}${RIGHT_PROMPT}\n${LAST_STATUS_PROMPT}${PROMPT_CHAR} "
 }

--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -196,7 +196,7 @@ function powerline_battery_status_prompt {
 }
 
 function powerline_in_vim_prompt {
-  if [ -z "$MYVIMRC" ]; then
+  if [ -z "$VIMRUNTIME" ]; then
     IN_VIM_PROMPT=""
   else
     IN_VIM_PROMPT="$(set_rgb_color - ${IN_VIM_PROMPT_COLOR}) ${IN_VIM_PROMPT_TEXT} "

--- a/themes/powerline/powerline.theme.bash
+++ b/themes/powerline/powerline.theme.bash
@@ -25,6 +25,10 @@ CWD_THEME_PROMPT_COLOR=240
 
 LAST_STATUS_THEME_PROMPT_COLOR=52
 
+IN_VIM_PROMPT_COLOR=35
+IN_VIM_PROMPT_TEXT="vim"
+
+
 function set_rgb_color {
     if [[ "${1}" != "-" ]]; then
         fg="38;5;${1}"
@@ -103,16 +107,26 @@ function powerline_last_status_prompt {
     fi
 }
 
+function powerline_in_vim_prompt {
+  if [ -z "$MYVIMRC" ]; then
+    IN_VIM_PROMPT=""
+  else
+    IN_VIM_PROMPT="$(set_rgb_color ${LAST_THEME_COLOR} ${IN_VIM_PROMPT_COLOR})${THEME_PROMPT_SEPARATOR}${normal}$(set_rgb_color - ${IN_VIM_PROMPT_COLOR}) ${IN_VIM_PROMPT_TEXT} ${normal}$(set_rgb_color ${IN_VIM_PROMPT_COLOR} -)${normal}"
+    LAST_THEME_COLOR=${IN_VIM_PROMPT_COLOR}
+  fi
+}
+
 function powerline_prompt_command() {
     local LAST_STATUS="$?"
 
     powerline_shell_prompt
+    powerline_in_vim_prompt
     powerline_virtualenv_prompt
     powerline_scm_prompt
     powerline_cwd_prompt
     powerline_last_status_prompt LAST_STATUS
 
-    PS1="${SHELL_PROMPT}${VIRTUALENV_PROMPT}${SCM_PROMPT}${CWD_PROMPT}${LAST_STATUS_PROMPT} "
+    PS1="${SHELL_PROMPT}${IN_VIM_PROMPT}${VIRTUALENV_PROMPT}${SCM_PROMPT}${CWD_PROMPT}${LAST_STATUS_PROMPT} "
 }
 
 PROMPT_COMMAND=powerline_prompt_command

--- a/themes/powerline/powerline.theme.bash
+++ b/themes/powerline/powerline.theme.bash
@@ -108,7 +108,7 @@ function powerline_last_status_prompt {
 }
 
 function powerline_in_vim_prompt {
-  if [ -z "$MYVIMRC" ]; then
+  if [ -z "$VIMRUNTIME" ]; then
     IN_VIM_PROMPT=""
   else
     IN_VIM_PROMPT="$(set_rgb_color ${LAST_THEME_COLOR} ${IN_VIM_PROMPT_COLOR})${THEME_PROMPT_SEPARATOR}${normal}$(set_rgb_color - ${IN_VIM_PROMPT_COLOR}) ${IN_VIM_PROMPT_TEXT} ${normal}$(set_rgb_color ${IN_VIM_PROMPT_COLOR} -)${normal}"


### PR DESCRIPTION
Sometimes I find myself unable to remember if I am currently in bash coming from vim (via `:sh`), usually when I have multiple terminals open.

I patched the `powerline` theme to indicate to me if I stepped in from `vim` or not:

#### Normal

![screen shot 2015-08-31 at 10 27 10 am](https://cloud.githubusercontent.com/assets/1437428/9585385/73c2b36e-4fcb-11e5-8f06-8f2b129c709b.png)

#### From `vim`

![screen shot 2015-08-31 at 10 27 52 am](https://cloud.githubusercontent.com/assets/1437428/9585400/827ad5ee-4fcb-11e5-886f-dbdb008932d5.png)

If there is an interest in having this throughout all themes and having this as a feature, I am willing to do the work.