### PR TITLE
Speed up $PROMPT_COMMAND by using rvm-prompt

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -268,8 +268,8 @@ function hg_prompt_vars {
 
 function rvm_version_prompt {
   if which rvm &> /dev/null; then
-    rvm=$(rvm tools identifier) || return
-    if [ $rvm != "system" ]; then
+    rvm=$(rvm-prompt) || return
+    if [ -n "$rvm" ]; then
       echo -e "$RVM_THEME_PROMPT_PREFIX$rvm$RVM_THEME_PROMPT_SUFFIX"
     fi
   fi


### PR DESCRIPTION
Running `rvm tools identifier` seems to be really slow. Using [`rvm-prompt`](https://rvm.io/workflow/prompt) greatly speeds up the evaluation of `$PROMPT_COMMAND`.