### PR TITLE
Support short username in xterm title plugin

### DIFF
--- a/plugins/available/xterm.plugin.bash
+++ b/plugins/available/xterm.plugin.bash
@@ -8,11 +8,11 @@ set_xterm_title () {
 
 
 precmd () {
-    set_xterm_title "${USER}@${SHORT_HOSTNAME:-${HOSTNAME}} `dirs -0` $PROMPTCHAR"
+    set_xterm_title "${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}} `dirs -0` $PROMPTCHAR"
 }
 
 preexec () {
-    set_xterm_title "$1 {`dirs -0`} (${USER}@${SHORT_HOSTNAME:-${HOSTNAME}})"
+    set_xterm_title "$1 {`dirs -0`} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
 }
 
 case "$TERM" in

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -31,6 +31,11 @@ export SCM_CHECK=true
 # Will otherwise fall back on $HOSTNAME.
 #export SHORT_HOSTNAME=$(hostname -s)
 
+# Set Xterm/screen/Tmux title with only a short username.
+# Uncomment this (or set SHORT_USER to something else),
+# Will otherwise fall back on $USER.
+#export SHORT_USER=${USER:0:8}
+
 # Set vcprompt executable path for scm advance info in prompt (demula theme)
 # https://github.com/djl/vcprompt
 #export VCPROMPT_EXECUTABLE=~/.vcprompt/bin/vcprompt


### PR DESCRIPTION
This allows users with long usernames (ie full name) to only see a part of it.

I'm open to suggestions about what the default "short username" should should actually _be_. I chose to just truncate at 8 chars, but maybe there's better options. I am also unaware if there's an utility to get a short username automatically (something like `hostname -s` but for users).