### PR TITLE
add fasd alias

### DIFF
--- a/aliases/available/fasd.aliases.bash
+++ b/aliases/available/fasd.aliases.bash
@@ -1,0 +1,10 @@
+cite 'about-alias'
+about-alias 'common fasd abbreviations'
+
+alias a='fasd -a'
+alias s='fasd -si'
+alias d='fasd -d'
+alias f='fasd -f'
+alias sd='fasd -sid'
+alias sf='fasd -sif'
+alias z='fasd_cd -d'


### PR DESCRIPTION
add `fasd` aliases, which is removed in #691.
this alias is same as official fasd alias https://github.com/clvv/fasd#introduction.