### PR TITLE
Recursive load of out of place custom config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ For custom scripts, and aliases, just create the following files (they'll be ign
 
 Anything in the custom directory will be ignored, with the exception of `custom/example.bash`.
 
-Alternately, if you would like to keep your custom scripts under version control, you can set `BASH_IT_CUSTOM` in your `~/.bashrc` to another location outside of the `~/.bash_it` folder.
+Alternately, if you would like to keep your custom scripts under version control, you can set `BASH_IT_CUSTOM` in your `~/.bashrc` to another location outside of the `~/.bash_it` folder. In this case, any `*.bash` file under every directory below `BASH_IT_CUSTOM` folder will be used.
 
 ## Themes
 

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -67,7 +67,7 @@ do
 done
 
 # Custom
-CUSTOM="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/*.bash"
+CUSTOM="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/*.bash ${BASH_IT_CUSTOM:=${BASH_IT}/custom}/**/*.bash"
 for config_file in $CUSTOM
 do
   if [ -e "${config_file}" ]; then


### PR DESCRIPTION
I found the out-of-place folder for custom configuration quite interesting (```BASH_IT_CUSTOM ```), as I would be able to load my current setup maintained in a separated repository. However, I think the current approach that only load ```*.bash``` files directly under the specified folder is too restrictive. With this addition, scripts could be organized in sub-directories.

In order to maintain compatibility with bash before version 4, it just adds an additional file pattern nstead of using ```**/*.bash``` pattern and ```globstar``` bash option.