### PR TITLE
Add `gf` alias for fetching all and pruning

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -5,6 +5,7 @@ about-alias 'common git abbreviations'
 alias gcl='git clone'
 alias ga='git add'
 alias gall='git add .'
+alias gf='git fetch --all --prune'
 alias gus='git reset HEAD'
 alias gm="git merge"
 alias g='git'


### PR DESCRIPTION
Adds `gf` as an alias for fetching all git remotes and pruning obsolete remote branches.