### PR TITLE
plugins: percol: Unalias zz before defining zz function

### DIFF
--- a/plugins/available/percol.plugin.bash
+++ b/plugins/available/percol.plugin.bash
@@ -35,6 +35,7 @@ if command -v percol>/dev/null; then
         bind -x '"\C-r": _replace_by_history'
 
         # bind zz to percol if fasd enable
+        unalias zz
         if command -v fasd>/dev/null; then
             function zz() {
                 local l=$(fasd -d | awk '{print $2}' | percol)


### PR DESCRIPTION
Percol defines zz alias by default. This ensures that the percol
plugin will work as expected.