### PR TITLE
Upstream grep color

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -4,7 +4,8 @@ about-alias 'general aliases'
 if ls --color -d . &> /dev/null
 then
   alias ls="ls --color=auto"
-else
+elif ls -G -d . &> /dev/null
+then
   alias ls='ls -G'        # Compact view, show colors
 fi
 
@@ -18,8 +19,13 @@ alias l1='ls -1'
 alias _="sudo"
 
 # colored grep
-alias grep='grep --color=auto'
-export GREP_COLOR='1;33'
+# Need to check an existing file for a pattern that will be found to ensure
+# that the check works when on an OS that supports the color option
+if grep --color=auto "a" $BASH_IT/*.md &> /dev/null
+then
+  alias grep='grep --color=auto'
+  export GREP_COLOR='1;33'
+fi
 
 which gshuf &> /dev/null
 if [ $? -eq 0 ]

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -1,9 +1,15 @@
 cite about-alias
 about-alias 'general aliases'
 
+if ls --color -d . &> /dev/null
+then
+  alias ls="ls --color=auto"
+else
+  alias ls='ls -G'        # Compact view, show colors
+fi
+
 # List directory contents
 alias sl=ls
-alias ls='ls -G'        # Compact view, show colors
 alias la='ls -AF'       # Compact view, show hidden
 alias ll='ls -al'
 alias l='ls -a'
@@ -15,10 +21,6 @@ alias _="sudo"
 alias grep='grep --color=auto'
 export GREP_COLOR='1;33'
 
-if [ $(uname) = "Linux" ]
-then
-  alias ls="ls --color=auto"
-fi
 which gshuf &> /dev/null
 if [ $? -eq 0 ]
 then

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -11,6 +11,10 @@ alias l1='ls -1'
 
 alias _="sudo"
 
+# colored grep
+alias grep='grep --color=auto'
+export GREP_COLOR='1;33'
+
 if [ $(uname) = "Linux" ]
 then
   alias ls="ls --color=auto"

--- a/lib/appearance.bash
+++ b/lib/appearance.bash
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-# colored grep
-alias grep='grep --color=auto'
-export GREP_COLOR='1;33'
-
 # colored ls
 export LSCOLORS='Gxfxcxdxdxegedabagacad'
 


### PR DESCRIPTION
Fixing the `ls` and `grep` aliases to be omitted if the `color` options are not available.

Closes #884 #643 #819 #818 