### PR TITLE
Add check if user has coreutils installed from Homebrew

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -15,8 +15,6 @@ if [ $(uname) = "Linux" ] || brew ls --versions coreutils > /dev/null
 then
   alias ls="ls --color=auto"
 fi
-
-
 which gshuf &> /dev/null
 if [ $? -eq 0 ]
 then

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -11,10 +11,12 @@ alias l1='ls -1'
 
 alias _="sudo"
 
-if [ $(uname) = "Linux" ]
+if [ $(uname) = "Linux" ] || brew ls --versions coreutils > /dev/null
 then
   alias ls="ls --color=auto"
 fi
+
+
 which gshuf &> /dev/null
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
I noticed that I lose the color in my directory listing when running `ls` after I installed the coreutils.

I couldn't think of a less cumbersome way to do this check to see if the user is *actually* using the `ls` command from coreutils or the one with macOS