### PR TITLE
Silent install - solution to issue #676

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,44 @@
 #!/usr/bin/env bash
+# bash-it installer
+show_usage() {
+  echo -e "\n$0 : Install bash-it"
+  echo -e "Usage:\n$0 [arguments] \n"
+  echo "Arguments:"
+  echo "--help (-h): Display this help message"
+  echo "--silent (-s): Install default settings without prompting for input";
+  echo "--interactive (-i): Interactively choose plugins"
+  exit 0;
+}
+
+echo "Installing bash-it"
+
+for param in "$@"; do
+  shift
+  case "$param" in
+    "--help")        set -- "$@" "-h" ;;
+    "--silent")      set -- "$@" "-s" ;;
+    "--interactive") set -- "$@" "-i" ;;
+    *)               set -- "$@" "$param"
+  esac
+done
+
+OPTIND=1
+while getopts "hsi" opt
+do
+  case "$opt" in
+  "h") show_usage; exit 0 ;;
+  "s") silent=true ;;
+  "i") interactive=true ;;
+  "?") show_usage >&2; exit 1 ;;
+  esac
+done
+shift $(expr $OPTIND - 1)
+
+if [[ $silent ]] && [[ $interactive ]]; then
+  echo "Options --silent and --interactive are mutually exclusive. Please choose one or the other."
+  exit 1;
+fi
+
 BASH_IT="$(cd "$(dirname "$0")" && pwd)"
 
 case $OSTYPE in
@@ -14,8 +54,7 @@ BACKUP_FILE=$CONFIG_FILE.bak
 
 if [ -e "$HOME/$BACKUP_FILE" ]; then
   echo -e "\033[0;33mBackup file already exists. Make sure to backup your .bashrc before running this installation.\033[0m" >&2
-  while true
-  do
+  while ! [ $silent ];  do
     read -e -n 1 -r -p "Would you like to overwrite the existing backup? This will delete your existing backup file ($HOME/$BACKUP_FILE) [y/N] " RESP
     case $RESP in
     [yY])
@@ -32,7 +71,7 @@ if [ -e "$HOME/$BACKUP_FILE" ]; then
   done
 fi
 
-while true
+while ! [ $silent ]
 do
   read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash-it templates at the end? [y/N] " choice
   case $choice in
@@ -57,6 +96,14 @@ do
     ;;
   esac
 done
+
+if [ $silent ]; then
+  # backup/new by default
+  test -w "$HOME/$CONFIG_FILE" &&
+  cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
+  echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
+  sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+fi
 
 echo -e "\033[0;32mCopied the template $CONFIG_FILE into ~/$CONFIG_FILE, edit this file to customize bash-it\033[0m"
 
@@ -98,7 +145,7 @@ function load_some() {
   done
 }
 
-if [[ "$1" == "--interactive" ]]
+if [[ $interactive ]] && ! [[ $silent ]] ;
 then
   for type in "aliases" "plugins" "completion"
   do

--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,6 @@ show_usage() {
   exit 0;
 }
 
-echo "Installing bash-it"
-
 for param in "$@"; do
   shift
   case "$param" in
@@ -35,7 +33,7 @@ done
 shift $(expr $OPTIND - 1)
 
 if [[ $silent ]] && [[ $interactive ]]; then
-  echo "Options --silent and --interactive are mutually exclusive. Please choose one or the other."
+  echo "\033[91mOptions --silent and --interactive are mutually exclusive. Please choose one or the other.\033[m"
   exit 1;
 fi
 
@@ -51,7 +49,7 @@ case $OSTYPE in
 esac
 
 BACKUP_FILE=$CONFIG_FILE.bak
-
+echo "Installing bash-it"
 if [ -e "$HOME/$BACKUP_FILE" ]; then
   echo -e "\033[0;33mBackup file already exists. Make sure to backup your .bashrc before running this installation.\033[0m" >&2
   while ! [ $silent ];  do
@@ -71,8 +69,7 @@ if [ -e "$HOME/$BACKUP_FILE" ]; then
   done
 fi
 
-while ! [ $silent ]
-do
+while ! [ $silent ]; do
   read -e -n 1 -r -p "Would you like to keep your $CONFIG_FILE and append bash-it templates at the end? [y/N] " choice
   case $choice in
   [yY])
@@ -85,10 +82,7 @@ do
     break
     ;;
   [nN]|"")
-    test -w "$HOME/$CONFIG_FILE" &&
-    cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
-    echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
-    sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+    backup_new
     break
     ;;
   *)
@@ -99,13 +93,8 @@ done
 
 if [ $silent ]; then
   # backup/new by default
-  test -w "$HOME/$CONFIG_FILE" &&
-  cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
-  echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
-  sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+  backup_new
 fi
-
-echo -e "\033[0;32mCopied the template $CONFIG_FILE into ~/$CONFIG_FILE, edit this file to customize bash-it\033[0m"
 
 function load_one() {
   file_type=$1
@@ -143,6 +132,14 @@ function load_some() {
       esac
     done
   done
+}
+
+function backup_new() {
+  test -w "$HOME/$CONFIG_FILE" &&
+  cp -aL "$HOME/$CONFIG_FILE" "$HOME/$CONFIG_FILE.bak" &&
+  echo -e "\033[0;32mYour original $CONFIG_FILE has been backed up to $CONFIG_FILE.bak\033[0m"
+  sed "s|{{BASH_IT}}|$BASH_IT|" "$BASH_IT/template/bash_profile.template.bash" > "$HOME/$CONFIG_FILE"
+  echo -e "\033[0;32mCopied the template $CONFIG_FILE into ~/$CONFIG_FILE, edit this file to customize bash-it\033[0m"
 }
 
 if [[ $interactive ]] && ! [[ $silent ]] ;


### PR DESCRIPTION
This pull request satisfies #676 requesting a silent install option without prompts. I have followed requirements provided by @nwinkler in the issue thread.
#### Features:
- [x] Implemented new options system supporting both short and long options
- [x] Added --silent (-s) option for installation without prompting the user
- [x] Re-implemented --interactive (-i) in the new option system
- [x] Overwrite existing backups in --silent (-s) mode
- [x] backup bash profile and create new profile in --silent (-s) mode
- [x] Ignore interactive options when silent is enabled

#### Additional Features:
- [x] Getopts builtin is used for option handling, so unknown opts are rejected
- [x] Added check to mutually exclude --silent (-s) and --interactive (-i)
- [x] Implemented show_usage function and usage message
- [x] Implemented --help (-h) option to display usage