### PR TITLE
Fixing bcup alias as per Brew note

### DIFF
--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -3,8 +3,8 @@
 cite 'about-alias'
 about-alias 'homebrew abbreviations'
 
-alias bup='brew update && brew upgrade --all'
-alias bupc='brew update && brew upgrade --all --cleanup'
+alias bup='brew update && brew upgrade '
+alias bupc='brew update && brew upgrade --cleanup'
 alias bout='brew outdated'
 alias bin='brew install'
 alias brm='brew uninstall'

--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -3,7 +3,7 @@
 cite 'about-alias'
 about-alias 'homebrew abbreviations'
 
-alias bup='brew update && brew upgrade '
+alias bup='brew update && brew upgrade'
 alias bupc='brew update && brew upgrade --cleanup'
 alias bout='brew outdated'
 alias bin='brew install'


### PR DESCRIPTION
Recently when you run `bcup` you'll get this nice little warning.

`Warning: We decided to not change the behaviour of `brew upgrade` so
`brew upgrade --all` is equivalent to `brew upgrade` without any other
arguments (so the `--all` is a no-op and can be removed).`

This PR removes `-all` from the bup and bupc aliases.