### PR TITLE
Guard against unset COLUMNS

### DIFF
--- a/themes/iterate/iterate.theme.bash
+++ b/themes/iterate/iterate.theme.bash
@@ -52,7 +52,7 @@ function prompt_command() {
     fi
 
     local wrap_char=""
-    [[ ${#new_PS1} -gt $(($COLUMNS/1)) ]] && wrap_char="\n"
+    [[ $COLUMNS && ${#new_PS1} > $(($COLUMNS/1)) ]] && wrap_char="\n"
     PS1="${new_PS1}${green}${wrap_char}→${reset_color} "
 }
 


### PR DESCRIPTION
When logging in to a new CentOS 7 machine COLUMNS has not been set before the theme is evaluated, causing the following error:
```shell
irongiant-mbp → ssh clayreimann@toren.ddns
Last login: Fri Jun 23 10:05:11 2017 from cpe-24-209-155-17.wi.res.rr.com
-bash: /1: syntax error: operand expected (error token is "/1")
-bash-4.2$ 
```

This fix is based on advice from https://stackoverflow.com/a/3601734