### PR TITLE
Remove bcup alias

### DIFF
--- a/aliases/available/homebrew-cask.aliases.bash
+++ b/aliases/available/homebrew-cask.aliases.bash
@@ -3,7 +3,6 @@
 cite 'about-alias'
 about-alias 'homebrew-cask abbreviations'
 
-alias bcup='brew cask update'
 alias bcin='brew cask install'
 alias bcrm='brew cask uninstall'
 alias bczp='brew cask zap'


### PR DESCRIPTION
Remove bcup alias since it's being depreciated by Homebrew:
`Warning: Calling brew cask update is deprecated and will be disabled on 2017-07-01!
Use brew update instead.`