### PR TITLE
Preserve `PROMPT_COMMAND` exportedness for subshells

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -5,7 +5,10 @@ about-plugin 'osx-specific functions'
 if [ $(uname) = "Darwin" ]; then
   if type update_terminal_cwd > /dev/null 2>&1 ; then
     if ! [[ $PROMPT_COMMAND =~ (^|;)update_terminal_cwd($|;) ]] ; then
-      export PROMPT_COMMAND="$PROMPT_COMMAND;update_terminal_cwd"
+      PROMPT_COMMAND="$PROMPT_COMMAND;update_terminal_cwd"
+      declared="$(declare -p PROMPT_COMMAND)"
+      [[ "$declared" =~ \ -[aAilrtu]*x[aAilrtu]*\  ]] 2>/dev/null
+      [[ $? -eq 0 ]] && export PROMPT_COMMAND
     fi
   fi
 fi


### PR DESCRIPTION
This PR fixes issue #708 where themes were sometimes left in a partially broken environment with missing dependencies, causing recurring error messages on every prompt.

On OS X, when a theme is active with a dynamic `PROMPT_COMMAND` which it does not bother to export, and said `PROMPT_COMMAND` is backed by shell functions which are not exported either, and at the same time the theme is not OS-X-aware (with respect to `update_terminal_cwd`), and the user then launches a (non-login) interactive subshell from the OS X Terminal, a `command not found` message appears on every command invocation.

The issue is caused by a regression in PR #514, which injects `update_terminal_cwd` into the prompt in order to support Terminal’s open-tab-in-current-directory feature. As a side effect, this PR also escalates the exportedness of `PROMPT_COMMAND`, no matter if the theme actually chose to export it earlier. At the same time, theme-specific shell functions (which `PROMPT_COMMAND` calls) always remain unexported so the subshell is left with a partially broken environment.

The subshell cannot recover from this situation because unlike in Linux, Bash-it on OS X is not sourced when a non-login subshell launches. This causes the dependencies to remain broken which leads to the error being displayed.

The PR tries to fix this by preserving `PROMPT_COMMAND`’s exportedness. This leaves the choice with the individual theme which is now responsible for exporting either all or nothing of its environment.
