### PR TITLE
improve plugin for rbenv

### DIFF
--- a/plugins/available/rbenv.plugin.bash
+++ b/plugins/available/rbenv.plugin.bash
@@ -3,7 +3,7 @@
 cite about-plugin
 about-plugin 'load rbenv, if you are using it'
 
-pathmunge $HOME/.rbenv/bin
+pathmunge "$HOME"/.rbenv/bin
 [ -x `which rbenv` ] && eval "$(rbenv init -)"
 
-[ -d $HOME/.rbenv/plugins/ruby-build ] && pathmunge $HOME/.rbenv/plugins/ruby-build/bin
+[ -d "$HOME"/.rbenv/plugins/ruby-build ] && pathmunge "$HOME"/.rbenv/plugins/ruby-build/bin

--- a/plugins/available/rbenv.plugin.bash
+++ b/plugins/available/rbenv.plugin.bash
@@ -3,9 +3,7 @@
 cite about-plugin
 about-plugin 'load rbenv, if you are using it'
 
-pathmunge "${HOME}/.rbenv/bin"
+pathmunge $HOME/.rbenv/bin
+[ -x `which rbenv` ] && eval "$(rbenv init -)"
 
-[[ `which rbenv` ]] && eval "$(rbenv init -)"
-
-# Load the auto-completion script if rbenv was loaded.
-[[ -e ~/.rbenv/completions/rbenv.bash ]] && source ~/.rbenv/completions/rbenv.bash
+[ -d $HOME/.rbenv/plugins/ruby-build ] && pathmunge $HOME/.rbenv/plugins/ruby-build/bin


### PR DESCRIPTION
- Check if `rbenv` exists and is executable.
- Removed auto-completion script loader because `eval "$(rbenv init -)"` automatically does that.
- If [ruby-build](https://github.com/rbenv/ruby-build) (rbenv plugin for `rbenv install` command) is installed as plugin, add it to PATH