### PR TITLE
Load bash-completion2 on macOS

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -13,4 +13,9 @@ if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
   if [ -f "$BREW_PREFIX"/etc/bash_completion ]; then
     . "$BREW_PREFIX"/etc/bash_completion
   fi
+
+  # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
+  if [ -f "$BREW_PREFIX"/share/bash-completion/bash_completion ]; then
+    . "$BREW_PREFIX"/share/bash-completion/bash_completion
+  fi
 fi


### PR DESCRIPTION
This is required for projects completion, otherwise you get this error:
```
_init_completion: command not found
```