### PR TITLE
Added Autojump plugin

### DIFF
--- a/plugins/available/autojump.plugin.bash
+++ b/plugins/available/autojump.plugin.bash
@@ -1,0 +1,8 @@
+cite about-plugin
+about-plugin 'Autojump configuration, see https://github.com/wting/autojump for more details'
+
+# Only supports the Homebrew variant at the moment.
+# Feel free to provide a PR to support other install locations
+if command -v brew &>/dev/null && [[ -s $(brew --prefix)/etc/profile.d/autojump.sh ]]; then
+  . $(brew --prefix)/etc/profile.d/autojump.sh
+fi


### PR DESCRIPTION
See https://github.com/wting/autojump for more details.

Currently only supports the version installed through Homebrew on OS X.
Please feel free to provide a PR for supporting additional installation
options.