### PR TITLE
Check for empty PROMPT_COMMAND before appending preexec_invoke_cmd

### DIFF
--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -122,7 +122,11 @@ function preexec_install () {
     shopt -s extdebug > /dev/null 2>&1
 
     # Finally, install the actual traps.
-    PROMPT_COMMAND="${PROMPT_COMMAND};preexec_invoke_cmd"
+    if [[ ! -z "${PROMPT_COMMAND// }" ]]; then
+      PROMPT_COMMAND="${PROMPT_COMMAND};preexec_invoke_cmd"
+    else
+      PROMPT_COMMAND="preexec_invoke_cmd"
+    fi
     trap 'preexec_invoke_exec' DEBUG
 }
 


### PR DESCRIPTION
Fix for https://github.com/Bash-it/bash-it/issues/767

In iTerm on OSX El Capitan, the `PROMPT_COMMAND` variable can be empty when it is referenced in `preexec_install`. This causes an extra semicolon to appear at the beginning of the `PROMPT_COMMAND` var.

This fix checks for an empty or whitespace only `PROMPT_COMMAND` before appending `preexec_invoke_cmd`