### PR TITLE
Added docker-compose plugin

### DIFF
--- a/aliases/available/docker-compose.aliases.bash
+++ b/aliases/available/docker-compose.aliases.bash
@@ -2,4 +2,5 @@ cite 'about-alias'
 about-alias 'docker-compose abbreviations'
 
 alias dco="docker-compose"
-alias dcofresh="docker-compose stop ; docker-compose rm -f ; docker-compose up -d ; docker-compose logs"
+alias dcofresh="docker-compose-fresh"
+alias dcol="docker-compose logs -f --tail 100"

--- a/plugins/available/docker-compose.plugin.bash
+++ b/plugins/available/docker-compose.plugin.bash
@@ -1,0 +1,20 @@
+cite about-plugin
+about-plugin 'Helper functions for using docker-compose'
+
+function docker-compose-fresh() {
+  about 'Shut down, remove and start again the docker-compose setup, then tail the logs'
+  group 'docker-compose'
+  param '1: name of the docker-compose.yaml file to use (optional). Default: docker-compose.yaml'
+  example 'docker-compose-fresh docker-compose-foo.yaml'
+
+  local DCO_FILE_PARAM=""
+  if [ -n "$1" ]; then
+    echo "Using docker-compose file: $1"
+    DCO_FILE_PARAM="--file $1"
+  fi
+
+  docker-compose $DCO_FILE_PARAM stop
+  docker-compose $DCO_FILE_PARAM rm -f --all
+  docker-compose $DCO_FILE_PARAM up -d
+  docker-compose $DCO_FILE_PARAM logs -f --tail 100
+}


### PR DESCRIPTION
Only function so far: `docker-compose-fresh`, which shuts down a running docker-compose instance, deletes the containers, and starts up fresh instances, then tails the container logs.

Converted this from an alias to a function so that a parameter can be provided for the name of the `docker-compose.yaml` file name.