### PR TITLE
More advanced ls aliases

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -2,26 +2,52 @@ cite about-alias
 about-alias 'general aliases'
 
 # List directory contents
-# Source: http://tldp.org/LDP/abs/html/sample-bashrc.html
+# Alias source: http://tldp.org/LDP/abs/html/sample-bashrc.html
+
+local LS_COLOR_OPTION
+
+case "$OSTYPE" in
+  linux*)
+    # Set Linux color option
+    LS_COLOR_OPTION="--color=auto"
+    ;;
+    darwin*)
+    # Set BSD color optio
+    LS_COLOR_OPTION="-G"
+    #Check if coreutils version of if exists
+    if [[ -x "/usr/local/opt/coreutils/libexec/gnubin/ls" ]]; then
+      # Check if coreutils path is in $PATH
+      if [[ ":$PATH:" == *":/usr/local/opt/coreutils/libexec/gnubin:"* ]]; then
+        # Set Linux color option
+        LS_COLOR_OPTION="--color"
+      fi
+    fi
+    ;;
+  *)
+    # Use Linux color option as fallback
+    LS_COLOR_OPTION="--color=auto"
+    ;;
+esac
+
 
 # # Add colors for filetype and  human-readable sizes by default on 'ls':
-alias l='ls -a --color'            # Standard
-alias lx='ls -lXB --color'         # Sort by extension.
-alias lk='ls -lSr --color'         # Sort by size, biggest last.
-alias lt='ls -ltr --color'         # Sort by date, most recent last.
-alias lc='ls -ltcr --color'        # Sort by/show change time,most recent last.
-alias lu='ls -ltur --color'        # Sort by/show access time,most recent last.
+alias l="ls -a $LS_COLOR_OPTION"            # Standard
+alias lx="ls -lXB $LS_COLOR_OPTION"         # Sort by extension.
+alias lk="ls -lSr $LS_COLOR_OPTION"         # Sort by size, biggest last.
+alias lt="ls -ltr $LS_COLOR_OPTION"         # Sort by date, most recent last.
+alias lc="ls -ltcr $LS_COLOR_OPTION"        # Sort by/show change time,most recent last.
+alias lu="ls -ltur $LS_COLOR_OPTION"        # Sort by/show access time,most recent last.
 
 # # The ubiquitous 'll': directories first, with alphanumeric sorting:
-alias ll="ls -lv --group-directories-first --color"
-alias lm='ll |more'                # Pipe through 'more'
-alias lr='ll -R'                   # Recursive ls.
-alias la='ll -A'                   # Show hidden files.
+alias ll="ls -lv --group-directories-first $LS_COLOR_OPTION"
+alias lm="ll |more"                # Pipe through "more"
+alias lr="ll -R"                   # Recursive ls.
+alias la="ll -A"                   # Show hidden files.
 
-alias tree='tree -C'               # Nice alternative to 'recursive ls' ...
+alias tree="tree -C"               # Nice alternative to "recursive ls" ...
 
-alias sl='ls'
-alias l1='ls -1 --group-directories-first --color'
+alias sl="ls"
+alias l1="ls -1 --group-directories-first $LS_COLOR_OPTION"
 
 
 alias _="sudo"

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -5,7 +5,6 @@ about-alias 'general aliases'
 # Source: http://tldp.org/LDP/abs/html/sample-bashrc.html
 
 # # Add colors for filetype and  human-readable sizes by default on 'ls':
-#alias ls='ls --color'
 alias l='ls -a --color'            # Standard
 alias lx='ls -lXB --color'         # Sort by extension.
 alias lk='ls -lSr --color'         # Sort by size, biggest last.
@@ -15,17 +14,14 @@ alias lu='ls -ltur --color'        # Sort by/show access time,most recent last.
 
 # # The ubiquitous 'll': directories first, with alphanumeric sorting:
 alias ll="ls -lv --group-directories-first --color"
