### PR TITLE
Honor NVM_DIR shell variable set externally

### DIFF
--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -5,7 +5,7 @@
 cite about-plugin
 about-plugin 'node version manager configuration'
 
-[ -v $NVM_DIR ] && NVM_DIR="$HOME/.nvm"
+export NVM_DIR=${NVM_DIR:- $HOME/.nvm}
 # This loads nvm
 if command -v brew &>/dev/null && [ -s $(brew --prefix nvm)/nvm.sh ]
 then

--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -5,7 +5,7 @@
 cite about-plugin
 about-plugin 'node version manager configuration'
 
-export NVM_DIR="$HOME/.nvm"
+[ -v $NVM_DIR ] && NVM_DIR="$HOME/.nvm"
 # This loads nvm
 if command -v brew &>/dev/null && [ -s $(brew --prefix nvm)/nvm.sh ]
 then


### PR DESCRIPTION
Some people (including myself) like building / compiling and binding libraries in custom directories rather than the default (`$HOME`). The `nvm` plugin hard-codes `NVM_DIR` to `$HOME/.nvm`. This change would honor the externally set `NVM_DIR` shell variable and then fall-back to the default `$HOME/.nvm` if the variable isn't set externally.