### PR TITLE
aliases: git: change 'gw' to 'gwc' to avoid collision with gradle plugin

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -58,7 +58,7 @@ alias gll='git log --graph --pretty=oneline --abbrev-commit'
 alias gg="git log --graph --pretty=format:'%C(bold)%h%Creset%C(magenta)%d%Creset %s %C(yellow)<%an> %C(cyan)(%cr)%Creset' --abbrev-commit --date=relative"
 alias ggs="gg --stat"
 alias gsl="git shortlog -sn"
-alias gw="git whatchanged"
+alias gwc="git whatchanged"
 alias gt="git tag"
 alias gta="git tag -a"
 alias gtd="git tag -d"


### PR DESCRIPTION
 `gw` is currently aliased to `git whatchanged` but that collides  with the gradle  plugin, which defines a `gw` function.

See https://github.com/Bash-it/bash-it/blob/master/plugins/available/gradle.plugin.bash#L4