### PR TITLE
Prevent unbound variable errors in Powerline

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -2,6 +2,7 @@
 THEME_CHECK_SUDO=${THEME_CHECK_SUDO:=true}
 
 function set_color {
+  set +u
   if [[ "${1}" != "-" ]]; then
     fg="38;5;${1}"
   fi
@@ -13,6 +14,7 @@ function set_color {
 }
 
 function __powerline_user_info_prompt {
+  set +u
   local user_info=""
   local color=${USER_INFO_THEME_PROMPT_COLOR}
 
@@ -51,6 +53,7 @@ function __powerline_ruby_prompt {
 }
 
 function __powerline_python_venv_prompt {
+  set +u
   local python_venv=""
 
   if [[ -n "${CONDA_DEFAULT_ENV}" ]]; then


### PR DESCRIPTION
If you're running a script which returns errors for unbound variables and doesn't unset it, powerline will fail to load the prompt as there are some potentially empty variables in those functions.

This PR fixes unbound variables errors you can get if bash got `set -u`.