### PR TITLE
fix(docker): "bash-it help plugins"

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -381,7 +381,7 @@ _help-plugins()
 
     # display a brief progress message...
     printf '%s' 'please wait, building help...'
-    typeset grouplist=$(mktemp /tmp/grouplist.XXXX)
+    typeset grouplist=$(mktemp /tmp/grouplist.XXXXXX)
     typeset func
     for func in $(typeset_functions)
     do


### PR DESCRIPTION
# Bugfix

This closes Bash-it/bash-it-docker#1

![BoJack](https://media.giphy.com/media/AEsUINFBsRVN6/giphy.gif)