### PR TITLE
Added empty check for PROMPT_COMMAND in fasd plugin

### DIFF
--- a/plugins/available/fasd.plugin.bash
+++ b/plugins/available/fasd.plugin.bash
@@ -24,6 +24,7 @@ __init_fasd() {
     # add bash hook
     case $PROMPT_COMMAND in
       *_fasd_prompt_func*) ;;
+      "") PROMPT_COMMAND="_fasd_prompt_func";;
       *) PROMPT_COMMAND="_fasd_prompt_func;$PROMPT_COMMAND";;
     esac
     eval "$(fasd --init bash-ccomp bash-ccomp-install)"


### PR DESCRIPTION
This should fix the additional issue found in #775.