### PR TITLE
Update osx.plugin.bash

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -4,7 +4,7 @@ about-plugin 'osx-specific functions'
 # OS X: Open new tabs in same directory
 if [ $(uname) = "Darwin" ]; then
   if type update_terminal_cwd > /dev/null 2>&1 ; then
-    if ! [[ $PROMPT_COMMAND =~ (^|;)update_terminal_cwd($|;) ]] ; then
+    if ! [[ $PROMPT_COMMAND =~ (^|;|\s)update_terminal_cwd($|;|\s) ]] ; then
       export PROMPT_COMMAND="$PROMPT_COMMAND;update_terminal_cwd"
     fi
   fi

--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -4,7 +4,7 @@ about-plugin 'osx-specific functions'
 # OS X: Open new tabs in same directory
 if [ $(uname) = "Darwin" ]; then
   if type update_terminal_cwd > /dev/null 2>&1 ; then
-    if ! [[ $PROMPT_COMMAND =~ (^|;|\s)update_terminal_cwd($|;|\s) ]] ; then
+    if ! [[ $PROMPT_COMMAND =~ (^|;| )update_terminal_cwd($|;| ) ]] ; then
       export PROMPT_COMMAND="$PROMPT_COMMAND;update_terminal_cwd"
     fi
   fi


### PR DESCRIPTION
I've updated a little bit the `PROMPT_COMMAND` regex check, as auto jump added spaces between semicolons, so it previously results adding `update_terminal_cwd` one more time:

`PROMPT_COMMAND=prompt_command;update_terminal_cwd ; autojump_add_to_database;update_terminal_cwd`