### PR TITLE
Add history cite and about-plugin lines

### DIFF
--- a/plugins/available/history.plugin.bash
+++ b/plugins/available/history.plugin.bash
@@ -1,6 +1,8 @@
+cite about-plugin
+about-plugin 'history manipulation'
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history
-if [ -t 1 ]; 
+if [ -t 1 ]
 then
     bind '"[A":history-search-backward'
     bind '"[B":history-search-forward'


### PR DESCRIPTION
This pull request resolves issue #726. A trailing semi-colon and space have also been removed since 'then' was already on another line.