### PR TITLE
export.completion.bash

### DIFF
--- a/completion/available/export.completion.bash
+++ b/completion/available/export.completion.bash
@@ -1,0 +1,1 @@
+complete -W '$(printenv | awk -F= "{print \$1}")' export

--- a/completion/available/export.completion.bash
+++ b/completion/available/export.completion.bash
@@ -1,1 +1,1 @@
-complete -W '$(printenv | awk -F= "{print \$1}")' export
+complete -o nospace -S = -W '$(printenv | awk -F= "{print \$1}")' export


### PR DESCRIPTION
Auto-completion for `export`. Will find already defined environmental variables using `printenv` and provide those for autocompletion.