### PR TITLE
Adding support for git user & git pair in git prompt (off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,11 @@ also, with this flag to false, Bash-it will not show the repository as dirty whe
 
 #### Git user
 
-In some environments it is useful to know the value of the currently-set git user, which is used to mark all new commits. For example, any organization that uses the practice of pair programming will typically author each commit with a [combined name of two authors](https://github.com/pivotal/git_scripts). When another pair uses the same pairing station, the authors must be changed.
+In some environments it is useful to know the value of the current git user, which is used to mark all new commits. For example, any organization that uses the practice of pair programming will typically author each commit with a [combined names of the two authors](https://github.com/pivotal/git_scripts). When another pair uses the same pairing station, the authors are changed at the beginning of the session.
 
-To enable display of the current pair in the prompt, you can set `SCM_GIT_SHOW_CURRENT_USER` to `true`. Once set, the `SCM_CURRENT_USER` variable will be automatically set to the initials of the git author(s). It will also be included in the default git prompt.
+To get up and running with this technique, run `gem install pivotal_git_scripts`, and then edit your `~/.pairs` file, according to the specification on the [gem's homepage](https://github.com/pivotal/git_scripts) After that you should be able to run `git pair kg as` to set the author to, eg. "Konstantin Gredeskoul and Alex Saxby", assuming they've been added to the `~/.pairs` file. Please see gem's documentation for more information.
+
+To enable the display of the current pair in the prompt, you must set `SCM_GIT_SHOW_CURRENT_USER` to `true`. Once set, the `SCM_CURRENT_USER` variable will be automatically populated with the initials of the git author(s). It will also be included in the default git prompt. Even if you do not have `git pair` installed, as long as your `user.name` is set, your initials will be computed from your name, and shown in the prompt.
 
 You can control the prefix and the suffix of this component using the two variables:
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ also, with this flag to false, Bash-it will not show the repository as dirty whe
 
 **NOTE:** If you set in git configuration file the option to ignore *untracked* files, this flag has no effect, and Bash-it will ignore *untracked* files always.
 
+#### Git user
+
+In some environments it is useful to know the value of the currently-set git user, which is used to mark all new commits. For example, any organization that uses the practice of pair programming will typically author each commit with a [combined name of two authors](https://github.com/pivotal/git_scripts). When another pair uses the same pairing station, the authors must be changed.
+
+To enable display of the current pair in the prompt, you can set `SCM_GIT_SHOW_CURRENT_USER` to `true`. Once set, the `SCM_CURRENT_USER` variable will be automatically set to the initials of the git author(s). It will also be included in the default git prompt.
+
+You can control the prefix and the suffix of this component using the two variables:
+
+* `export SCM_THEME_CURRENT_USER_PREFFIX=' ☺︎ '`
+
+And
+
+* `export SCM_THEME_CURRENT_USER_SUFFIX=' '``
+
 #### Ignore repo status
 
 When working in repos with a large code base Bash-it can slow down your prompt when checking the repo status, to avoid it, there is an option you can set via Git config to disable checking repo status in Bash-it.
@@ -184,7 +198,7 @@ $ git config --global --add bash-it.hide-status 1
 
 setting this flag globally has the same effect that `SCM_CHECK=true` but only for Git repos.
 
-### pass function renamed to passgen
+### Pass function renamed to passgen
 
 The Bash-it `pass` function has been renamed to `passgen` in order to avoid a naming conflict with the [pass password manager]. In order to minimize the impact on users of the legacy Bash-it `pass` function, Bash-it will create the alias `pass` that calls the new `passgen` function if the `pass` password manager command is not found on the `PATH` (default behavior).
 

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -147,11 +147,7 @@ function git_prompt_vars {
     fi
   fi
 
-  if [[ "${SCM_GIT_SHOW_CURRENT_USER}" = "true" ]]; then
-    # support two or more initials, set by 'git pair' plugin
-    SCM_CURRENT_USER=`git config user.initials | sed 's% %+%'`
-    details+="$(git_user_info)"
-  fi
+  [[ "${SCM_GIT_SHOW_CURRENT_USER}" == "true" ]] && details+="$(git_user_info)"
 
   SCM_CHANGE=$(git rev-parse --short HEAD 2>/dev/null)
 
@@ -342,9 +338,11 @@ function python_version_prompt {
 }
 
 function git_user_info {
-  if [[ -n "$SCM_CURRENT_USER" ]]; then
-    echo -e "$SCM_THEME_CURRENT_USER_PREFFIX$SCM_CURRENT_USER$SCM_THEME_CURRENT_USER_SUFFIX"
-  fi
+  # support two or more initials, set by 'git pair' plugin
+  SCM_CURRENT_USER=$(git config user.initials | sed 's% %+%')
+  # if `user.initials` weren't set, attempt to extract initials from `user.name`
+  [[ -z "${SCM_CURRENT_USER}" ]] && SCM_CURRENT_USER=$(printf "%s" $(for word in $(git config user.name | tr 'A-Z' 'a-z'); do printf "%1.1s" $word; done))
+  [[ -n "${SCM_CURRENT_USER}" ]] && printf "%s" "$SCM_THEME_CURRENT_USER_PREFFIX$SCM_CURRENT_USER$SCM_THEME_CURRENT_USER_SUFFIX"
 }
 
 # backwards-compatibility

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -13,6 +13,8 @@ SCM_THEME_TAG_PREFIX='tag:'
 SCM_THEME_DETACHED_PREFIX='detached:'
 SCM_THEME_BRANCH_TRACK_PREFIX=' → '
 SCM_THEME_BRANCH_GONE_PREFIX=' ⇢ '
+SCM_THEME_CURRENT_USER_PREFFIX=' ☺︎ '
+SCM_THEME_CURRENT_USER_SUFFIX=''
 
 CLOCK_CHAR='☆'
 THEME_CLOCK_CHECK=${THEME_CLOCK_CHECK:=true}
@@ -21,6 +23,7 @@ THEME_BATTERY_PERCENTAGE_CHECK=${THEME_BATTERY_PERCENTAGE_CHECK:=true}
 SCM_GIT_SHOW_DETAILS=${SCM_GIT_SHOW_DETAILS:=true}
 SCM_GIT_SHOW_REMOTE_INFO=${SCM_GIT_SHOW_REMOTE_INFO:=auto}
 SCM_GIT_IGNORE_UNTRACKED=${SCM_GIT_IGNORE_UNTRACKED:=false}
+SCM_GIT_SHOW_CURRENT_USER=${SCM_GIT_SHOW_CURRENT_USER:=false}
 
 SCM_GIT='git'
 SCM_GIT_CHAR='±'
@@ -142,6 +145,12 @@ function git_prompt_vars {
       fi
       SCM_STATE=${GIT_THEME_PROMPT_DIRTY:-$SCM_THEME_PROMPT_DIRTY}
     fi
+  fi
+
+  if [[ "${SCM_GIT_SHOW_CURRENT_USER}" = "true" ]]; then
+    # support two or more initials, set by 'git pair' plugin
+    SCM_CURRENT_USER=`git config user.initials | sed 's% %+%'`
+    details+="$(git_user_info)"
   fi
 
   SCM_CHANGE=$(git rev-parse --short HEAD 2>/dev/null)
@@ -332,6 +341,11 @@ function python_version_prompt {
   echo -e "$(virtualenv_prompt)$(condaenv_prompt)$(py_interp_prompt)"
 }
 
+function git_user_info {
+  if [[ -n "$SCM_CURRENT_USER" ]]; then
+    echo -e "$SCM_THEME_CURRENT_USER_PREFFIX$SCM_CURRENT_USER$SCM_THEME_CURRENT_USER_SUFFIX"
+  fi
+}
 
 # backwards-compatibility
 function git_prompt_info {


### PR DESCRIPTION
The reasoning is stated in the README diff below. 

I know several people at Pivotal are customizing their bash_it to include this, but i thought that adding an optional support for this "properly" would be valuable to a quite a few folks.

I chose to name the prefix and suffix with the generic `SCM` because I expect that users of other SCMSs may want to implement their own. At that point the `SCM_GIT_SHOW_CURRENT_USER` switch can also become a more generic `SCM_SHOW_CURRENT_USER`.