### PR TITLE
Support shortened command & dir name in xterm title plugin

### DIFF
--- a/plugins/available/xterm.plugin.bash
+++ b/plugins/available/xterm.plugin.bash
@@ -1,18 +1,28 @@
 cite about-plugin
 about-plugin 'automatically set your xterm title with host and location info'
 
+
+short_dirname () {
+    local dir_name=`dirs -0`
+    [ "$SHORT_TERM_LINE" = true ] && [ ${#dir_name} -gt 8 ] && echo ${dir_name##*/} || echo $dir_name
+}
+
+short_command () {
+  local input_command="$@"
+  [ "$SHORT_TERM_LINE" = true ] && [ ${#input_command} -gt 8 ] && echo ${input_command%% *} || echo $input_command
+}
+
 set_xterm_title () {
     local title="$1"
     echo -ne "\033]0;$title\007"
 }
 
-
 precmd () {
-    set_xterm_title "${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}} `dirs -0` $PROMPTCHAR"
+    set_xterm_title "${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}} `short_dirname` $PROMPTCHAR"
 }
 
 preexec () {
-    set_xterm_title "$1 {`dirs -0`} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
+    set_xterm_title "$(short_command $1) {`short_dirname`} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
 }
 
 case "$TERM" in

--- a/plugins/available/xterm.plugin.bash
+++ b/plugins/available/xterm.plugin.bash
@@ -2,12 +2,12 @@ cite about-plugin
 about-plugin 'automatically set your xterm title with host and location info'
 
 
-short_dirname () {
-    local dir_name=`dirs -0`
-    [ "$SHORT_TERM_LINE" = true ] && [ ${#dir_name} -gt 8 ] && echo ${dir_name##*/} || echo $dir_name
+_short-dirname () {
+  local dir_name=`dirs -0`
+  [ "$SHORT_TERM_LINE" = true ] && [ ${#dir_name} -gt 8 ] && echo ${dir_name##*/} || echo $dir_name
 }
 
-short_command () {
+_short-command () {
   local input_command="$@"
   [ "$SHORT_TERM_LINE" = true ] && [ ${#input_command} -gt 8 ] && echo ${input_command%% *} || echo $input_command
 }
@@ -18,11 +18,11 @@ set_xterm_title () {
 }
 
 precmd () {
-    set_xterm_title "${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}} `short_dirname` $PROMPTCHAR"
+    set_xterm_title "${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}} `_short-dirname` $PROMPTCHAR"
 }
 
 preexec () {
-    set_xterm_title "$(short_command $1) {`short_dirname`} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
+    set_xterm_title "`_short-command $1` {`_short-dirname`} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
 }
 
 case "$TERM" in

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -36,6 +36,10 @@ export SCM_CHECK=true
 # Will otherwise fall back on $USER.
 #export SHORT_USER=${USER:0:8}
 
+# Set Xterm/screen/Tmux title with shortened command and directory.
+# Uncomment this to set.
+#export SHORT_TERM_LINE=true
+
 # Set vcprompt executable path for scm advance info in prompt (demula theme)
 # https://github.com/djl/vcprompt
 #export VCPROMPT_EXECUTABLE=~/.vcprompt/bin/vcprompt


### PR DESCRIPTION
This allows the user to see only last level of the current path (if dirname is longer than 8 chars),
and only first word of the ongoing command line if it's longer than 8 chars.

For example:
```
find / - type f {/var/foo/long} (user@server)
```
will become:
```
find {long} (user@server)
```