### PR TITLE
Fix/history improvement

### DIFF
--- a/lib/history.bash
+++ b/lib/history.bash
@@ -2,10 +2,10 @@
 
 # Bash History Handling
 
-shopt -s histappend                              # append to bash_history if Terminal.app quits
+shopt -s histappend                                      # append to bash_history if Terminal.app quits
 export HISTCONTROL=${HISTCONTROL:-ignorespace:erasedups} # erase duplicates; alternative option: export HISTCONTROL=ignoredups
-export HISTSIZE=${HISTSIZE:-5000}                # resize history size
-export AUTOFEATURE=${AUTOFEATURE:-true autotest} # Cucumber / Autotest integration
+export HISTSIZE=${HISTSIZE:-5000}                        # resize history size
+export AUTOFEATURE=${AUTOFEATURE:-true autotest}         # Cucumber / Autotest integration
 
 function rh {
   history | awk '{a[$2]++}END{for(i in a){print a[i] " " i}}' | sort -rn | head

--- a/lib/history.bash
+++ b/lib/history.bash
@@ -3,7 +3,7 @@
 # Bash History Handling
 
 shopt -s histappend                              # append to bash_history if Terminal.app quits
-export HISTCONTROL=${HISTCONTROL:-erasedups}     # erase duplicates; alternative option: export HISTCONTROL=ignoredups
+export HISTCONTROL=${HISTCONTROL:-ignorespace:erasedups} # erase duplicates; alternative option: export HISTCONTROL=ignoredups
 export HISTSIZE=${HISTSIZE:-5000}                # resize history size
 export AUTOFEATURE=${AUTOFEATURE:-true autotest} # Cucumber / Autotest integration
 


### PR DESCRIPTION
I think this is a very usual habit to start to type a command with a space to not to store in the history file. While this habit common in general, it's good to keep in core. 