### PR TITLE
[install.sh] add flag not to modify exist config file during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ The install script can take the following options:
 
 * `--interactive`: Asks the user which aliases, completions and plugins to enable.
 
+* `--no-modify-config`: Do not modify config file (~/.bash_profile or ~/.bashrc).
+
 When run without the `--interactive` switch, Bash-it only enables a sane default set of functionality to keep your shell clean and to avoid issues with missing dependencies. Feel free to enable the tools you want to use after the installation.
+
+When you run without the `--no-modify-config` switch, Bash-it installation automatically modify your existing config file.
 
 **NOTE**: Keep in mind how Bash load its configuration files, `.bash_profile` for login shells (and in Mac OS X in terminal emulators like [Terminal.app](http://www.apple.com/osx/apps/) or [iTerm2](https://www.iterm2.com/)) and `.bashrc` for interactive shells (default mode in most of the GNU/Linux terminal emulators), to ensure that Bash-it is loaded correctly. A good "practice" is sourcing `.bashrc` into `.bash_profile` to keep things working in all the scenarios, to achieve this, you can add this snippet in your `.bash_profile`:
 


### PR DESCRIPTION
### What is changed
- ask whether you want to modify existing config file (i.e. `.bashrc`) during installation

there is no way to run `install.sh`, keeping config file (i.e. `.bashrc`) unchanged.
therefore, i add this option for interactive mode.
