### PR TITLE
Add other bash completion importation for other distribution

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -7,6 +7,12 @@ if [ -f /etc/bash_completion ]; then
   . /etc/bash_completion
 fi
 
+# Some distribution makes use of a profile.d script to import completion.
+if [ -f /etc/profile.d/bash_completion.sh ]; then
+  . /etc/profile.d/bash_completion.sh
+fi
+
+
 if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
   BREW_PREFIX=$(brew --prefix)
 


### PR DESCRIPTION
Fedora import that script from /etc/bashrc script that can import /etc/profile.d/*.sh

See issue #849