### PR TITLE
Replace `~` with $HOME in docker-machine plugin

### DIFF
--- a/plugins/available/docker-machine.plugin.bash
+++ b/plugins/available/docker-machine.plugin.bash
@@ -5,7 +5,7 @@ about-plugin 'Helpers to get Docker setup correctly for docker-machine'
 # or its configured for a different IP
 if [[ `uname -s` == "Darwin" ]]; then
   export DOCKER_HOST="tcp://192.168.99.100:2376"
-  export DOCKER_CERT_PATH="~/.docker/machine/machines/dev"
+  export DOCKER_CERT_PATH="$HOME/.docker/machine/machines/dev"
   export DOCKER_TLS_VERIFY=1
   export DOCKER_MACHINE_NAME="dev"
 fi


### PR DESCRIPTION
The `~` caused docker commands to error with the following:
```
$ docker images
Could not read CA certificate "~/.docker/machine/machines/dev/ca.pem"
```
Switching to $HOME fixes the issue