### PR TITLE
fix: missing virtualenv prompt

### DIFF
--- a/themes/bakke/bakke.theme.bash
+++ b/themes/bakke/bakke.theme.bash
@@ -16,7 +16,7 @@ function prompt_command() {
     #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(ruby_version_prompt) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
     #PS1="\n${purple}\h: ${reset_color} ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
     #PS1="\n${cyan}\h: ${reset_color} ${yellow}\w\n${red}$(scm_char)${red}$(scm_prompt_info) ${green}→${reset_color} "
-    PS1="\n${cyan}\h: ${reset_color} ${yellow}\w ${green}$(scm_prompt_info)\n${reset_color}→ "
+    PS1="\n${cyan}\h:$(virtualenv_prompt) ${reset_color} ${yellow}\w ${green}$(scm_prompt_info)\n${reset_color}→ "
 }
 
 safe_append_prompt_command prompt_command


### PR DESCRIPTION
i am using the bakke theme and just noticed that it does not display a potential virtual environment in the prompt. this pull request fixes this issue; it’s just a minimal change.