### PR TITLE
update brew completion

### DIFF
--- a/completion/available/brew.completion.bash
+++ b/completion/available/brew.completion.bash
@@ -1,9 +1,5 @@
 if which brew >/dev/null 2>&1; then
-  if [ -f `brew --prefix`/etc/bash_completion ]; then
-    . `brew --prefix`/etc/bash_completion
-  fi
-
-  if [ -f `brew --prefix`/Library/Contributions/brew_bash_completion.sh ]; then
-    . `brew --prefix`/Library/Contributions/brew_bash_completion.sh
+  if [ -f `brew --prefix`/etc/bash_completion.d/brew ]; then
+      . `brew --prefix`/etc/bash_completion.d/brew
   fi
 fi


### PR DESCRIPTION
This PR updates the completion file for Homebrew. 

I discovered that bash-it was not actually providing me with any completion for Homebrew, and I found the location of brew's completion file [here](https://github.com/Homebrew/brew/blob/d7aa0c0335dd67e4151503f3a29d7089c57059c3/etc/bash_completion.d/brew).

If the maintainers would prefer that this change is made with only additions to the file, feel free to let me know!
