### PR TITLE
scp should have completion too

### DIFF
--- a/completion/available/ssh.completion.bash
+++ b/completion/available/ssh.completion.bash
@@ -11,7 +11,7 @@ _sshcomplete() {
       local OPTIONS=" -- ${CURRENT_PROMPT}"
     fi
 
-    
+
     # parse all defined hosts from .ssh/config
     if [ -r "$HOME/.ssh/config" ]; then
         COMPREPLY=($(compgen -W "$(grep ^Host "$HOME/.ssh/config" | awk '{for (i=2; i<=NF; i++) print $i}' )" ${OPTIONS}) )
@@ -28,9 +28,8 @@ _sshcomplete() {
     if [ -r /etc/hosts ]; then
         COMPREPLY=( ${COMPREPLY[@]} $(compgen -W "$( grep -v '^[[:space:]]*$' /etc/hosts | grep -v '^#' | awk '{for (i=2; i<=NF; i++) print $i}' )" ${OPTIONS}) )
     fi
-    
+
     return 0
 }
 
-complete -o default -o nospace -F _sshcomplete ssh
-
+complete -o default -o nospace -F _sshcomplete ssh scp


### PR DESCRIPTION
Hi there, 

I think `scp` should have completion too. Basically it can use same completions with `ssh`
