### PR TITLE
general.aliases: Run `which gshuf` in if condition

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -27,8 +27,7 @@ then
   export GREP_COLOR='1;33'
 fi
 
-which gshuf &> /dev/null
-if [ $? -eq 0 ]
+if which gshuf &> /dev/null
 then
   alias shuf=gshuf
 fi


### PR DESCRIPTION
If .bashrc is sourced while `set -e` is set, and `gshuf` is not installed,
then running `which gshuf` will cause the shell to error and exit.
Running `which gshuf` during an if condition will capture the error.