### PR TITLE
Adding alias for sane default options to "ag" ("the silver searcher")

### DIFF
--- a/aliases/available/ag.aliases.bash
+++ b/aliases/available/ag.aliases.bash
@@ -1,4 +1,12 @@
 cite 'about-alias'
 about-alias 'the silver searcher (ag) aliases'
 
+## Summary for args to less:
+# less(1)
+#   -M (-M or --LONG-PROMPT) Prompt very verbosely
+#   -I (-I or --IGNORE-CASE) Searches with '/' ignore case
+#   -R (-R or --RAW-CONTROL-CHARS) For handling ANSI colors
+#   -F (-F or --quit-if-one-screen) Auto exit if <1 screen
+#   -X (-X or --no-init) Disable termcap init & deinit
+
 alias ag='ag --smart-case --pager="less -MIRFX"'

--- a/aliases/available/ag.aliases.bash
+++ b/aliases/available/ag.aliases.bash
@@ -1,0 +1,4 @@
+cite 'about-alias'
+about-alias 'the silver searcher (ag) aliases'
+
+alias ag='ag --smart-case --pager="less -MIRFX"'


### PR DESCRIPTION
`ag` (["the silver searcher"][1]) is a fast alternative to `grep` or [`ack`][2] for source code repo searching.  This PR adds a default alias with some sane defaults similar to those used for `ack`.

[1]: http://geoff.greer.fm/ag/
[2]: http://beyondgrep.com/