### PR TITLE
PROMPT_COMMAND env var should not end in ';'

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -408,6 +408,7 @@ function safe_append_prompt_command {
     if [[ -n $1 ]] ; then
         case $PROMPT_COMMAND in
             *$1*) ;;
+            "") PROMPT_COMMAND="$1";;
             *) PROMPT_COMMAND="$1;$PROMPT_COMMAND";;
         esac
     fi


### PR DESCRIPTION
Calling the `safe_append_prompt_command` function results in the PROMPT_COMMAND environment variable having a `;` suffix. e.g. `COMMAND1;COMMAND2;`

A subsequent append to the environment variable, like in the preexec_install function

```
function preexec_install () {
    ....
    PROMPT_COMMAND="${PROMPT_COMMAND};preexec_invoke_cmd"
    ....
}

```
will result in the variable being set to `COMMAND1;COMMAND2;;preexec_invoke_cmd `. This causes the following error.

```

-bash: PROMPT_COMMAND: line 0: syntax error near unexpected token `;;'
-bash: PROMPT_COMMAND: line 0: `direnv_hook;prompt_command;;preexec_invoke_cmd`
```

This change ensures that the `safe_append_prompt_command ` function does not set the `;` suffix.

This fixes #772. 