### PR TITLE
adding new curl alais to show only headers on a GET request

### DIFF
--- a/aliases/available/curl.aliases.bash
+++ b/aliases/available/curl.aliases.bash
@@ -17,6 +17,8 @@ function _set_pkg_aliases()
                 alias clocr='curl -L -C - -O --retry 5'
                 # follow redirects, fetch banner
                 alias clb='curl -L -I'
+		# see only response headers from a get request
+		alias clhead='curl -D - -so /dev/null'
 	fi
 }
 


### PR DESCRIPTION
I find this command extremely helpful in my day-to-day work, much better than using -I for a HEAD request since the site you are looking at might show different headers for GET vs HEAD