### PR TITLE
Fix execution of trap DEBUG on subshells

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -91,3 +91,5 @@ if [ -e "$HOME/.jekyllconfig" ]
 then
   . "$HOME/.jekyllconfig"
 fi
+
+set +T

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -92,4 +92,5 @@ then
   . "$HOME/.jekyllconfig"
 fi
 
+# Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
 set +T


### PR DESCRIPTION
Disable trap DEBUG on subshells, this will fix issue where some sub-shell could issue unexpectedly some of the subshell commands.

Example:

    ~ for i in $(ls /tmp | head -2) ; do ssh $i lala; done 
    ssh: Could not resolve hostname \033]0;fri: Temporary failure in name resolution
    ssh: Could not resolve hostname sep: Temporary failure in name resolution
    ssh: connect to host 2017 port 22: Invalid argument
    ssh: Could not resolve hostname 14:51:18: Temporary failure in name resolution
    ssh: Could not resolve hostname +0200: Temporary failure in name resolution
    ssh: Could not resolve hostname for: Temporary failure in name resolution
    ssh: Could not resolve hostname i: Temporary failure in name resolution
    ssh: Could not resolve hostname in: Temporary failure in name resolution
    ssh: Could not resolve hostname $(ls: Temporary failure in name resolution
    ssh: Could not resolve hostname /tmp: Temporary failure in name resolution
    ssh: Could not resolve hostname |: Temporary failure in name resolution
    ssh: Could not resolve hostname head: Temporary failure in name resolution
    unknown option -- )
    usage: ssh [-1246AaCfGgKkMNnqsTtVvXxYy] [-b bind_address] [-c cipher_spec]
               [-D [bind_address:]port] [-E log_file] [-e escape_char]
               [-F configfile] [-I pkcs11] [-i identity_file] [-L address]
               [-l login_name] [-m mac_spec] [-O ctl_cmd] [-o option] [-p port]
               [-Q query_option] [-R address] [-S ctl_path] [-W host:port]
               [-w local_tun[:remote_tun]] [user@]hostname [command]
    ssh: Could not resolve hostname ;: Temporary failure in name resolution

After patch:

     ~ for i in $(ls /tmp | head -2) ; do ssh $i lala; done 
    ssh: Could not resolve hostname ch-6n92k: Temporary failure in name resolution
    ssh: Could not resolve hostname chfailed-z9qbc: Temporary failure in name resolution
     ~ 

