### PR TITLE
Add AIO function to echo scm prompt char and info

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -20,6 +20,8 @@ SCM_THEME_BRANCH_TRACK_PREFIX=' → '
 SCM_THEME_BRANCH_GONE_PREFIX=' ⇢ '
 SCM_THEME_CURRENT_USER_PREFFIX=' ☺︎ '
 SCM_THEME_CURRENT_USER_SUFFIX=''
+SCM_THEME_CHAR_PREFIX=''
+SCM_THEME_CHAR_SUFFIX=''
 
 THEME_BATTERY_PERCENTAGE_CHECK=${THEME_BATTERY_PERCENTAGE_CHECK:=true}
 
@@ -97,7 +99,7 @@ function scm_prompt_info {
 
 function scm_prompt_char_info {
   scm_prompt_char
-  echo -ne "${SCM_CHAR}"
+  echo -ne "${SCM_THEME_CHAR_PREFIX}${SCM_CHAR}${SCM_THEME_CHAR_SUFFIX}"
   scm_prompt_info_common
 }
 
@@ -439,7 +441,7 @@ function hg_prompt_info() {
 
 function scm_char {
   scm_prompt_char
-  echo -e "$SCM_CHAR"
+  echo -e "${SCM_THEME_CHAR_PREFIX}${SCM_CHAR}${SCM_THEME_CHAR_SUFFIX}"
 }
 
 function prompt_char {

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -111,6 +111,30 @@ function scm_prompt_info {
   [[ ${SCM} == ${SCM_SVN} ]] && svn_prompt_info && return
 }
 
+function scm_prompt_char_info {
+  # Determine the scm char and print it
+  scm_prompt_char
+  echo -ne "${SCM_CHAR}"
+
+  SCM_DIRTY=0
+  SCM_STATE=''
+
+  if [[ ${SCM} == ${SCM_GIT} ]]; then
+    if [[ ${SCM_GIT_SHOW_MINIMAL_INFO} == true ]]; then
+      # user requests minimal git status information
+      git_prompt_minimal_info
+    else
+      # more detailed git status
+      git_prompt_info
+    fi
+    return
+  fi
+
+  # TODO: consider adding minimal status information for hg and svn
+  [[ ${SCM} == ${SCM_HG} ]] && hg_prompt_info && return
+  [[ ${SCM} == ${SCM_SVN} ]] && svn_prompt_info && return
+}
+
 function git_prompt_minimal_info {
   local ref
   local status

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -92,30 +92,16 @@ function scm_prompt_vars {
 function scm_prompt_info {
   scm
   scm_prompt_char
-  SCM_DIRTY=0
-  SCM_STATE=''
-
-  if [[ ${SCM} == ${SCM_GIT} ]]; then
-    if [[ ${SCM_GIT_SHOW_MINIMAL_INFO} == true ]]; then
-      # user requests minimal git status information
-      git_prompt_minimal_info
-    else
-      # more detailed git status
-      git_prompt_info
-    fi
-    return
-  fi
-
-  # TODO: consider adding minimal status information for hg and svn
-  [[ ${SCM} == ${SCM_HG} ]] && hg_prompt_info && return
-  [[ ${SCM} == ${SCM_SVN} ]] && svn_prompt_info && return
+  scm_prompt_info_common
 }
 
 function scm_prompt_char_info {
-  # Determine the scm char and print it
   scm_prompt_char
   echo -ne "${SCM_CHAR}"
+  scm_prompt_info_common
+}
 
+function scm_prompt_info_common {
   SCM_DIRTY=0
   SCM_STATE=''
 

--- a/themes/bobby/bobby.theme.bash
+++ b/themes/bobby/bobby.theme.bash
@@ -2,7 +2,7 @@
 
 SCM_THEME_PROMPT_DIRTY=" ${red}✗"
 SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓"
-SCM_THEME_PROMPT_PREFIX=" |"
+SCM_THEME_PROMPT_PREFIX=" ${green}|"
 SCM_THEME_PROMPT_SUFFIX="${green}|"
 
 GIT_THEME_PROMPT_DIRTY=" ${red}✗"
@@ -23,7 +23,7 @@ __bobby_clock() {
 
 function prompt_command() {
     #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(ruby_version_prompt) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
-    PS1="\n$(battery_char) $(__bobby_clock)${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
+    PS1="\n$(battery_char) $(__bobby_clock)${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_prompt_char_info) ${green}→${reset_color} "
 }
 
 THEME_SHOW_CLOCK_CHAR=${THEME_SHOW_CLOCK_CHAR:-"true"}


### PR DESCRIPTION
- Refactor common code into scm_prompt_info_common
- Add AIO function to echo scm prompt char and info.
Invoking the `scm_char` and `scm_prompt_info` functions separately for `PS1`
duplicates calls to the `scm` and `scm_prompt_char` functions to check what
`${SCM}`, if any, we currently reside in. This problem was exacerbated
when working outside of any repo as we had to go through all the
conditionals twice just to determine we're not in any scm repo. Unnecessary
conditionals slows down the prompt so this adds a new function that
streamlines printing out both the scm char and scm prompt info with one
invocation.
- Add prefix and suffix capability to SCM char
- Update bobby theme to use `scm_prompt_char_info`.
The bobby theme now uses `scm_prompt_char_info` to print out the SCM char
and SCM prompt info. This also required fixing the
`SCM_THEME_PROMPT_PREFIX` to match `GIT_THEME_PROMPT_PREFIX`.