### PR TITLE
Alias and complete common misspellings of bash-it

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -71,6 +71,13 @@ fi
 alias md='mkdir -p'
 alias rd='rmdir'
 
+# Common misspellings of bash-it
+alias shit='bash-it'
+alias batshit='bash-it'
+alias bashit='bash-it'
+alias bash_it='bash-it'
+alias bash_ti='bash-it'
+
 # Display whatever file is regular file or folder
 catt() {
   for i in "$@"; do

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -110,4 +110,10 @@ _bash-it-comp()
 	return 0
 }
 
+# Activate completion for bash-it and its common misspellings
 complete -F _bash-it-comp bash-it
+complete -F _bash-it-comp bash-ti
+complete -F _bash-it-comp shit
+complete -F _bash-it-comp bashit
+complete -F _bash-it-comp batshit
+complete -F _bash-it-comp bash_it


### PR DESCRIPTION
Title and diff should be self-explanatory.