### PR TITLE
Trying to go back and figure out why tests were breaking on Travis

### DIFF
--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -9,13 +9,14 @@ load ../../lib/helpers
 
 NO_COLOR=true
 
-IS_DARWIN=
-[[ "$(uname -s)" == "Darwin" ]] && IS_DARWIN=true
-
 @test "helpers search aliases" {
-  if [ -z "$IS_DARWIN" ]; then
-     skip 'search test only runs on OSX'
-  fi
   run _bash-it-search-component 'plugins' 'base'
   [[ "${lines[0]}" =~ 'plugins' && "${lines[0]}" =~ 'base' ]]
+}
+
+@test "helpers search all ruby et al" {
+  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails'
+  [[ "${lines[0]}" == 'aliases     : bundler rails' ]]
+  [[ "${lines[1]}" == 'plugins     : chruby chruby-auto ruby' ]]
+  [[ "${lines[2]}" == 'completions : bundler gem rake' ]]
 }

--- a/test/run
+++ b/test/run
@@ -3,4 +3,4 @@ PATH=$PATH:$(pwd)/bats/bin
 set +e
 [[ -z "$(which bats)" ]] && git clone --depth 1 https://github.com/sstephenson/bats.git
 set -e
-exec bats ${CI:+--tap} test/{lib,plugins}
+exec ./bats/bin/bats ${CI:+--tap} ./test/{lib,plugins}

--- a/test/run
+++ b/test/run
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-PATH=$PATH:$(pwd)/bats/bin
-set +e
-[[ -z "$(which bats)" ]] && git clone --depth 1 https://github.com/sstephenson/bats.git
-set -e
-exec ./bats/bin/bats ${CI:+--tap} ./test/{lib,plugins}
+test_directory="$(cd "$(dirname "$0")" && pwd)"
+bats_executable="${test_directory}/../bats/bin/bats"
+
+[ ! -e $bats_executable ] && \
+  git clone --depth 1 https://github.com/sstephenson/bats.git ${test_directory}/../bats
+
+if [ -z "${BASH_IT}" ]; then
+  export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
+fi
+
+exec $bats_executable ${CI:+--tap} ${test_directory}/{lib,plugins}


### PR DESCRIPTION
### Please Do Not Merge Yet.

Creating this PR to benefit from the automatic CI integration and figure out why the tests were failing. 

* Re-enabling failing test on Travis
* Adding a much more full featured test for searching of ruby-related terms (passes locally).
* Adding concrete path to `bats` and `test` to avoid path-munging magic.

