### PR TITLE
Remove `continue` from conditional

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -1,17 +1,16 @@
 # Helper function loading various enable-able files
 function _load_bash_it_files() {
   subdirectory="$1"
-  if [ ! -d "${BASH_IT}/${subdirectory}/enabled" ]
+  if [ -d "${BASH_IT}/${subdirectory}/enabled" ]
   then
-    continue
+    FILES="${BASH_IT}/${subdirectory}/enabled/*.bash"
+    for config_file in $FILES
+    do
+      if [ -e "${config_file}" ]; then
+        source $config_file
+      fi
+    done
   fi
-  FILES="${BASH_IT}/${subdirectory}/enabled/*.bash"
-  for config_file in $FILES
-  do
-    if [ -e "${config_file}" ]; then
-      source $config_file
-    fi
-  done
 }
 
 # Function for reloading aliases


### PR DESCRIPTION
This is an artifact left over from when this function was extracted from
inside a loop https://github.com/Bash-it/bash-it/commit/b524bb604756d33ec330abe5300a7a1a6d3a833b

However, `continue` isn't doing anything when not inside a loop and this
now raises a warning in bash 4.4:

"continue: only meaningful in a `for', `while', or `until' loop"