### PR TITLE
Python errors handling in 'pyedit' command

### DIFF
--- a/plugins/available/python.plugin.bash
+++ b/plugins/available/python.plugin.bash
@@ -14,7 +14,7 @@ function pyedit() {
     example '$ pyedit requests'
     group 'python'
 
-    xpyc=`python -c "import sys; stdout = sys.stdout; sys.stdout = sys.stderr; import $1; stdout.write($1.__file__)"`
+    xpyc=`python -c "import os, sys; f = open(os.devnull, 'w'); sys.stderr = f; module = __import__('$1'); sys.stdout.write(module.__file__)"`
 
     if [ "$xpyc" == "" ]; then
         echo "Python module $1 not found"


### PR DESCRIPTION
Do now show python warnings (import or syntax) if module name is bad.