### PR TITLE
Add support for ng (Angular CLI) completion.

### DIFF
--- a/completion/available/ng.completion.bash
+++ b/completion/available/ng.completion.bash
@@ -1,0 +1,3 @@
+
+. <(ng completion --bash)
+


### PR DESCRIPTION
This PR dynamically adds completion support to Bash-It.

It is forward-compatible, meaning that currently Angular CLI 1.0.0.beta.28.3 is the main version.
With 1.0.0.beta.30 onwards, the option --bash is taken effect to produce bash-only syntax.

This works, because beta.28.3 "ignores" --bash.
The output is a clever mix of bash and zsh, which detects the shell and sets up the completion accordingly.

In future, the clever monkey-patching is not included anymore, thanks to --bash, yay!
