### PR TITLE
 Add follow sym link and option to append template to existing .bashrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,11 +32,11 @@ if [ -e "$HOME/$BACKUP_FILE" ]; then
     done
 fi
 
-read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash_it templates at the end?[y/N] " choice
+read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash-it templates at the end? [y/N] " choice
   case $choice in
     [yY])
 	  (sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" || tail -n +2) >> "$HOME/$CONFIG_FILE"
-	  echo -e "\033[0;32mBash_it template has correctly added to your $CONFIG_FILE\033[0m"
+	  echo -e "\033[0;32mBash-it template has been added to your $CONFIG_FILE\033[0m"
       ;;
     [nN]|"")
 	  test -w "$HOME/$CONFIG_FILE" &&

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,11 @@ do
   read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash-it templates at the end? [y/N] " choice
     case $choice in
       [yY])
-	    (sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" || tail -n +2) >> "$HOME/$CONFIG_FILE"
+        test -w "$HOME/$CONFIG_FILE" &&
+	    cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
+	    echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
+
+	    (sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" | tail -n +2) >> "$HOME/$CONFIG_FILE"
 	    echo -e "\033[0;32mBash-it template has been added to your $CONFIG_FILE\033[0m"
 	    break
         ;;

--- a/install.sh
+++ b/install.sh
@@ -32,11 +32,22 @@ if [ -e "$HOME/$BACKUP_FILE" ]; then
     done
 fi
 
-test -w "$HOME/$CONFIG_FILE" &&
-  cp -a "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
-  echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
-
-sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash_it templates at the end?[y/N] " choice
+  case $choice in
+    [yY])
+	  (sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" || tail -n +2) >> "$HOME/$CONFIG_FILE"
+	  echo -e "\033[0;32mBash_it template has correctly added to your $CONFIG_FILE\033[0m"
+      ;;
+    [nN]|"")
+	  test -w "$HOME/$CONFIG_FILE" &&
+	  cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
+	  echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
+	  sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+      ;;
+    *)
+      echo -e "\033[91mPlease choose y or n.\033[m"
+      ;;
+  esac
 
 echo -e "\033[0;32mCopied the template $CONFIG_FILE into ~/$CONFIG_FILE, edit this file to customize bash-it\033[0m"
 

--- a/install.sh
+++ b/install.sh
@@ -32,22 +32,28 @@ if [ -e "$HOME/$BACKUP_FILE" ]; then
     done
 fi
 
-read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash-it templates at the end? [y/N] " choice
-  case $choice in
-    [yY])
-	  (sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" || tail -n +2) >> "$HOME/$CONFIG_FILE"
-	  echo -e "\033[0;32mBash-it template has been added to your $CONFIG_FILE\033[0m"
-      ;;
-    [nN]|"")
-	  test -w "$HOME/$CONFIG_FILE" &&
-	  cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
-	  echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
-	  sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
-      ;;
-    *)
-      echo -e "\033[91mPlease choose y or n.\033[m"
-      ;;
-  esac
+while true
+do
+  read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash-it templates at the end? [y/N] " choice
+    case $choice in
+      [yY])
+	    (sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" || tail -n +2) >> "$HOME/$CONFIG_FILE"
+	    echo -e "\033[0;32mBash-it template has been added to your $CONFIG_FILE\033[0m"
+	    break
+        ;;
+      [nN]|"")
+	    test -w "$HOME/$CONFIG_FILE" &&
+	    cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
+	    echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
+	    sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+        break
+        ;;
+      *)
+        echo -e "\033[91mPlease choose y or n.\033[m"
+        ;;
+    esac
+done
+
 
 echo -e "\033[0;32mCopied the template $CONFIG_FILE into ~/$CONFIG_FILE, edit this file to customize bash-it\033[0m"
 


### PR DESCRIPTION
As per Issue #621 I added an option to let the user to keep his .bashrc and just append the general template of bashrc at the end. Also, in the normal flow I simply add the cp -aL options as suggested by @naught101 to let the installation process follow symlink in case .bashrc is one of them. First pull request for me here so, I hope it's all ok. In other case, please be patient :) 