### PR TITLE
load theme _after_ loading any plugins, etc

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -38,11 +38,14 @@ cite _about _param _example _group _author _version
 source "${BASH_IT}/themes/colors.theme.bash"
 source "${BASH_IT}/themes/base.theme.bash"
 
-# library
+# libraries, but skip appearance (themes) for now
 LIB="${BASH_IT}/lib/*.bash"
+APPEARANCE_LIB="${BASH_IT}/lib/appearance.bash"
 for config_file in $LIB
 do
-  source $config_file
+  if [ $config_file != $APPEARANCE_LIB ]; then
+    source $config_file
+  fi
 done
 
 # Load enabled aliases, completion, plugins
@@ -50,6 +53,9 @@ for file_type in "aliases" "completion" "plugins"
 do
   _load_bash_it_files $file_type
 done
+
+# appearance (themes) now, after all dependencies
+source $APPEARANCE_LIB
 
 # Load custom aliases, completion, plugins
 for file_type in "aliases" "completion" "plugins"


### PR DESCRIPTION
- where we used to load lib/*.bash, skip loading lib/appearance.sh, otherwise it would be first due to alphabetical order

- load lib/appearance.sh after enabled plugins, etc

- this allows themes to assume that certain basics are available, like `command_exists`

- fixes #729