### PR TITLE
Fix bug: themes break global $PROMPT_COMMAND variable

### DIFF
--- a/themes/axin/axin.theme.bash
+++ b/themes/axin/axin.theme.bash
@@ -35,4 +35,4 @@ function prompt_command() {
   PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]@ \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\[$SCM_THEME_PROMPT_PREFIX\]${white}\t \[$PURPLE\]\$(scm_prompt_info) \n\$ \[$RESET\]"
 }
 
-PROMPT_COMMAND=prompt_command
+safe_append_prompt_command prompt_command

--- a/themes/bakke/bakke.theme.bash
+++ b/themes/bakke/bakke.theme.bash
@@ -19,4 +19,4 @@ function prompt_command() {
     PS1="\n${cyan}\h: ${reset_color} ${yellow}\w ${green}$(scm_prompt_info)\n${reset_color}→ "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -403,3 +403,12 @@ function aws_profile {
     echo -e "default"
   fi
 }
+
+function safe_append_prompt_command {
+    if [[ -n $1 ]] ; then
+        case $PROMPT_COMMAND in
+            *$1*) ;;
+            *) PROMPT_COMMAND="$1;$PROMPT_COMMAND";;
+        esac
+    fi
+}

--- a/themes/binaryanomaly/binaryanomaly.theme.bash
+++ b/themes/binaryanomaly/binaryanomaly.theme.bash
@@ -102,4 +102,4 @@ SCM_GIT_CHAR="${green}±${light_grey}"
 SCM_SVN_CHAR="${bold_cyan}⑆${light_grey}"
 SCM_HG_CHAR="${bold_red}☿${light_grey}"
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/bobby-python/bobby-python.theme.bash
+++ b/themes/bobby-python/bobby-python.theme.bash
@@ -16,4 +16,4 @@ function prompt_command() {
     PS1="\n${yellow}$(python_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/bobby/bobby.theme.bash
+++ b/themes/bobby/bobby.theme.bash
@@ -17,4 +17,4 @@ function prompt_command() {
     PS1="\n$(battery_char) $(clock_char) ${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/brunton/brunton.theme.bash
+++ b/themes/brunton/brunton.theme.bash
@@ -31,4 +31,4 @@ ${white}>${normal} "
 
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/candy/candy.theme.bash
+++ b/themes/candy/candy.theme.bash
@@ -3,4 +3,4 @@ function prompt_command() {
     PS1="${green}\u@\h ${blue}\T ${reset_color}${white}\w${reset_color}$(scm_prompt_info)${blue} →${bold_blue} ${reset_color} ";
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/clean/clean.theme.bash
+++ b/themes/clean/clean.theme.bash
@@ -17,4 +17,4 @@ function prompt_command() {
     RPROMPT='[\t]'
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/cooperkid/cooperkid.theme.bash
+++ b/themes/cooperkid/cooperkid.theme.bash
@@ -36,4 +36,4 @@ function prompt() {
     PS1="\n${user_host}${prompt_symbol}${ruby} ${git_branch} ${return_status}\n${prompt_char}"
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/cupcake/cupcake.theme.bash
+++ b/themes/cupcake/cupcake.theme.bash
@@ -76,4 +76,4 @@ function prompt_command() {
 }
 
 # Runs prompt (this bypasses bash_it $PROMPT setting)
-PROMPT_COMMAND=prompt_command
+safe_append_prompt_command prompt_command

--- a/themes/demula/demula.theme.bash
+++ b/themes/demula/demula.theme.bash
@@ -126,5 +126,5 @@ ${D_INTERMEDIATE_COLOR}$ ${D_DEFAULT_COLOR}"
 }
 
 # Runs prompt (this bypasses bash_it $PROMPT setting)
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt
 

--- a/themes/doubletime/doubletime.theme.bash
+++ b/themes/doubletime/doubletime.theme.bash
@@ -56,7 +56,7 @@ $(doubletime_scm_prompt)$reset_color $ "
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter
 
 git_prompt_status() {
   local git_status_output

--- a/themes/doubletime_multiline/doubletime_multiline.theme.bash
+++ b/themes/doubletime_multiline/doubletime_multiline.theme.bash
@@ -21,4 +21,4 @@ $(doubletime_scm_prompt)$reset_color $ "
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter

--- a/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.bash
+++ b/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.bash
@@ -21,4 +21,4 @@ $(doubletime_scm_prompt)$reset_color $ "
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter

--- a/themes/dulcie/dulcie.theme.bash
+++ b/themes/dulcie/dulcie.theme.bash
@@ -95,4 +95,4 @@ dulcie_prompt() {
   PS1="${PS1}${DULCIE_PROMPTCHAR} "
 }
 
-PROMPT_COMMAND=dulcie_prompt
+safe_append_prompt_command dulcie_prompt

--- a/themes/duru/duru.theme.bash
+++ b/themes/duru/duru.theme.bash
@@ -21,4 +21,4 @@ prompt() {
   PS1="${yellow}# ${reset_color}$(last_two_dirs)$(scm_prompt_info)${reset_color}$(venv)${reset_color} ${cyan}\n> ${reset_color}"
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/emperor/emperor.theme.bash
+++ b/themes/emperor/emperor.theme.bash
@@ -31,4 +31,4 @@ function prompt_command() {
     PS1="\n$(get_hour_color)$(date +%H) ${purple}\h ${reset_color}in ${prompt_color}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/envy/envy.theme.bash
+++ b/themes/envy/envy.theme.bash
@@ -13,4 +13,4 @@ function prompt_command() {
     PS1="\n${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/gallifrey/gallifrey.theme.bash
+++ b/themes/gallifrey/gallifrey.theme.bash
@@ -38,4 +38,4 @@ pure_prompt() {
     esac
 }
 
-PROMPT_COMMAND=pure_prompt;
+safe_append_prompt_command pure_prompt

--- a/themes/hawaii50/hawaii50.theme.bash
+++ b/themes/hawaii50/hawaii50.theme.bash
@@ -197,4 +197,4 @@ function prompt() {
     PS4='+ '
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/iterate/iterate.theme.bash
+++ b/themes/iterate/iterate.theme.bash
@@ -56,4 +56,4 @@ function prompt_command() {
     PS1="${new_PS1}${green}${wrap_char}→${reset_color} "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/luan/luan.theme.bash
+++ b/themes/luan/luan.theme.bash
@@ -26,4 +26,4 @@ function prompt_command() {
       $arrow $prompt"
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/mairan/mairan.theme.bash
+++ b/themes/mairan/mairan.theme.bash
@@ -127,4 +127,4 @@ PS2="└─▪ "
 
 
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/mbriggs/mbriggs.theme.bash
+++ b/themes/mbriggs/mbriggs.theme.bash
@@ -31,4 +31,4 @@ function prompt() {
     PS1="\n${n_commands} ${user_host} ${prompt_symbol} ${ruby} ${open}${current_path}${git_branch}${close}${return_status}\n${prompt_char}"
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/minimal/minimal.theme.bash
+++ b/themes/minimal/minimal.theme.bash
@@ -9,4 +9,4 @@ prompt() {
   PS1="$(scm_prompt_info)${reset_color} ${cyan}\W${reset_color} "
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/modern-t/modern-t.theme.bash
+++ b/themes/modern-t/modern-t.theme.bash
@@ -53,4 +53,4 @@ PS2="└─▪ "
 
 
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/modern/modern.theme.bash
+++ b/themes/modern/modern.theme.bash
@@ -53,4 +53,4 @@ PS2="└─▪ "
 
 
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/morris/morris.theme.bash
+++ b/themes/morris/morris.theme.bash
@@ -25,4 +25,4 @@ SCM_THEME_PROMPT_PREFIX="${green}("
 SCM_THEME_PROMPT_SUFFIX="${green})${reset_color}"
 
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/n0qorg/n0qorg.theme.bash
+++ b/themes/n0qorg/n0qorg.theme.bash
@@ -9,7 +9,7 @@ function prompt_command() {
     PS1="${bold_blue}[$(hostname)]${normal} \w${normal} ${bold_white}[$(git_prompt_info)]${normal}» "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command
 
 ## git-theme
 # feel free to change git chars.

--- a/themes/nwinkler/nwinkler.theme.bash
+++ b/themes/nwinkler/nwinkler.theme.bash
@@ -37,7 +37,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter
 
 SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
 SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"

--- a/themes/nwinkler_random_colors/nwinkler_random_colors.theme.bash
+++ b/themes/nwinkler_random_colors/nwinkler_random_colors.theme.bash
@@ -102,7 +102,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter
 
 SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
 SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"

--- a/themes/pete/pete.theme.bash
+++ b/themes/pete/pete.theme.bash
@@ -10,7 +10,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter
 
 SCM_THEME_PROMPT_DIRTY=" ✗"
 SCM_THEME_PROMPT_CLEAN=" ✓"

--- a/themes/powerline-multiline/powerline-multiline.theme.bash
+++ b/themes/powerline-multiline/powerline-multiline.theme.bash
@@ -240,4 +240,4 @@ function __powerline_prompt_command {
         SEGMENTS_AT_LEFT SEGMENTS_AT_RIGHT
 }
 
-PROMPT_COMMAND=__powerline_prompt_command
+safe_append_prompt_command __powerline_prompt_command

--- a/themes/powerline-naked/powerline-naked.theme.bash
+++ b/themes/powerline-naked/powerline-naked.theme.bash
@@ -106,5 +106,5 @@ function powerline_prompt_command() {
     PS1="${SHELL_PROMPT}${VIRTUALENV_PROMPT}${SCM_PROMPT}${CWD_PROMPT}${LAST_STATUS_PROMPT} "
 }
 
-PROMPT_COMMAND=powerline_prompt_command
+safe_append_prompt_command powerline_prompt_command
 

--- a/themes/powerline-plain/powerline-plain.theme.bash
+++ b/themes/powerline-plain/powerline-plain.theme.bash
@@ -120,5 +120,5 @@ function powerline_prompt_command() {
     PS1="${SHELL_PROMPT}${GEMSET_PROMPT}${VIRTUALENV_PROMPT}${SCM_PROMPT}${CWD_PROMPT}${LAST_STATUS_PROMPT} "
 }
 
-PROMPT_COMMAND=powerline_prompt_command
+safe_append_prompt_command powerline_prompt_command
 

--- a/themes/powerline/powerline.theme.bash
+++ b/themes/powerline/powerline.theme.bash
@@ -129,5 +129,5 @@ function powerline_prompt_command() {
     PS1="${SHELL_PROMPT}${IN_VIM_PROMPT}${VIRTUALENV_PROMPT}${SCM_PROMPT}${CWD_PROMPT}${LAST_STATUS_PROMPT} "
 }
 
-PROMPT_COMMAND=powerline_prompt_command
+safe_append_prompt_command powerline_prompt_command
 

--- a/themes/primer/primer.theme.bash
+++ b/themes/primer/primer.theme.bash
@@ -5,4 +5,4 @@ function prompt_command() {
     PS1="${blue}\T ${reset_color}${white}\w${reset_color}$(scm_prompt_info)${blue} →${bold_blue} ${reset_color} ";
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/pro/pro.theme.bash
+++ b/themes/pro/pro.theme.bash
@@ -19,4 +19,4 @@ function prompt() {
   PS1="\h: \W $(scm_prompt_info)${reset_color} $ "
 }
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/pure/pure.theme.bash
+++ b/themes/pure/pure.theme.bash
@@ -40,4 +40,4 @@ pure_prompt() {
     esac
 }
 
-PROMPT_COMMAND=pure_prompt;
+safe_append_prompt_command pure_prompt

--- a/themes/rainbowbrite/rainbowbrite.theme.bash
+++ b/themes/rainbowbrite/rainbowbrite.theme.bash
@@ -18,7 +18,7 @@ prompt_setter() {
   PS4='+ '
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter
 
 SCM_NONE_CHAR='·'
 SCM_THEME_PROMPT_DIRTY=" ${red}✗"

--- a/themes/rana/rana.theme.bash
+++ b/themes/rana/rana.theme.bash
@@ -211,4 +211,4 @@ ${D_INTERMEDIATE_COLOR}$ ${D_DEFAULT_COLOR}"
 }
 
 # Runs prompt (this bypasses bash_it $PROMPT setting)
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/rjorgenson/rjorgenson.theme.bash
+++ b/themes/rjorgenson/rjorgenson.theme.bash
@@ -97,4 +97,4 @@ PS2="└─$(my_prompt_char)"
 
 
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/roderik/roderik.theme.bash
+++ b/themes/roderik/roderik.theme.bash
@@ -14,4 +14,4 @@ function prompt_command() {
     fi
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/sexy/sexy.theme.bash
+++ b/themes/sexy/sexy.theme.bash
@@ -43,4 +43,4 @@ function prompt_command() {
   PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]at \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on \")\[$PURPLE\]\$(parse_git_branch)\[$WHITE\]\n\$ \[$RESET\]"
 }
 
-PROMPT_COMMAND=prompt_command
+safe_append_prompt_command prompt_command

--- a/themes/simple/simple.theme.bash
+++ b/themes/simple/simple.theme.bash
@@ -22,4 +22,4 @@ SCM_THEME_PROMPT_CLEAN=" ✓"
 SCM_THEME_PROMPT_PREFIX="("
 SCM_THEME_PROMPT_SUFFIX=")"
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/sirup/sirup.theme.bash
+++ b/themes/sirup/sirup.theme.bash
@@ -19,4 +19,4 @@ function prompt_command() {
     PS1="$blue\W/$bold_blue$(rvm_version_prompt)$bold_green$(__git_ps1 " (%s)") ${normal}$ "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/slick/slick.theme.bash
+++ b/themes/slick/slick.theme.bash
@@ -83,4 +83,4 @@ PS2="> "
 
 
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt

--- a/themes/standard/standard.theme.bash
+++ b/themes/standard/standard.theme.bash
@@ -21,4 +21,4 @@ function prompt_command() {
     PROMPT='${green}\u${normal}@${green}\h${normal}:${blue}\w${normal}${red}$(prompt_char)$(git_prompt_info)${normal}\$ '
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/tonka/tonka.theme.bash
+++ b/themes/tonka/tonka.theme.bash
@@ -30,7 +30,7 @@ PS2="$LIGHT_BLUE-$YELLOW-$YELLOW-$NO_COLOUR "
 
 }
 
-PROMPT_COMMAND=prompt_setter
+safe_append_prompt_command prompt_setter
 
 export PS3=">> "
 

--- a/themes/tonotdo/tonotdo.theme.bash
+++ b/themes/tonotdo/tonotdo.theme.bash
@@ -10,4 +10,4 @@ function prompt_command() {
   PS1="${yellow}\u${normal}${cyan}@\h${normal}${purple} ${normal}${green}\w${normal}$(scm_prompt_info)> "
 }
 
-PROMPT_COMMAND=prompt_command
+safe_append_prompt_command prompt_command

--- a/themes/tylenol/tylenol.theme.bash
+++ b/themes/tylenol/tylenol.theme.bash
@@ -17,4 +17,4 @@ function prompt_command() {
     PS1="\n${green}$(virtualenv_prompt)${red}$(ruby_version_prompt) ${reset_color}\h ${orange}in ${reset_color}\w\n${yellow}$(scm_char)$(scm_prompt_info) ${yellow}→${white} "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/zitron/zitron.theme.bash
+++ b/themes/zitron/zitron.theme.bash
@@ -21,4 +21,4 @@ function prompt_command() {
     PS1="${no_color}\u:$(hostname)${normal}:${bold_yellow}\W/${normal} $(git_prompt_info)${reset_color}$ "
 }
 
-PROMPT_COMMAND=prompt_command;
+safe_append_prompt_command prompt_command

--- a/themes/zork/zork.theme.bash
+++ b/themes/zork/zork.theme.bash
@@ -94,4 +94,4 @@ PS2="└─▪ "
 
 
 
-PROMPT_COMMAND=prompt
+safe_append_prompt_command prompt


### PR DESCRIPTION
This PR fixes issue #731 where `$PROMPT_COMMAND` was overwritten in themes, causing plugins not functioning correctly.

I extracted a function called `safe_append_prompt_command` into` base.theme.bash`, which appends the target function if it is not already appended. Then in each theme, added a call to this function.

#### One further concern

Another potential issue worth noting is that, different themes are using different names for the hook function (e.g. `pure_prompt` in theme `pure`, `prompt` in theme `brunton`, while `prompt_command` is most common). My concern is, if the user changes the theme (by modifying the `BASH_IT_THEME` in `.bashrc` and do a `reload` without logging out and in (lets call it "live change"), the old hook function will still exist in the `$PROMPT_COMMAND` variable which might cause unexpected issues. (Though, I'm not sure how many people would do such kind of "live change".)

One solution might be, unify the names of these functions, to a more specific one (say `_theme_prompt_command` to avoid overwriting user defined hooks). And move the calling of the append function into [appearance.bash](https://github.com/Bash-it/bash-it/blob/master/lib/appearance.bash#L21). Thus each theme would only need to define the hook function named `_theme_prompt_command` (if they need) and do not need to worry about how it is appended or set to `$PROMPT_COMMAND`.