### PR TITLE
Changed the laravel alias a:controller to php artisan make:controller 

### DIFF
--- a/aliases/available/laravel.aliases.bash
+++ b/aliases/available/laravel.aliases.bash
@@ -3,7 +3,7 @@ about-alias 'laravel artisan abbreviations'
 
 # A list of useful laravel aliases
 
-alias laravel='/home/breno/.composer/vendor/bin/laravel'
+alias laravel="/home/${USER}/.composer/vendor/bin/laravel"
 # asset
 alias a:apub='php artisan asset:publish'
 

--- a/aliases/available/laravel.aliases.bash
+++ b/aliases/available/laravel.aliases.bash
@@ -3,6 +3,7 @@ about-alias 'laravel artisan abbreviations'
 
 # A list of useful laravel aliases
 
+alias laravel='/home/breno/.composer/vendor/bin/laravel'
 # asset
 alias a:apub='php artisan asset:publish'
 
@@ -21,7 +22,7 @@ alias a:command='php artisan command:make'
 alias a:confpub='php artisan config:publish'
 
 # controller
-alias a:controller='php artisan controller:make'
+alias a:controller='php artisan make:controller'
 
 # db
 alias a:seed='php artisan db:seed'


### PR DESCRIPTION
Changed the laravel alias a:controller from 'php artisan controller:make' to 'php artisan make:controller'.

Added the laravel alias, so for new projects, can be used "laravel new project"