### PR TITLE
Add Makefile completion

### DIFF
--- a/completion/available/makefile.completion.bash
+++ b/completion/available/makefile.completion.bash
@@ -1,0 +1,3 @@
+# Add completion for Makefile
+# see http://stackoverflow.com/a/38415982/1472048
+complete -W "\`grep -oE '^[a-zA-Z0-9_-]+:([^=]|$)' Makefile | sed 's/[^a-zA-Z0-9_-]*$//'\`" make


### PR DESCRIPTION
Sometimes, Makefile won't be completed (as for me on Fedora 25) as soon as bash-it is activated. This completion script can provide a Makefile completion.