### PR TITLE
Added AC indicator support on OS X

### DIFF
--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -4,20 +4,12 @@ about-plugin 'display info about your battery charge level'
 ac_adapter_connected(){
   if command_exists acpi;
   then
-    acpi -a | grep "on-line"
-    if [[ "$?" -eq 0 ]]; then
-      return 1
-    else
-      return 0
-    fi
+    acpi -a | grep -q "on-line"
+    return $?
   elif command_exists ioreg;
   then
-    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | grep '"ExternalConnected"' | awk -F'=' '{print $2}')
-    if [[ "$IOREG_OUTPUT" == *"Yes"* ]]; then
-      return 0
-    else
-      return 1
-    fi
+    ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = Yes'
+    return $?
   fi
 }
 

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -2,15 +2,23 @@ cite about-plugin
 about-plugin 'display info about your battery charge level'
 
 ac_adapter_connected(){
-    if command_exists acpi;
-    then
-        acpi -a | grep "on-line"
-        if [[ "$?" -eq 0 ]]; then
-           return 1
-        else
-           return 0
-        fi
+  if command_exists acpi;
+  then
+    acpi -a | grep "on-line"
+    if [[ "$?" -eq 0 ]]; then
+      return 1
+    else
+      return 0
     fi
+  elif command_exists ioreg;
+  then
+    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | grep '"ExternalConnected"' | awk -F'=' '{print $2}')
+    if [[ "$IOREG_OUTPUT" == *"Yes"* ]]; then
+      return 0
+    else
+      return 1
+    fi
+  fi
 }
 
 battery_percentage(){

--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -153,7 +153,7 @@ function __powerline_battery_prompt {
     else
       color="${BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR}"
     fi
-    [[ "$(ac_adapter_connected)" ]] && battery_status="${BATTERY_AC_CHAR}${battery_status}"
+    ac_adapter_connected && battery_status="${BATTERY_AC_CHAR} ${battery_status}"
     echo "${battery_status}%|${color}"
   fi
 }

--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -35,7 +35,7 @@ LAST_STATUS_THEME_PROMPT_COLOR=196
 
 CLOCK_THEME_PROMPT_COLOR=240
 
-BATTERY_AC_CHAR="⚡"
+BATTERY_AC_CHAR=${BATTERY_AC_CHAR:="⚡"}
 BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR=70
 BATTERY_STATUS_THEME_PROMPT_LOW_COLOR=208
 BATTERY_STATUS_THEME_PROMPT_CRITICAL_COLOR=160
@@ -153,7 +153,7 @@ function __powerline_battery_prompt {
     else
       color="${BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR}"
     fi
-    ac_adapter_connected && battery_status="${BATTERY_AC_CHAR} ${battery_status}"
+    ac_adapter_connected && battery_status="${BATTERY_AC_CHAR}${battery_status}"
     echo "${battery_status}%|${color}"
   fi
 }


### PR DESCRIPTION
Not sure about the logic for returning 1/0 from the function, though - will have to clarify.

@edubxb - You added the `ac_adapter_connected` function back then. What is the return value of this function? From the code, it looks like this:

* return 1 if the AC adapter is connected
* return 0 if the AC adapter is not connected

Is this correct? I found that in that case, the `[[ $(...)]]` condition in the theme does not seem to work. At least that's what I've seen on OS X.

The below fix makes it work on OS X, but I don't know whether it still works on Linux (or has ever worked)...

Let me know what you think.
