### PR TITLE
Use --cleanup on upgrade in Homebrew “bupc” alias

### DIFF
--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -4,7 +4,7 @@ cite 'about-alias'
 about-alias 'homebrew abbreviations'
 
 alias bup='brew update && brew upgrade --all'
-alias bupc='brew update && brew upgrade --all && brew cleanup'
+alias bupc='brew update && brew upgrade --all --cleanup'
 alias bout='brew outdated'
 alias bin='brew install'
 alias brm='brew uninstall'


### PR DESCRIPTION
The “upgrade and clean up” Homebrew alias `bupc` doesn't need to use `&&` chaining to run `brew cleanup` after `brew upgrade --all`; Homebrew's `upgrade` command supports a `--cleanup` option that does just that.

I imagine this will also more gracefully handle situations where Homebrew is able to upgrade some but not all of the outdated packages on the system.