### PR TITLE
Added aliases for easier systemd use.

### DIFF
--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -1,0 +1,15 @@
+cite 'about-alias'
+about-alias 'systemd service'
+
+case $OSTYPE in
+    linux*)
+	alias sc='systemctl'
+	alias scr='systemctl daemon-reload'
+	alias scu='systemctl --user'
+	alias scur='systemctl --user daemon-reload'
+	alias sce='systemctl stop'
+	alias scue='systemctl --user stop'
+	alias scs='systemctl start'
+	alias scus='systemctl --user start'
+    ;;
+esac


### PR DESCRIPTION
Just a few common used systemd aliases for less typing. 

How I use it: 

'sc' means systemwide systemctrl, 'scu' means systemctrl --user. Stop and start has same beginning letter, so 'e' is used to denote 'end', for example scue means systemctrl --user stop. 