### PR TITLE
Show git user initials again for bobby

### DIFF
--- a/themes/bobby/bobby.theme.bash
+++ b/themes/bobby/bobby.theme.bash
@@ -14,7 +14,7 @@ RVM_THEME_PROMPT_SUFFIX="|"
 
 function prompt_command() {
     #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(ruby_version_prompt) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
-    PS1="\n$(battery_char) $(clock_char) ${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
+    PS1="\n$(battery_char) $(clock_char) ${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(git_prompt_info) ${green}→${reset_color} "
 }
 
 safe_append_prompt_command prompt_command


### PR DESCRIPTION
* [Changes to the base theme](https://github.com/Bash-it/bash-it/pull/797) resulted in git user initials being omitted from `scm_prompt_info`
* This keeps bobby the same 