### PR TITLE
Fixed pygmentize in less.

### DIFF
--- a/plugins/available/less-pretty-cat.plugin.bash
+++ b/plugins/available/less-pretty-cat.plugin.bash
@@ -23,6 +23,6 @@ if $(command -v pygmentize &> /dev/null) ; then
       about 'it pigments the file passed in and passes it to less for pagination'
       param '$1: the file to paginate with less'
       example 'less mysite/manage.py'
-      pygmentize "$*" | "$LESS_BIN" -R
+      pygmentize -g $* | "$LESS_BIN" -R
   }
 fi


### PR DESCRIPTION
Was not working correctly with file extensions unknown to pygmentize. Added the -g option to pygmentize command.

The issue fixed by this commit can be reproduced with the follwing command (considering the master branch):

```bash
echo "This is a test" > test.toto | less test.toto
``` 
which returns
```
Error: no lexer for filename 'test.toto' found
```

Also I removed the double quotes around ```$*``` (maybe I should have done it in another PR) because this does not allow to pass additional options to pygmentize (at least on OS X) as claimed in commit e143d4f6969eb1774a0d83cf378c171967d0487f (unless I am missing something). For instance:

```bash
less -l matlab hessian.m
```
does not work because of the double quotes. If you want I can split this PR in two parts.