### PR TITLE
Show crouton debian_chroot and python virtualenv (if applicable) (feature)

### DIFF
--- a/themes/zork/zork.theme.bash
+++ b/themes/zork/zork.theme.bash
@@ -71,7 +71,7 @@ prompt() {
     # yes, these are the the same for now ...
     my_ps_host_root="${green}\h${normal}";
  
-    my_ps_user="${green}\h${normal}"
+    my_ps_user="${bold_green}\u${normal}"
     my_ps_root="${bold_red}\u${normal}";
 
     if [ -n "$VIRTUAL_ENV" ]


### PR DESCRIPTION
Add features to zork theme.  Show activated python virtualenv and chromebook crouton debian chroot, if and when either apply.