### PR TITLE
#1028 fix

### DIFF
--- a/plugins/available/sshagent.plugin.bash
+++ b/plugins/available/sshagent.plugin.bash
@@ -126,8 +126,8 @@ function sshagent() {
   param '1: on|off '
   example '$ sshagent on'
   group 'ssh'    
-  [[ -v SSH_AGENT_ENV ]] \
-  || export SSH_AGENT_ENV="${HOME}/.ssh/agent_env.${HOSTNAME}"
+  [[ -z "${SSH_AGENT_ENV}" ]] \
+  && export SSH_AGENT_ENV="${HOME}/.ssh/agent_env.${HOSTNAME}"
 
   case "${1}" in
     on) _ensure_valid_sshagent_env;


### PR DESCRIPTION
- '-v' used before is not available until bash 4.x

Signed-off-by: Maxim Kovgan <max@opsguru.io>