### PR TITLE
Make installer more path-with-spaces-proof, fixes #952

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ function load_one() {
 function load_some() {
   file_type=$1
   [ -d "$BASH_IT/$file_type/enabled" ] || mkdir "$BASH_IT/$file_type/enabled"
-  for path in `ls $BASH_IT/${file_type}/available/[^_]*`
+  for path in "$BASH_IT/${file_type}/available/"[^_]*
   do
     file_name=$(basename "$path")
     while true


### PR DESCRIPTION
NOTE: This doesn't make Bash-it usable as there's so many similar errors scattered in other locations, this commit simply makes installer works

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>