### PR TITLE
Allow custom themes to be in $BASH_IT/custom/themes

### DIFF
--- a/lib/appearance.bash
+++ b/lib/appearance.bash
@@ -7,7 +7,15 @@ export GREP_COLOR='1;33'
 # colored ls
 export LSCOLORS='Gxfxcxdxdxegedabagacad'
 
+if [[ -z "$CUSTOM_THEME_DIR" ]]; then
+    CUSTOM_THEME_DIR="${BASH_IT}/custom/themes"
+fi
+
 # Load the theme
 if [[ $BASH_IT_THEME ]]; then
-    source "$BASH_IT/themes/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
+    if [[ -f "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash" ]]; then
+        source "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
+    else
+        source "$BASH_IT/themes/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
+    fi
 fi


### PR DESCRIPTION
This will look for a theme in $BASH_IT/custom/themes before $BASH_IT/themes.