### PR TITLE
Strip out the remotes/ prefix of the branch name

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -159,6 +159,7 @@ function git_prompt_vars {
       [[ "${tracking_info}" =~ .+\[gone\]$ ]] && local branch_gone="true"
       tracking_info=${tracking_info#\#\# ${SCM_BRANCH}...}
       tracking_info=${tracking_info% [*}
+      tracking_info=${tracking_info#remotes/}
       local remote_name=${tracking_info%%/*}
       local remote_branch=${tracking_info#${remote_name}/}
       local remote_info=""


### PR DESCRIPTION
I was seeing `master -> remotes/bash-it/master` at the command prompt. As I understand it, that should have been `master -> bash-it` but the presence of `remotes/` in there was messing this up. This change fixes that by being explicit about stripping it out.