### PR TITLE
Make all vars defined in lib/history.bash overridable

### DIFF
--- a/lib/history.bash
+++ b/lib/history.bash
@@ -2,10 +2,10 @@
 
 # Bash History Handling
 
-shopt -s histappend              # append to bash_history if Terminal.app quits
-export HISTCONTROL=erasedups     # erase duplicates; alternative option: export HISTCONTROL=ignoredups
-export HISTSIZE=5000             # resize history size
-export AUTOFEATURE=true autotest
+shopt -s histappend                              # append to bash_history if Terminal.app quits
+export HISTCONTROL=${HISTCONTROL:-erasedups}     # erase duplicates; alternative option: export HISTCONTROL=ignoredups
+export HISTSIZE=${HISTSIZE:-5000}                # resize history size
+export AUTOFEATURE=${AUTOFEATURE:-true autotest} # Cucumber / Autotest integration
 
 function rh {
   history | awk '{a[$2]++}END{for(i in a){print a[i] " " i}}' | sort -rn | head


### PR DESCRIPTION
 Set these before sourcing Bash-It in `.bashrc` or `.bash_profile` to override defaults.
If [unset or null][1], the original hard-coded defaults are still used.

[1]: http://stackoverflow.com/a/16753536/645491