### PR TITLE
Allow multiple aliases on same ssh config Host line to complete.

### DIFF
--- a/completion/available/ssh.completion.bash
+++ b/completion/available/ssh.completion.bash
@@ -14,7 +14,7 @@ _sshcomplete() {
     
     # parse all defined hosts from .ssh/config
     if [ -r "$HOME/.ssh/config" ]; then
-        COMPREPLY=($(compgen -W "$(grep ^Host "$HOME/.ssh/config" | awk '{print $2}' )" ${OPTIONS}) )
+        COMPREPLY=($(compgen -W "$(grep ^Host "$HOME/.ssh/config" | awk '{$1=""; print $0}' )" ${OPTIONS}) )
     fi
 
     # parse all hosts found in .ssh/known_hosts


### PR DESCRIPTION
This allows to parse the whole Host line like in 
```
Host shared-022.oms.net omshared                  
    hostname                    shared-022.oms.net
```
instead of only retrieving the first host on the Host line