### PR TITLE
adding ability to set theme as a path to specific file

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,12 @@ Alternately, if you would like to keep your custom scripts under version control
 
 ## Themes
 
-There are a few Bash-it themes. If you've created your own custom prompts, I'd love it if you shared with everyone else! Just submit a Pull Request.
+There are over 50+ Bash-it themes to pick from in `.bash_it/themes`. The default theme is `bobby`.  Set `BASH_IT_THEME` to the theme name you want, or if you've developed your own custom theme outside of `.bash_it/themes` point directly to the theme file.  
 
-You can see the theme screenshots [here](https://github.com/Bash-it/bash-it/wiki/Themes).
+You can easily preview the themes in your own shell using `BASH_PREVIEW=true reload`.
 
-Alternatively, you can preview the themes in your own shell using `BASH_PREVIEW=true reload`.
+If you've created your own custom prompts, I'd love it if you shared with everyone else! Just submit a Pull Request.
+You can see theme screenshots on [wiki/Themes](https://github.com/Bash-it/bash-it/wiki/Themes).
 
 **NOTE**: Bash-it and some themes use UTF-8 characters, so to avoid extrange behaviors in your terminal, set your locale to `LC_ALL=en_US.UTF-8` or the equivalent to your language if isn't American English.
 

--- a/lib/appearance.bash
+++ b/lib/appearance.bash
@@ -9,7 +9,9 @@ fi
 
 # Load the theme
 if [[ $BASH_IT_THEME ]]; then
-    if [[ -f "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash" ]]; then
+    if [[ -f $BASH_IT_THEME ]]; then
+        source $BASH_IT_THEME
+    elif [[ -f "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash" ]]; then
         source "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
     else
         source "$BASH_IT/themes/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"


### PR DESCRIPTION
I wanted to track my custom theme file in a different repo outside of the .bash_it directory.

This tweak here allows you to set the BASH_IT_THEME to point at the specific theme file you want to use without worry of the putting it into the `.bash_it/themes/(name)/(name).theme.bash` scheme.
Example of my .bashrc for setting the theme using this tweak:
```
# Lock and Load a custom theme file
# location /.bash_it/themes/
#export BASH_IT_THEME='modern'
export BASH_IT_THEME="$HOME/.local/bash_it-theme.bash"
```