### PR TITLE
Source docker-machine environment variables rather than hardcoding

### DIFF
--- a/plugins/available/docker-machine.plugin.bash
+++ b/plugins/available/docker-machine.plugin.bash
@@ -4,8 +4,5 @@ about-plugin 'Helpers to get Docker setup correctly for docker-machine'
 # Note, this might need to be different if you use a machine other than 'dev',
 # or its configured for a different IP
 if [[ `uname -s` == "Darwin" ]]; then
-  export DOCKER_HOST="tcp://192.168.99.100:2376"
-  export DOCKER_CERT_PATH="$HOME/.docker/machine/machines/dev"
-  export DOCKER_TLS_VERIFY=1
-  export DOCKER_MACHINE_NAME="dev"
+  eval "$(docker-machine env dev)"
 fi

--- a/plugins/available/docker-machine.plugin.bash
+++ b/plugins/available/docker-machine.plugin.bash
@@ -1,8 +1,11 @@
 cite about-plugin
 about-plugin 'Helpers to get Docker setup correctly for docker-machine'
 
-# Note, this might need to be different if you use a machine other than 'dev',
-# or its configured for a different IP
+# Note, this might need to be different if you use a machine other than 'dev'
 if [[ `uname -s` == "Darwin" ]]; then
-  eval "$(docker-machine env dev)"
+  # check if dev machine is running
+  docker-machine ls | grep --quiet 'dev.*Running'
+  if [[ "$?" = "0" ]]; then
+    eval "$(docker-machine env dev)"
+  fi
 fi


### PR DESCRIPTION
The docker-machine IP can change if the machine is recreated. `docker-machine env dev` sources the current machine settings.

Signed-off-by: Frank Kotsianas <fkotsian@pivotal.io>