### PR TITLE
Battery upower

### DIFF
--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -2,7 +2,11 @@ cite about-plugin
 about-plugin 'display info about your battery charge level'
 
 ac_adapter_connected(){
-  if command_exists acpi;
+  if command_exists upower;
+  then
+    upower --show-info $(upower --enumerate | grep BAT) | grep --quiet state | grep --quiet charging
+    return $?
+  elif command_exists acpi;
   then
     acpi -a | grep -q "on-line"
     return $?
@@ -18,7 +22,11 @@ ac_adapter_connected(){
 }
 
 ac_adapter_disconnected(){
-  if command_exists acpi;
+  if command_exists upower;
+  then
+    upower --show-info $(upower --enumerate | grep BAT) | grep --quiet state | grep --quiet discharging
+    return $?
+  elif command_exists acpi;
   then
     acpi -a | grep -q "off-line"
     return $?
@@ -37,7 +45,18 @@ battery_percentage(){
   about 'displays battery charge as a percentage of full (100%)'
   group 'battery'
   
-  if command_exists acpi;
+  if command_exists upower;
+  then
+    local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage)
+    case UPOWER_OUTPUT in
+      100*)
+        echo '100'
+      ;;
+      *)
+        echo $UPOWER_OUTPUT | tail --bytes 4 | head --bytes 2
+      ;;
+    esac
+  elif command_exists acpi;
   then
     local ACPI_OUTPUT=$(acpi -b)
     case $ACPI_OUTPUT in

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -47,15 +47,8 @@ battery_percentage(){
   
   if command_exists upower;
   then
-    local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage)
-    case UPOWER_OUTPUT in
-      100*)
-        echo '100'
-      ;;
-      *)
-        echo $UPOWER_OUTPUT | tail --bytes 4 | head --bytes 2
-      ;;
-    esac
+    local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage | tail --bytes 5)
+    echo ${UPOWER_OUTPUT: : -1}
   elif command_exists acpi;
   then
     local ACPI_OUTPUT=$(acpi -b)


### PR DESCRIPTION
`upower` is the new standard for knowing the power status of devices connected to the Linux kernel > v3.x. The `acpi` package is now only an optional package that requires an additional installation. This change-set adds support for `upower` over-riding `acpi` for first preference. However, the `acpi` mechanism has been maintained as a fallback mechanism for legacy systems running the Linux  kernel < v3.

Reading Reference : https://askubuntu.com/questions/69556/how-to-check-battery-status-using-terminal