### PR TITLE
Fix Sublime Text alias. Solves #889

### DIFF
--- a/aliases/available/osx.aliases.bash
+++ b/aliases/available/osx.aliases.bash
@@ -18,7 +18,7 @@ alias textedit='open -a TextEdit'
 alias hex='open -a "Hex Fiend"'
 alias skype='open -a Skype'
 alias mou='open -a Mou'
-alias subl='open -a Sublime\ Text --args'
+alias subl='open -a Sublime\ Text'
 
 if [ -s /usr/bin/firefox ] ; then
   unalias firefox


### PR DESCRIPTION
Sublime Text was not opening specified file or folder using the alias. Fixed by removing `--args`

Details in  #889 