### PR TITLE
Recognize fasd when sourced

### DIFF
--- a/plugins/available/fasd.plugin.bash
+++ b/plugins/available/fasd.plugin.bash
@@ -2,7 +2,7 @@ cite about-plugin
 about-plugin 'initialize fasd (see https://github.com/clvv/fasd)'
 
 __init_fasd() {
-  which fasd &> /dev/null
+  command -v fasd &> /dev/null
   if [ $? -eq 1 ]; then
     echo -e "You must install fasd before you can use this plugin"
     echo -e "See: https://github.com/clvv/fasd"


### PR DESCRIPTION
According to fasd [README](https://github.com/clvv/fasd/blob/master/README.md):
> Optionally, if you can also source fasd if you want fasd to be a shell function instead of an executable.  

fasd can be also used by sourcing it and not only by including it into path. This patch will ensure that fasd will be properly recognized, even when it is sourced and not included in path.