### PR TITLE
Loading Homebrew Bash Completion if installed

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -1,5 +1,16 @@
 #!/usr/bin/env bash
 
+# Loads the system's Bash completion modules.
+# If Homebrew is installed (OS X), its Bash completion modules are loaded.
+
 if [ -f /etc/bash_completion ]; then
-	. /etc/bash_completion
+  . /etc/bash_completion
+fi
+
+if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
+  BREW_PREFIX=$(brew --prefix)
+
+  if [ -f "$BREW_PREFIX"/etc/bash_completion ]; then
+    . "$BREW_PREFIX"/etc/bash_completion
+  fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,7 @@ else
   echo ""
   echo -e "\033[0;32mEnabling sane defaults\033[0m"
   load_one completion bash-it.completion.bash
+  load_one completion system.completion.bash
   load_one plugins base.plugin.bash
   load_one plugins alias-completion.plugin.bash
   load_one aliases general.aliases.bash


### PR DESCRIPTION
In addition to the regular /etc/bash_completion, the one from Homebrew is loaded when running on OS X, and when Homebrew is installed.

Also added the system completion to the default install options, since this is a feature that's requested frequently.