### PR TITLE
Addresses duplicate emacs alias use of 'et'. See Issue #578

### DIFF
--- a/aliases/available/emacs.aliases.bash
+++ b/aliases/available/emacs.aliases.bash
@@ -4,7 +4,7 @@ about-alias 'emacs editor'
 case $OSTYPE in
   linux*)
     alias em='emacs'
-    alias et='emacs -nw'
+    alias en='emacs -nw'
     alias e='emacsclient -n'
     alias et='emacsclient -t'
     alias ed='emacs --daemon'


### PR DESCRIPTION
As requested, here's a pull request fixing issue #578 