### PR TITLE
Faster search, and cleaner completion

### DIFF
--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -65,7 +65,7 @@ _bash-it-comp()
 			COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
 			return 0
 			;;
-    update)
+    update | search)
       return 0
       ;;
 		enable | disable)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -176,12 +176,14 @@ _bash-it-search-component() {
 
   _component=$1
   local func=_bash-it-${_component}
+  local help=$($func)
+
   shift
   declare -a terms=($@)
   declare -a matches=()
   local _grep=$(which egrep || which grep)
   for term in "${terms[@]}"; do
-    local term_match=($($func | ${_grep} -i -- ${term} | cut -d ' ' -f 1  | tr '\n' ' '))
+    local term_match=($(echo "${help}"| ${_grep} -i -- ${term} | cut -d ' ' -f 1  | tr '\n' ' '))
     [[ "${#term_match[@]}" -gt 0 ]] && {
       matches=(${matches[@]} ${term_match[@]})
     }


### PR DESCRIPTION
Tidying up search feature – now searching in constant time, by caching output of each of `bash-it show plugin|aliases|completions` instead of running it for each search term.

Also, ensuring there is no auto-completion after search, eg: `bash-it search[TAB]` stops and shows no options, as there are none – user is supposed to provide search terms there.

Thanks! Hopefully this is it! (LOL, famous last words :)