### PR TITLE
[bugfix] Fixed messed-up git prompt

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -119,7 +119,7 @@ function git_status_summary {
     if (!seen_header) {
       print
     }
-    print untracked "\t" unstaged "\t" staged
+    print untracked + 0 "\t" unstaged + 0 "\t" staged + 0
   }'
 }
 


### PR DESCRIPTION
Fixes a bug introduced by #649 (mea culpa)

Basically, the wrong symbols are used to show unstaged or staged files (? or U rather than resp. U or S) in the git prompt.

When there are no untracked or unstaged files, `untracked` or `unstaged` are empty. As a consequence tabs are concatenated in the output of `git_status_summary` and the following `read` in `git_prompt_vars` reads the wrong fields.

Adding `+ 0` ensures that the output of `git_status_summary` always consists of 3 tab-separated numbers.