### PR TITLE
skip ruby PATH test if ruby not installed

### DIFF
--- a/test/plugins/ruby.plugin.bats
+++ b/test/plugins/ruby.plugin.bats
@@ -11,6 +11,10 @@ load ../../plugins/available/ruby.plugin
 }
 
 @test "plugins ruby: PATH includes ~/.gem/ruby/bin" {
+  if ! which ruby >/dev/null; then
+    skip 'ruby not installed'
+  fi
+
   last_path_entry=$(echo $PATH | tr ":" "\n" | tail -1);
   [[ "${last_path_entry}" == "${HOME}"/.gem/ruby/*/bin ]]
 }


### PR DESCRIPTION
ruby plugin obviously only adds gem to the PATH if ruby is present