### PR TITLE
Adding pip3 completion

### DIFF
--- a/completion/available/pip3.completion.bash
+++ b/completion/available/pip3.completion.bash
@@ -1,0 +1,11 @@
+
+# pip bash completion start
+_pip_completion()
+{
+    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   PIP_AUTO_COMPLETE=1 $1 ) )
+}
+complete -o default -F _pip_completion pip3
+# pip bash completion end
+


### PR DESCRIPTION
When you install Python 3 you also get pip3 which doesn't have a completion setup.