### PR TITLE
OS X fix for usage function.

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -121,7 +121,7 @@ function usage ()
     param '1: directory name'
     group 'base'
     if [ $(uname) = "Darwin" ]; then
-        if [ -n $1 ]; then
+        if [ -n "$1" ]; then
             du -hd $1
         else
             du -hd 1

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -122,14 +122,14 @@ function usage ()
     group 'base'
     if [ $(uname) = "Darwin" ]; then
         if [ -n "$1" ]; then
-            du -hd $1
+            du -hd 1 "$1"
         else
             du -hd 1
         fi
 
     elif [ $(uname) = "Linux" ]; then
-        if [ -n $1 ]; then
-            du -h --max-depth=1 $1
+        if [ -n "$1" ]; then
+            du -h --max-depth=1 "$1"
         else
             du -h --max-depth=1
         fi


### PR DESCRIPTION
The usage function appears to be broken on OS X. When executing the function without a depth parameter you got the following error:

`>_ usage
du: option requires an argument -- d
usage: du [-H | -L | -P] [-a | -s | -d depth] [-c] [-h | -k | -m | -g] [-x] [-I mask] [file ...]`

The if-statement appears to be executed in reverse. Adding the quotes to the condition fixes this. If this change needs to added to the Linux section of the function please let me know and I'll update the pull request.