### PR TITLE
Fix for bash-it help plugins error (pathmunge group value).

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -434,7 +434,7 @@ if ! type pathmunge > /dev/null 2>&1
 then
   function pathmunge () {
     about 'prevent duplicate directories in you PATH variable'
-    group 'lib helpers'
+    group 'helpers'
     example 'pathmunge /path/to/dir is equivalent to PATH=/path/to/dir:$PATH'
     example 'pathmunge /path/to/dir after is equivalent to PATH=$PATH:/path/to/dir'
 


### PR DESCRIPTION
Running `bash-it help plugins` results in the following error in the output:

```
lib:
cat: /tmp/grouplist.v0W0.lib: No such file or directory

:cat: helpers: No such file or directory
helpers:
```

It appears that the group value for the pathmunge function is set to 'lib helpers' which throws off the parsing logic in the _help-plugins function. Changing the group value for pathmunge to 'helpers' fixes this. 