-  alias lm='ll |more'                # Pipe through 'more'
-  alias lr='ll -R'                   # Recursive ls.
-  alias la='ll -A'                   # Show hidden files.
+alias lm='ll |more'                # Pipe through 'more'
+alias lr='ll -R'                   # Recursive ls.
+alias la='ll -A'                   # Show hidden files.
+
 alias tree='tree -C'               # Nice alternative to 'recursive ls' ...
 
 alias sl='ls'
 alias l1='ls -1 --group-directories-first --color'
-
-# alias ls='ls -G'        # Compact view, show colors
-# alias la='ls -AF'       # Compact view, show hidden
-# alias ll='ls -al'
 
 
 alias _="sudo"

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -11,7 +11,7 @@ case "$OSTYPE" in
     # Set Linux color option
     LS_COLOR_OPTION="--color=auto"
     ;;
-    darwin*)
+  darwin*)
     # Set BSD color optio
     LS_COLOR_OPTION="-G"
     #Check if coreutils version of if exists
@@ -19,7 +19,7 @@ case "$OSTYPE" in
       # Check if coreutils path is in $PATH
       if [[ ":$PATH:" == *":/usr/local/opt/coreutils/libexec/gnubin:"* ]]; then
         # Set Linux color option
-        LS_COLOR_OPTION="--color"
+        LS_COLOR_OPTION="--color=auto"
       fi
     fi
     ;;
@@ -43,8 +43,6 @@ alias ll="ls -lv --group-directories-first $LS_COLOR_OPTION"
 alias lm="ll |more"                # Pipe through "more"
 alias lr="ll -R"                   # Recursive ls.
 alias la="ll -A"                   # Show hidden files.
-
-alias tree="tree -C"               # Nice alternative to "recursive ls" ...
 
 alias sl="ls"
 alias l1="ls -1 --group-directories-first $LS_COLOR_OPTION"

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -2,19 +2,35 @@ cite about-alias
 about-alias 'general aliases'
 
 # List directory contents
-alias sl=ls
-alias ls='ls -G'        # Compact view, show colors
-alias la='ls -AF'       # Compact view, show hidden
-alias ll='ls -al'
-alias l='ls -a'
-alias l1='ls -1'
+# Source: http://tldp.org/LDP/abs/html/sample-bashrc.html
+
+# # Add colors for filetype and  human-readable sizes by default on 'ls':
+#alias ls='ls --color'
+alias l='ls -a --color'            # Standard
+alias lx='ls -lXB --color'         # Sort by extension.
+alias lk='ls -lSr --color'         # Sort by size, biggest last.
+alias lt='ls -ltr --color'         # Sort by date, most recent last.
+alias lc='ls -ltcr --color'        # Sort by/show change time,most recent last.
+alias lu='ls -ltur --color'        # Sort by/show access time,most recent last.
+
+# # The ubiquitous 'll': directories first, with alphanumeric sorting:
+alias ll="ls -lv --group-directories-first --color"
+  alias lm='ll |more'                # Pipe through 'more'
+  alias lr='ll -R'                   # Recursive ls.
+  alias la='ll -A'                   # Show hidden files.
+alias tree='tree -C'               # Nice alternative to 'recursive ls' ...
+
+alias sl='ls'
+alias l1='ls -1 --group-directories-first --color'
+
+# alias ls='ls -G'        # Compact view, show colors
+# alias la='ls -AF'       # Compact view, show hidden
+# alias ll='ls -al'
+
 
 alias _="sudo"
 
-if [ $(uname) = "Linux" ]
-then
-  alias ls="ls --color=auto"
-fi
+
 which gshuf &> /dev/null
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
Used more advanced ls aliases from: http://tldp.org/LDP/abs/html/sample-bashrc.html
Original ls remains unaliased (--> better if other programs depend on it)
Removed unneeded -if [ $(uname) = "Linux" ] that prevents colored ls output on OS X

--> tested on Linux and OS X wit coreutils