### PR TITLE
Add subl to osx.aliases.bash

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -55,6 +55,7 @@ alias gtl="git tag -l"
 alias gnew="git log HEAD@{1}..HEAD@{0}"
 # Add uncommitted and unstaged changes to the last commit
 alias gcaa="git commit -a --amend -C HEAD"
+alias ggui="git gui"
 
 case $OSTYPE in
   darwin*)

--- a/aliases/available/osx.aliases.bash
+++ b/aliases/available/osx.aliases.bash
@@ -18,6 +18,7 @@ alias textedit='open -a TextEdit'
 alias hex='open -a "Hex Fiend"'
 alias skype='open -a Skype'
 alias mou='open -a Mou'
+alias subl='open -a Sublime\ Text --args'
 
 if [ -s /usr/bin/firefox ] ; then
   unalias firefox


### PR DESCRIPTION
Sublime Text is a popular editor on Mac OS X. It would benefit many people if `subl` is added to `osx.aliases.bash`.