### PR TITLE
Move enabled components to a global directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ plugins/custom.plugins.bash
 .*.un~
 bats
 .idea
+enabled/*

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,17 +27,19 @@ This order is subject to change.
 
 For `aliases`, `plugins` and `completions`, the following rules are applied that influence the load order:
 
-* Each type has its own `enabled` directory, into which the enabled components are linked into. Enabled plugins are symlinked from `$BASH_IT/plugins/available` to `$BASH_IT/plugins/enabled` for example.
-* Within each of the `enabled` directories, the files are loaded in alphabetical order.
+* There is a global `enabled` directory, which the enabled components are linked into. Enabled plugins are symlinked from `$BASH_IT/plugins/available` to `$BASH_IT/enabled` for example. All component types are linked into the same common `$BASH_IT/enabled` directory.
+* Within the common `enabled` directories, the files are loaded in alphabetical order, which is based on the item's load priority (see next item).
 * When enabling a component, a _load priority_ is assigned to the file. The following default priorities are used:
     * Aliases: 150
     * Plugins: 250
     * Completions: 350
-* When symlinking a component into an `enabled` directory, the load priority is used as a prefix for the linked name, separated with three dashes from the name of the component. The `node.plugin.bash` would be symlinked to `250---node.plugin.bash` for example.
+* When symlinking a component into the `enabled` directory, the load priority is used as a prefix for the linked name, separated with three dashes from the name of the component. The `node.plugin.bash` would be symlinked to `250---node.plugin.bash` for example.
 * Each file can override the default load priority by specifying a new value. To do this, the file needs to include a comment in the following form. This example would cause the `node.plugin.bash` (if included in that file) to be linked to `225---node.plugin.bash`:
 
   ```bash
   # BASH_IT_LOAD_PRIORITY: 225
   ```
+
+Having the order based on a numeric priority in a common directory allows for more flexibility. While in general, aliases are loaded first (since their default priority is 150), it's possible to load some aliases after the plugins, or some plugins after completions by setting the items' load priority. This is more flexible than a fixed type-based order or a strict alphabetical order based on name.
 
 These items are subject to change. When making changes to the internal functionality, this page needs to be updated as well.

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -47,7 +47,6 @@ done
 # TODO Automatically check for content that needs to be migrated
 
 # Load enabled aliases, completion, plugins
-# TODO Add new global directory structure
 for file_type in "aliases" "plugins" "completion"
 do
   _load_bash_it_files $file_type

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -48,6 +48,9 @@ done
 
 # TODO Automatically check for content that needs to be migrated
 
+# Load the global "enabled" directory
+_load_global_bash_it_files
+
 # Load enabled aliases, completion, plugins
 for file_type in "aliases" "plugins" "completion"
 do

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -46,8 +46,6 @@ do
   fi
 done
 
-# TODO Automatically check for content that needs to be migrated
-
 # Load the global "enabled" directory
 _load_global_bash_it_files
 

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -44,7 +44,10 @@ do
   fi
 done
 
+# TODO Automatically check for content that needs to be migrated
+
 # Load enabled aliases, completion, plugins
+# TODO Add new global directory structure
 for file_type in "aliases" "plugins" "completion"
 do
   _load_bash_it_files $file_type

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -91,9 +91,13 @@ fi
 
 # Adding Support for other OSes
 PREVIEW="less"
-[ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview"
-# shellcheck disable=SC2034
-[ -s /Applications/Preview.app ] && PREVIEW="/Applications/Preview.app"
+
+if [ -s /usr/bin/gloobus-preview ]; then
+  PREVIEW="gloobus-preview"
+elif [ -s /Applications/Preview.app ]; then
+  # shellcheck disable=SC2034
+  PREVIEW="/Applications/Preview.app"
+fi
 
 # Load all the Jekyll stuff
 

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -29,6 +29,7 @@ then
 fi
 
 # Load composure first, so we support function metadata
+# shellcheck source=./lib/composure.bash
 source "${BASH_IT}/lib/composure.bash"
 
 # support 'plumbing' metadata
@@ -40,6 +41,7 @@ APPEARANCE_LIB="${BASH_IT}/lib/appearance.bash"
 for config_file in $LIB
 do
   if [ $config_file != $APPEARANCE_LIB ]; then
+    # shellcheck disable=SC1090
     source $config_file
   fi
 done
@@ -53,10 +55,13 @@ do
 done
 
 # Load colors first so they can be used in base theme
+# shellcheck source=./themes/colors.theme.bash
 source "${BASH_IT}/themes/colors.theme.bash"
+# shellcheck source=./themes/base.theme.bash
 source "${BASH_IT}/themes/base.theme.bash"
 
 # appearance (themes) now, after all dependencies
+# shellcheck source=./lib/appearance.bash
 source $APPEARANCE_LIB
 
 # Load custom aliases, completion, plugins
@@ -64,6 +69,7 @@ for file_type in "aliases" "completion" "plugins"
 do
   if [ -e "${BASH_IT}/${file_type}/custom.${file_type}.bash" ]
   then
+    # shellcheck disable=SC1090
     source "${BASH_IT}/${file_type}/custom.${file_type}.bash"
   fi
 done
@@ -73,23 +79,26 @@ CUSTOM="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/*.bash ${BASH_IT_CUSTOM:=${BASH_IT}
 for config_file in $CUSTOM
 do
   if [ -e "${config_file}" ]; then
+    # shellcheck disable=SC1090
     source $config_file
   fi
 done
 
 unset config_file
 if [[ $PROMPT ]]; then
-    export PS1="\["$PROMPT"\]"
+    export PS1="\[""$PROMPT""\]"
 fi
 
 # Adding Support for other OSes
 PREVIEW="less"
 [ -s /usr/bin/gloobus-preview ] && PREVIEW="gloobus-preview"
+# shellcheck disable=SC2034
 [ -s /Applications/Preview.app ] && PREVIEW="/Applications/Preview.app"
 
 # Load all the Jekyll stuff
 
 if [ -e "$HOME/.jekyllconfig" ]
 then
+  # shellcheck disable=SC1090
   . "$HOME/.jekyllconfig"
 fi

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -73,9 +73,14 @@ _bash-it-comp()
       return 0
       ;;
     help)
-      local help_args="plugins aliases completions migrate update"
-      COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
-      return 0
+      if [ x"${prev}" == x"aliases" ]; then
+        _bash-it-comp-list-available aliases
+        return 0
+      else
+        local help_args="plugins aliases completions migrate update"
+        COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
+        return 0
+      fi
       ;;
     update | search | migrate)
       return 0
@@ -103,16 +108,6 @@ _bash-it-comp()
             _bash-it-comp-enable-disable
             return 0
             ;;
-      esac
-      ;;
-    aliases)
-      prevprev="${COMP_WORDS[COMP_CWORD-2]}"
-
-      case "${prevprev}" in
-        help)
-          _bash-it-comp-list-available aliases
-          return 0
-          ;;
       esac
       ;;
   esac

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -31,9 +31,11 @@ _bash-it-comp-list-available-not-enabled()
 _bash-it-comp-list-enabled()
 {
   local subdirectory="$1"
+  local suffix enabled_things
 
-  # TODO Check for global directory as well
-  local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash" | sort`;
+  suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
+
+  enabled_things=$(for f in `sort <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")`;
     do
       basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"
     done)

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -21,7 +21,7 @@ _bash-it-comp-list-available-not-enabled()
 
       if [ -z "$enabled_component" ] && [ -z "$enabled_component_global" ]
       then
-        basename $f | cut -d'.' -f1
+        basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g'
       fi
     done)
 
@@ -37,7 +37,7 @@ _bash-it-comp-list-enabled()
 
   enabled_things=$(for f in `sort <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")`;
     do
-      basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"
+      basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g' | sed -e "s/^[0-9]*---//g"
     done)
 
   COMPREPLY=( $(compgen -W "all ${enabled_things}" -- ${cur}) )
@@ -51,7 +51,7 @@ _bash-it-comp-list-available()
 
   enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
     do
-      basename $f | cut -d'.' -f1
+      basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g'
     done)
 
   COMPREPLY=( $(compgen -W "${enabled_things}" -- ${cur}) )

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -2,112 +2,112 @@
 
 _bash-it-comp-enable-disable()
 {
-	local enable_disable_args="alias plugin completion"
-	COMPREPLY=( $(compgen -W "${enable_disable_args}" -- ${cur}) )
+  local enable_disable_args="alias plugin completion"
+  COMPREPLY=( $(compgen -W "${enable_disable_args}" -- ${cur}) )
 }
 
 _bash-it-comp-list-available-not-enabled()
 {
-	subdirectory="$1"
+  subdirectory="$1"
 
-	local available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
-		do
-			if [ ! -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] && [ ! -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]
-			then
-				basename $f | cut -d'.' -f1
-			fi
-		done)
+  local available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
+    do
+      if [ ! -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] && [ ! -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]
+      then
+        basename $f | cut -d'.' -f1
+      fi
+    done)
 
-	COMPREPLY=( $(compgen -W "all ${available_things}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "all ${available_things}" -- ${cur}) )
 }
 
 _bash-it-comp-list-enabled()
 {
-	subdirectory="$1"
+  subdirectory="$1"
 
-	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash" | sort`;
-		do
-			basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"
-		done)
+  local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash" | sort`;
+    do
+      basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"
+    done)
 
-	COMPREPLY=( $(compgen -W "all ${enabled_things}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "all ${enabled_things}" -- ${cur}) )
 }
 
 _bash-it-comp-list-available()
 {
-	subdirectory="$1"
+  subdirectory="$1"
 
-	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
-		do
-			basename $f | cut -d'.' -f1
-		done)
+  local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
+    do
+      basename $f | cut -d'.' -f1
+    done)
 
-	COMPREPLY=( $(compgen -W "${enabled_things}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "${enabled_things}" -- ${cur}) )
 }
 
 _bash-it-comp()
 {
-	local cur prev opts prevprev
-	COMPREPLY=()
-	cur="${COMP_WORDS[COMP_CWORD]}"
-	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	chose_opt="${COMP_WORDS[1]}"
-	file_type="${COMP_WORDS[2]}"
-	opts="help show enable disable update search migrate"
-	case "${chose_opt}" in
-		show)
-			local show_args="plugins aliases completions"
-			COMPREPLY=( $(compgen -W "${show_args}" -- ${cur}) )
-			return 0
-			;;
-		help)
-			local help_args="plugins aliases completions migrate update"
-			COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
-			return 0
-			;;
+  local cur prev opts prevprev
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  chose_opt="${COMP_WORDS[1]}"
+  file_type="${COMP_WORDS[2]}"
+  opts="help show enable disable update search migrate"
+  case "${chose_opt}" in
+    show)
+      local show_args="plugins aliases completions"
+      COMPREPLY=( $(compgen -W "${show_args}" -- ${cur}) )
+      return 0
+      ;;
+    help)
+      local help_args="plugins aliases completions migrate update"
+      COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
+      return 0
+      ;;
     update | search | migrate)
       return 0
       ;;
-		enable | disable)
-			if [ x"${chose_opt}" == x"enable" ];then
-				suffix="available-not-enabled"
-			else
-				suffix="enabled"
-			fi
-			case "${file_type}" in
-				alias)
-						_bash-it-comp-list-${suffix} aliases
-						return 0
-						;;
-				plugin)
-						_bash-it-comp-list-${suffix} plugins
-						return 0
-						;;
-				completion)
-						_bash-it-comp-list-${suffix} completion
-						return 0
-						;;
-				*)
-						_bash-it-comp-enable-disable
-						return 0
-						;;
-			esac
-			;;
-		aliases)
-			prevprev="${COMP_WORDS[COMP_CWORD-2]}"
+    enable | disable)
+      if [ x"${chose_opt}" == x"enable" ];then
+        suffix="available-not-enabled"
+      else
+        suffix="enabled"
+      fi
+      case "${file_type}" in
+        alias)
+            _bash-it-comp-list-${suffix} aliases
+            return 0
+            ;;
+        plugin)
+            _bash-it-comp-list-${suffix} plugins
+            return 0
+            ;;
+        completion)
+            _bash-it-comp-list-${suffix} completion
+            return 0
+            ;;
+        *)
+            _bash-it-comp-enable-disable
+            return 0
+            ;;
+      esac
+      ;;
+    aliases)
+      prevprev="${COMP_WORDS[COMP_CWORD-2]}"
 
-			case "${prevprev}" in
-				help)
-					_bash-it-comp-list-available aliases
-					return 0
-					;;
-			esac
-			;;
-	esac
+      case "${prevprev}" in
+        help)
+          _bash-it-comp-list-available aliases
+          return 0
+          ;;
+      esac
+      ;;
+  esac
 
-	COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
 
-	return 0
+  return 0
 }
 
 # Activate completion for bash-it and its common misspellings

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -12,10 +12,12 @@ _bash-it-comp-list-available-not-enabled()
 
   local available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
     do
-      # TODO Find a better way to check for these, without using -e + glob
-      if [ ! -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] \
-        && [ ! -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ] \
-        && [ ! -e "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]
+      file_entity=$(basename $f)
+
+      typeset enabled_component=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity,$file_entity} 2>/dev/null | head -1)
+      typeset enabled_component_global=$(command ls "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity 2>/dev/null | head -1)
+
+      if [ -z "$enabled_component" ] && [ -z "$enabled_component_global" ]
       then
         basename $f | cut -d'.' -f1
       fi

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -65,10 +65,10 @@ _bash-it-comp()
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   chose_opt="${COMP_WORDS[1]}"
   file_type="${COMP_WORDS[2]}"
-  opts="help show enable disable update search migrate"
+  opts="disable enable help migrate search show update"
   case "${chose_opt}" in
     show)
-      local show_args="plugins aliases completions"
+      local show_args="aliases completions plugins"
       COMPREPLY=( $(compgen -W "${show_args}" -- ${cur}) )
       return 0
       ;;
@@ -77,7 +77,7 @@ _bash-it-comp()
         _bash-it-comp-list-available aliases
         return 0
       else
-        local help_args="plugins aliases completions migrate update"
+        local help_args="aliases completions migrate plugins update"
         COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
         return 0
       fi

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -59,7 +59,7 @@ _bash-it-comp-list-available()
 
 _bash-it-comp()
 {
-  local cur prev opts prevprev
+  local cur prev opts
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -10,7 +10,9 @@ _bash-it-comp-list-available-not-enabled()
 {
   subdirectory="$1"
 
-  local available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
+  local available_things
+
+  available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
     do
       file_entity=$(basename $f)
 
@@ -28,7 +30,7 @@ _bash-it-comp-list-available-not-enabled()
 
 _bash-it-comp-list-enabled()
 {
-  subdirectory="$1"
+  local subdirectory="$1"
 
   # TODO Check for global directory as well
   local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash" | sort`;
@@ -43,7 +45,9 @@ _bash-it-comp-list-available()
 {
   subdirectory="$1"
 
-  local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
+  local enabled_things
+
+  enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
     do
       basename $f | cut -d'.' -f1
     done)

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -25,7 +25,7 @@ _bash-it-comp-list-enabled()
 {
 	subdirectory="$1"
 
-	local enabled_things=$(for f in `ls -1 "${BASH_IT}/$subdirectory/enabled/"*.bash 2>/dev/null`;
+	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash"`;
 		do
 			basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"
 		done)
@@ -37,7 +37,7 @@ _bash-it-comp-list-available()
 {
 	subdirectory="$1"
 
-	local enabled_things=$(for f in `ls -1 "${BASH_IT}/$subdirectory/available/"*.bash`;
+	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash"`;
 		do
 			basename $f | cut -d'.' -f1
 		done)

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -12,7 +12,10 @@ _bash-it-comp-list-available-not-enabled()
 
   local available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
     do
-      if [ ! -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] && [ ! -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]
+      # TODO Find a better way to check for these, without using -e + glob
+      if [ ! -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] \
+        && [ ! -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ] \
+        && [ ! -e "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]
       then
         basename $f | cut -d'.' -f1
       fi
@@ -25,6 +28,7 @@ _bash-it-comp-list-enabled()
 {
   subdirectory="$1"
 
+  # TODO Check for global directory as well
   local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash" | sort`;
     do
       basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -2,7 +2,7 @@
 
 _bash-it-comp-enable-disable()
 {
-  local enable_disable_args="alias plugin completion"
+  local enable_disable_args="alias completion plugin"
   COMPREPLY=( $(compgen -W "${enable_disable_args}" -- ${cur}) )
 }
 

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -12,7 +12,7 @@ _bash-it-comp-list-available-not-enabled()
 
   local available_things
 
-  available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
+  available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort -d`;
     do
       file_entity=$(basename $f)
 
@@ -35,7 +35,7 @@ _bash-it-comp-list-enabled()
 
   suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
 
-  enabled_things=$(for f in `sort <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")`;
+  enabled_things=$(for f in `sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")`;
     do
       basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g' | sed -e "s/^[0-9]*---//g"
     done)
@@ -49,7 +49,7 @@ _bash-it-comp-list-available()
 
   local enabled_things
 
-  enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
+  enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort -d`;
     do
       basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g'
     done)

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -10,7 +10,7 @@ _bash-it-comp-list-available-not-enabled()
 {
 	subdirectory="$1"
 
-	local available_things=$(for f in `ls -1 "${BASH_IT}/$subdirectory/available/"*.bash 2>/dev/null`;
+	local available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
 		do
 			if [ ! -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] && [ ! -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]
 			then
@@ -25,7 +25,7 @@ _bash-it-comp-list-enabled()
 {
 	subdirectory="$1"
 
-	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash"`;
+	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.bash" | sort`;
 		do
 			basename $f | cut -d'.' -f1 | sed -e "s/^[0-9]*---//g"
 		done)
@@ -37,7 +37,7 @@ _bash-it-comp-list-available()
 {
 	subdirectory="$1"
 
-	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash"`;
+	local enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort`;
 		do
 			basename $f | cut -d'.' -f1
 		done)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -5,6 +5,15 @@ BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN=${BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN:-250
 BASH_IT_LOAD_PRIORITY_DEFAULT_COMPLETION=${BASH_IT_LOAD_PRIORITY_DEFAULT_COMPLETION:-350}
 BASH_IT_LOAD_PRIORITY_SEPARATOR="---"
 
+function _command_exists ()
+{
+  _about 'checks for existence of a command'
+  _param '1: command to check'
+  _example '$ _command_exists ls && echo exists'
+  _group 'lib'
+  type "$1" &> /dev/null ;
+}
+
 # Helper function loading various enable-able files
 function _load_bash_it_files() {
   subdirectory="$1"

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -471,7 +471,7 @@ _help-aliases()
 
 _help-list-aliases ()
 {
-    typeset file=$(basename $1 | sed -e 's/\(.*\)\..*\.bash/\1/g')
+    typeset file=$(basename $1 | sed -e 's/[0-9]*[-]*\(.*\)\..*\.bash/\1/g')
     printf '\n\n%s:\n' "${file%%.*}"
     # metafor() strips trailing quotes, restore them with sed..
     cat $1 | metafor alias | sed "s/$/'/"

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -181,7 +181,7 @@ _bash-it-migrate() {
 
   for file_type in "aliases" "plugins" "completion"
   do
-    for f in `compgen -G "${BASH_IT}/$file_type/enabled/*.bash"`
+    for f in `sort <(compgen -G "${BASH_IT}/$file_type/enabled/*.bash")`
     do
       typeset ff=$(basename $f)
 

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -186,8 +186,6 @@ _bash-it-migrate() {
     do
       typeset ff=$(basename $f)
 
-      # Only process the ones that don't use the new structure
-      if ! [[ $ff =~ ^[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR.*\.bash$ ]] ; then
         # Get the type of component from the extension
         typeset single_type=$(echo $ff | sed -e 's/.*\.\(.*\)\.bash/\1/g' | sed 's/aliases/alias/g')
         typeset component_name=$(echo $ff | cut -d'.' -f1)
@@ -199,7 +197,6 @@ _bash-it-migrate() {
 
         $disable_func $component_name
         $enable_func $component_name
-      fi
     done
     shopt -u nullglob
   done

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -404,7 +404,7 @@ _enable-thing ()
           return
         fi
 
-        typeset enabled_plugin_global=$(command ls "${BASH_IT}/enabled/"[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable 2>/dev/null | head -1)
+        typeset enabled_plugin_global=$(command compgen -G "${BASH_IT}/enabled/[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable" 2>/dev/null | head -1)
         if [ ! -z "$enabled_plugin_global" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -188,7 +188,8 @@ _bash-it-migrate() {
 
       # Get the type of component from the extension
       typeset single_type=$(echo $ff | sed -e 's/.*\.\(.*\)\.bash/\1/g' | sed 's/aliases/alias/g')
-      typeset component_name=$(echo $ff | cut -d'.' -f1)
+      # Cut off the optional "250---" prefix and the suffix
+      typeset component_name=$(echo $ff | sed -e 's/[0-9]*[-]*\(.*\)\..*\.bash/\1/g')
 
       echo "Migrating $single_type $component_name."
 

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -454,11 +454,18 @@ _help-aliases()
         cat "${BASH_IT}/aliases/$alias_path" | metafor alias | sed "s/$/'/"
     else
         typeset f
+        shopt -s nullglob
+
         for f in "${BASH_IT}/aliases/enabled/"*
         do
             _help-list-aliases $f
         done
-        _help-list-aliases "${BASH_IT}/aliases/custom.aliases.bash"
+
+        shopt -u nullglob
+
+        if [ -e "${BASH_IT}/aliases/custom.aliases.bash" ]; then
+          _help-list-aliases "${BASH_IT}/aliases/custom.aliases.bash"
+        fi
     fi
 }
 

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 BASH_IT_LOAD_PRIORITY_DEFAULT_ALIAS=${BASH_IT_LOAD_PRIORITY_DEFAULT_ALIAS:-150}
 BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN=${BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN:-250}
 BASH_IT_LOAD_PRIORITY_DEFAULT_COMPLETION=${BASH_IT_LOAD_PRIORITY_DEFAULT_COMPLETION:-350}
@@ -227,7 +229,11 @@ _bash-it-describe ()
     for f in "${BASH_IT}/$subdirectory/available/"*.bash
     do
         # Check for both the old format without the load priority, and the extended format with the priority
-        if [ -e "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ] || [ -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] || [ -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]; then
+        declare enabled_files enabled_file
+        enabled_file=$(basename $f)
+        enabled_files=$(sort <(compgen -G "${BASH_IT}/enabled/*$BASH_IT_LOAD_PRIORITY_SEPARATOR${enabled_file}") <(compgen -G "${BASH_IT}/$subdirectory/enabled/${enabled_file}") <(compgen -G "${BASH_IT}/$subdirectory/enabled/*$BASH_IT_LOAD_PRIORITY_SEPARATOR${enabled_file}") | wc -l)
+
+        if [ $enabled_files -gt 0 ]; then
             enabled='x'
         else
             enabled=' '

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -282,29 +282,19 @@ _disable-thing ()
     fi
 
     if [ "$file_entity" = "all" ]; then
-        typeset f $file_type
+        typeset f $file_type suffix
+        suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
+
         # Disable everything that's using the old structure
-        for f in "${BASH_IT}/$subdirectory/available/"*.bash
+        for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash"`
         do
-            plugin=$(basename $f)
-            if [ -e "${BASH_IT}/$subdirectory/enabled/$plugin" ]; then
-                rm "${BASH_IT}/$subdirectory/enabled/$(basename $plugin)"
-            fi
-            if [ -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$plugin ]; then
-                rm "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $plugin)
-            fi
+          rm "$f"
         done
 
-        local suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
-
         # Disable everything in the global "enabled" directory
-        for f in "${BASH_IT}/$subdirectory/available/"*.${suffix}.bash
+        for f in `compgen -G "${BASH_IT}/enabled/*.${suffix}.bash"`
         do
-          plugin=$(basename $f)
-
-          if [ -e "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$plugin ]; then
-              rm "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $plugin)
-          fi
+          rm "$f"
         done
     else
         typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash 2>/dev/null | head -1)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -181,8 +181,7 @@ _bash-it-migrate() {
 
   for file_type in "aliases" "plugins" "completion"
   do
-    shopt -s nullglob
-    for f in "${BASH_IT}/$file_type/enabled/"*.bash
+    for f in `compgen -G "${BASH_IT}/$file_type/enabled/*.bash"`
     do
       typeset ff=$(basename $f)
 
@@ -199,7 +198,6 @@ _bash-it-migrate() {
       $disable_func $component_name
       $enable_func $component_name
     done
-    shopt -u nullglob
   done
 }
 

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -16,6 +16,20 @@ function _load_bash_it_files() {
       fi
     done
   fi
+
+  # In the new structure
+  if [ -d "${BASH_IT}/enabled" ]
+  then
+    local suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
+
+    FILES="${BASH_IT}/enabled/*.${suffix}.bash"
+    for config_file in $FILES
+    do
+      if [ -e "${config_file}" ]; then
+        source $config_file
+      fi
+    done
+  fi
 }
 
 # Function for reloading aliases

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -18,21 +18,6 @@ function _load_bash_it_files() {
       fi
     done
   fi
-
-  # In the new structure
-  if [ -d "${BASH_IT}/enabled" ]
-  then
-    declare suffix
-    suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
-
-    FILES="${BASH_IT}/enabled/*.${suffix}.bash"
-    for config_file in $FILES
-    do
-      if [ -e "${config_file}" ]; then
-        source $config_file
-      fi
-    done
-  fi
 }
 
 # Function for reloading aliases

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -223,7 +223,7 @@ _bash-it-describe ()
     for f in "${BASH_IT}/$subdirectory/available/"*.bash
     do
         # Check for both the old format without the load priority, and the extended format with the priority
-        if [ -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] || [ -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]; then
+        if [ -e "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ] || [ -e "${BASH_IT}/$subdirectory/enabled/"$(basename $f) ] || [ -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $f) ]; then
             enabled='x'
         else
             enabled=' '

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -454,14 +454,11 @@ _help-aliases()
         cat "${BASH_IT}/aliases/$alias_path" | metafor alias | sed "s/$/'/"
     else
         typeset f
-        shopt -s nullglob
 
-        for f in "${BASH_IT}/aliases/enabled/"*
+        for f in `sort <(compgen -G "${BASH_IT}/aliases/enabled/*") <(compgen -G "${BASH_IT}/enabled/*.aliases.bash")`
         do
             _help-list-aliases $f
         done
-
-        shopt -u nullglob
 
         if [ -e "${BASH_IT}/aliases/custom.aliases.bash" ]; then
           _help-list-aliases "${BASH_IT}/aliases/custom.aliases.bash"

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -471,7 +471,7 @@ _help-aliases()
 
 _help-list-aliases ()
 {
-    typeset file=$(basename $1)
+    typeset file=$(basename $1 | sed -e 's/\(.*\)\..*\.bash/\1/g')
     printf '\n\n%s:\n' "${file%%.*}"
     # metafor() strips trailing quotes, restore them with sed..
     cat $1 | metafor alias | sed "s/$/'/"

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -187,6 +187,9 @@ _bash-it-migrate() {
   _about 'migrates Bash-it configuration from a previous format to the current one'
   _group 'lib'
 
+  declare migrated_something
+  migrated_something=false
+
   for file_type in "aliases" "plugins" "completion"
   do
     for f in `sort <(compgen -G "${BASH_IT}/$file_type/enabled/*.bash")`
@@ -198,6 +201,8 @@ _bash-it-migrate() {
       # Cut off the optional "250---" prefix and the suffix
       typeset component_name=$(echo $ff | sed -e 's/[0-9]*[-]*\(.*\)\..*\.bash/\1/g')
 
+      migrated_something=true
+
       echo "Migrating $single_type $component_name."
 
       disable_func="_disable-$single_type"
@@ -207,6 +212,11 @@ _bash-it-migrate() {
       $enable_func $component_name
     done
   done
+
+  if [ "$migrated_something" = "true" ]; then
+    echo ""
+    echo "If any migration errors were reported, please try the following: reload && bash-it migrate"
+  fi
 }
 
 _bash-it-describe ()

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -273,6 +273,7 @@ _disable-thing ()
 
     if [ "$file_entity" = "all" ]; then
         typeset f $file_type
+        # Disable everything that's using the old structure
         for f in "${BASH_IT}/$subdirectory/available/"*.bash
         do
             plugin=$(basename $f)
@@ -282,6 +283,18 @@ _disable-thing ()
             if [ -e "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$plugin ]; then
                 rm "${BASH_IT}/$subdirectory/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $plugin)
             fi
+        done
+
+        local suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
+
+        # Disable everything in the global "enabled" directory
+        for f in "${BASH_IT}/$subdirectory/available/"*.${suffix}.bash
+        do
+          plugin=$(basename $f)
+
+          if [ -e "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$plugin ]; then
+              rm "${BASH_IT}/enabled/"*$BASH_IT_LOAD_PRIORITY_SEPARATOR$(basename $plugin)
+          fi
         done
     else
         typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash 2>/dev/null | head -1)
@@ -375,6 +388,12 @@ _enable-thing ()
         to_enable=$(basename $to_enable)
         # Check for existence of the file using a wildcard, since we don't know which priority might have been used when enabling it.
         typeset enabled_plugin=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable,$to_enable} 2>/dev/null | head -1)
+        if [ ! -z "$enabled_plugin" ] ; then
+          printf '%s\n' "$file_entity is already enabled."
+          return
+        fi
+
+        typeset enabled_plugin=$(command ls "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable 2>/dev/null | head -1)
         if [ ! -z "$enabled_plugin" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -284,16 +284,21 @@ _disable-thing ()
             fi
         done
     else
-        # Use a glob to search for both possible patterns
-        # 250---node.plugin.bash
-        # node.plugin.bash
-        # Either one will be matched by this glob
-        typeset plugin=$(command ls $ "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash,$file_entity.*bash} 2>/dev/null | head -1)
-        if [ -z "$plugin" ]; then
-            printf '%s\n' "sorry, $file_entity does not appear to be an enabled $file_type."
-            return
+        typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash 2>/dev/null | head -1)
+        if [ -z "$plugin_global" ]; then
+          # Use a glob to search for both possible patterns
+          # 250---node.plugin.bash
+          # node.plugin.bash
+          # Either one will be matched by this glob
+          typeset plugin=$(command ls $ "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash,$file_entity.*bash} 2>/dev/null | head -1)
+          if [ -z "$plugin" ]; then
+              printf '%s\n' "sorry, $file_entity does not appear to be an enabled $file_type."
+              return
+          fi
+          rm "${BASH_IT}/$subdirectory/enabled/$(basename $plugin)"
+        else
+          rm "${BASH_IT}/enabled/$(basename $plugin_global)"
         fi
-        rm "${BASH_IT}/$subdirectory/enabled/$(basename $plugin)"
     fi
 
     if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then
@@ -375,13 +380,13 @@ _enable-thing ()
           return
         fi
 
-        mkdir -p "${BASH_IT}/$subdirectory/enabled"
+        mkdir -p "${BASH_IT}/enabled"
 
         # Load the priority from the file if it present there
         local local_file_priority=$(grep -E "^# BASH_IT_LOAD_PRIORITY:" "${BASH_IT}/$subdirectory/available/$to_enable" | awk -F': ' '{ print $2 }')
         local use_load_priority=${local_file_priority:-$load_priority}
 
-        ln -s ../available/$to_enable "${BASH_IT}/$subdirectory/enabled/${use_load_priority}${BASH_IT_LOAD_PRIORITY_SEPARATOR}${to_enable}"
+        ln -s ../$subdirectory/available/$to_enable "${BASH_IT}/enabled/${use_load_priority}${BASH_IT_LOAD_PRIORITY_SEPARATOR}${to_enable}"
     fi
 
     if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -471,8 +471,8 @@ _help-aliases()
 
 _help-list-aliases ()
 {
-    typeset file=$(basename $1 | sed -e 's/[0-9]*[-]*\(.*\)\..*\.bash/\1/g')
-    printf '\n\n%s:\n' "${file%%.*}"
+    typeset file=$(basename $1 | sed -e 's/[0-9]*[-]*\(.*\)\.aliases\.bash/\1/g')
+    printf '\n\n%s:\n' "${file}"
     # metafor() strips trailing quotes, restore them with sed..
     cat $1 | metafor alias | sed "s/$/'/"
 }

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -303,10 +303,10 @@ _disable-thing ()
         return
     fi
 
-    if [ "$file_entity" = "all" ]; then
-        typeset f $file_type suffix
-        suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
+    typeset f suffix
+    suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
 
+    if [ "$file_entity" = "all" ]; then
         # Disable everything that's using the old structure
         for f in `compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash"`
         do
@@ -319,13 +319,13 @@ _disable-thing ()
           rm "$f"
         done
     else
-        typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash 2>/dev/null | head -1)
+        typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.$suffix.bash 2>/dev/null | head -1)
         if [ -z "$plugin_global" ]; then
           # Use a glob to search for both possible patterns
           # 250---node.plugin.bash
           # node.plugin.bash
           # Either one will be matched by this glob
-          typeset plugin=$(command ls $ "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.*bash,$file_entity.*bash} 2>/dev/null | head -1)
+          typeset plugin=$(command ls $ "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.$suffix.bash,$file_entity.$suffix.bash} 2>/dev/null | head -1)
           if [ -z "$plugin" ]; then
               printf '%s\n' "sorry, $file_entity does not appear to be an enabled $file_type."
               return

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -398,13 +398,13 @@ _enable-thing ()
 
         to_enable=$(basename $to_enable)
         # Check for existence of the file using a wildcard, since we don't know which priority might have been used when enabling it.
-        typeset enabled_plugin=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable,$to_enable} 2>/dev/null | head -1)
+        typeset enabled_plugin=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable,$to_enable} 2>/dev/null | head -1)
         if [ ! -z "$enabled_plugin" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return
         fi
 
-        typeset enabled_plugin_global=$(command ls "${BASH_IT}/enabled/[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable" 2>/dev/null | head -1)
+        typeset enabled_plugin_global=$(command ls "${BASH_IT}/enabled/"[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable 2>/dev/null | head -1)
         if [ ! -z "$enabled_plugin_global" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -186,17 +186,17 @@ _bash-it-migrate() {
     do
       typeset ff=$(basename $f)
 
-        # Get the type of component from the extension
-        typeset single_type=$(echo $ff | sed -e 's/.*\.\(.*\)\.bash/\1/g' | sed 's/aliases/alias/g')
-        typeset component_name=$(echo $ff | cut -d'.' -f1)
+      # Get the type of component from the extension
+      typeset single_type=$(echo $ff | sed -e 's/.*\.\(.*\)\.bash/\1/g' | sed 's/aliases/alias/g')
+      typeset component_name=$(echo $ff | cut -d'.' -f1)
 
-        echo "Migrating $single_type $component_name."
+      echo "Migrating $single_type $component_name."
 
-        disable_func="_disable-$single_type"
-        enable_func="_enable-$single_type"
+      disable_func="_disable-$single_type"
+      enable_func="_enable-$single_type"
 
-        $disable_func $component_name
-        $enable_func $component_name
+      $disable_func $component_name
+      $enable_func $component_name
     done
     shopt -u nullglob
   done
@@ -404,8 +404,8 @@ _enable-thing ()
           return
         fi
 
-        typeset enabled_plugin=$(command ls "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable 2>/dev/null | head -1)
-        if [ ! -z "$enabled_plugin" ] ; then
+        typeset enabled_plugin_global=$(command ls "${BASH_IT}/enabled/[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable" 2>/dev/null | head -1)
+        if [ ! -z "$enabled_plugin_global" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return
         fi

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -20,6 +20,20 @@ function _load_bash_it_files() {
   fi
 }
 
+function _load_global_bash_it_files() {
+  # In the new structure
+  if [ -d "${BASH_IT}/enabled" ]
+  then
+    FILES="${BASH_IT}/enabled/*.bash"
+    for config_file in $FILES
+    do
+      if [ -e "${config_file}" ]; then
+        source $config_file
+      fi
+    done
+  fi
+}
+
 # Function for reloading aliases
 function reload_aliases() {
   _load_bash_it_files "aliases"

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -2,23 +2,23 @@ cite about-plugin
 about-plugin 'display info about your battery charge level'
 
 ac_adapter_connected(){
-  if command_exists upower;
+  if _command_exists upower;
   then
     upower -i $(upower -e | grep BAT) | grep 'state' | grep -q 'charging\|fully-charged'
     return $?
-  elif command_exists acpi;
+  elif _command_exists acpi;
   then
     acpi -a | grep -q "on-line"
     return $?
-  elif command_exists pmset;
+  elif _command_exists pmset;
   then
     pmset -g batt | grep -q 'AC Power'
     return $?
-  elif command_exists ioreg;
+  elif _command_exists ioreg;
   then
     ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = Yes'
     return $?
-  elif command_exists WMIC;
+  elif _command_exists WMIC;
   then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=2'
     return $?
@@ -26,23 +26,23 @@ ac_adapter_connected(){
 }
 
 ac_adapter_disconnected(){
-  if command_exists upower;
+  if _command_exists upower;
   then
     upower -i $(upower -e | grep BAT) | grep 'state' | grep -q 'discharging'
     return $?
-  elif command_exists acpi;
+  elif _command_exists acpi;
   then
     acpi -a | grep -q "off-line"
     return $?
-  elif command_exists pmset;
+  elif _command_exists pmset;
   then
     pmset -g batt | grep -q 'Battery Power'
     return $?
-  elif command_exists ioreg;
+  elif _command_exists ioreg;
   then
     ioreg -n AppleSmartBattery -r | grep -q '"ExternalConnected" = No'
     return $?
-  elif command_exists WMIC;
+  elif _command_exists WMIC;
   then
     WMIC Path Win32_Battery Get BatteryStatus /Format:List | grep -q 'BatteryStatus=1'
     return $?
@@ -52,12 +52,12 @@ ac_adapter_disconnected(){
 battery_percentage(){
   about 'displays battery charge as a percentage of full (100%)'
   group 'battery'
-  
-  if command_exists upower;
+
+  if _command_exists upower;
   then
     local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage | tail --bytes 5)
     echo ${UPOWER_OUTPUT: : -1}
-  elif command_exists acpi;
+  elif _command_exists acpi;
   then
     local ACPI_OUTPUT=$(acpi -b)
     case $ACPI_OUTPUT in
@@ -72,7 +72,7 @@ battery_percentage(){
           ;;
         esac
       ;;
-      
+
       *" Charging"* | *" Discharging"*)
         local PERC_OUTPUT=$(echo $ACPI_OUTPUT | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
         echo ${PERC_OUTPUT}
@@ -84,7 +84,7 @@ battery_percentage(){
         echo '-1'
       ;;
     esac
-  elif command_exists pmset;
+  elif _command_exists pmset;
   then
     local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p')
     case $PMSET_OUTPUT in
@@ -95,7 +95,7 @@ battery_percentage(){
         echo $PMSET_OUTPUT | head -c 2
       ;;
     esac
-  elif command_exists ioreg;
+  elif _command_exists ioreg;
   then
     local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
     case $IOREG_OUTPUT in
@@ -106,7 +106,7 @@ battery_percentage(){
         echo $IOREG_OUTPUT | head -c 2
       ;;
     esac
-  elif command_exists WMIC;
+  elif _command_exists WMIC;
   then
     local WINPC=$(echo porcent=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List) | grep -o '[0-9]*')
     case $WINPC in
@@ -125,7 +125,7 @@ battery_percentage(){
 battery_charge(){
   about 'graphical display of your battery charge'
   group 'battery'
-  
+
   # Full char
   local F_C='▸'
   # Depleted char
@@ -136,7 +136,7 @@ battery_charge(){
   local DANGER_COLOR="${red}"
   local BATTERY_OUTPUT="${DEPLETED_COLOR}${D_C}${D_C}${D_C}${D_C}${D_C}"
   local BATTERY_PERC=$(battery_percentage)
-  
+
   case $BATTERY_PERC in
     no)
       echo ""

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,13 @@
 ## Testing with [Bats](https://github.com/sstephenson/bats#installing-bats-from-source)
+
+To execute the unit tests, please run the `run` script:
+
+```bash
+# If you are in the `test` directory:
+./run
+
+# If you are in the root `.bash_it` directory:
+test/run
 ```
-bats test/{lib,plugins}
-```
+
+The `run` script will automatically install [Bats](https://github.com/sstephenson/bats#installing-bats-from-source) if it is not already present, and will then run all tests found under the `test` directory, including subdirectories.

--- a/test/bash_it/bash_it.bats
+++ b/test/bash_it/bash_it.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+load ../../lib/composure
+
+function local_setup {
+  mkdir -p "$BASH_IT"
+  lib_directory="$(cd "$(dirname "$0")" && pwd)"
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
+
+  # Don't pollute the user's actual $HOME directory
+  # Use a test home directory instead
+  export BASH_IT_TEST_CURRENT_HOME="${HOME}"
+  export BASH_IT_TEST_HOME="$(cd "${BASH_IT}/.." && pwd)/BASH_IT_TEST_HOME"
+  mkdir -p "${BASH_IT_TEST_HOME}"
+  export HOME="${BASH_IT_TEST_HOME}"
+}
+
+function local_teardown {
+  export HOME="${BASH_IT_TEST_CURRENT_HOME}"
+
+  rm -rf "${BASH_IT_TEST_HOME}"
+
+  assert_equal "${BASH_IT_TEST_CURRENT_HOME}" "${HOME}"
+}
+
+@test "bash-it: load enabled aliases from new structure, priority-based" {
+  mkdir -p $BASH_IT/enabled
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/enabled/150---atom.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---atom.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---base.plugin.bash" ]
+
+  # The `ah` alias should not exist
+  run alias ah &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias ah &> /dev/null
+  assert_success
+}
+
+@test "bash-it: load enabled aliases from old structure, priority-based" {
+  mkdir -p $BASH_IT/aliases/enabled
+  mkdir -p $BASH_IT/plugins/enabled
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/150---atom.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---atom.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/plugins/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---base.plugin.bash" ]
+
+  # The `ah` alias should not exist
+  run alias ah &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias ah &> /dev/null
+  assert_success
+}
+
+@test "bash-it: load enabled aliases from old structure, without priorities" {
+  mkdir -p $BASH_IT/aliases/enabled
+  mkdir -p $BASH_IT/plugins/enabled
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/atom.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/atom.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/plugins/enabled/base.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/base.plugin.bash" ]
+
+  # The `ah` alias should not exist
+  run alias ah &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias ah &> /dev/null
+  assert_success
+}

--- a/test/bash_it/bash_it.bats
+++ b/test/bash_it/bash_it.bats
@@ -15,6 +15,9 @@ function local_setup {
   rm -rf "$BASH_IT"/completion/enabled
   rm -rf "$BASH_IT"/plugins/enabled
 
+  cp -r "$BASH_IT/test/fixtures/bash_it/aliases" "$BASH_IT"
+  cp -r "$BASH_IT/test/fixtures/bash_it/plugins" "$BASH_IT"
+
   # Don't pollute the user's actual $HOME directory
   # Use a test home directory instead
   export BASH_IT_TEST_CURRENT_HOME="${HOME}"
@@ -29,6 +32,109 @@ function local_teardown {
   rm -rf "${BASH_IT_TEST_HOME}"
 
   assert_equal "${BASH_IT_TEST_CURRENT_HOME}" "${HOME}"
+}
+
+@test "bash-it: verify that the test fixture is available" {
+  assert [ -e "$BASH_IT/aliases/available/a.aliases.bash" ]
+  assert [ -e "$BASH_IT/aliases/available/b.aliases.bash" ]
+}
+
+@test "bash-it: load aliases in order" {
+  mkdir -p $BASH_IT/aliases/enabled
+  mkdir -p $BASH_IT/plugins/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/plugins/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/aliases/enabled/150---a.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/aliases/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---b.aliases.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  assert_line "0" "alias test_alias='b'"
+}
+
+@test "bash-it: load aliases in priority order" {
+  mkdir -p $BASH_IT/aliases/enabled
+  mkdir -p $BASH_IT/plugins/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/plugins/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/aliases/enabled/175---a.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/175---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/aliases/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---b.aliases.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  assert_line "0" "alias test_alias='a'"
+}
+
+@test "bash-it: load aliases and plugins in priority order" {
+  mkdir -p $BASH_IT/aliases/enabled
+  mkdir -p $BASH_IT/plugins/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/plugins/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/aliases/enabled/150---a.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/aliases/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---b.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/c.plugin.bash $BASH_IT/plugins/enabled/250---c.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---c.plugin.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  assert_line "0" "alias test_alias='c'"
+}
+
+@test "bash-it: load aliases and plugins in priority order, with one alias higher than plugins" {
+  mkdir -p $BASH_IT/aliases/enabled
+  mkdir -p $BASH_IT/plugins/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/plugins/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/aliases/enabled/350---a.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/350---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/aliases/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---b.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/c.plugin.bash $BASH_IT/plugins/enabled/250---c.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---c.plugin.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  # This will be c, loaded from the c plugin, since the individual directories
+  # are loaded one by one.
+  assert_line "0" "alias test_alias='c'"
 }
 
 @test "bash-it: load enabled aliases from new structure, priority-based" {

--- a/test/bash_it/bash_it.bats
+++ b/test/bash_it/bash_it.bats
@@ -15,8 +15,8 @@ function local_setup {
   rm -rf "$BASH_IT"/completion/enabled
   rm -rf "$BASH_IT"/plugins/enabled
 
-  cp -r "$BASH_IT/test/fixtures/bash_it/aliases" "$BASH_IT"
-  cp -r "$BASH_IT/test/fixtures/bash_it/plugins" "$BASH_IT"
+  # Copy the test fixture to the Bash-it folder
+  rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
 
   # Don't pollute the user's actual $HOME directory
   # Use a test home directory instead
@@ -135,6 +135,100 @@ function local_teardown {
   # This will be c, loaded from the c plugin, since the individual directories
   # are loaded one by one.
   assert_line "0" "alias test_alias='c'"
+}
+
+@test "bash-it: load global aliases in order" {
+  mkdir -p $BASH_IT/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/enabled/150---a.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---b.aliases.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  assert_line "0" "alias test_alias='b'"
+}
+
+@test "bash-it: load global aliases in priority order" {
+  mkdir -p $BASH_IT/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/enabled/175---a.aliases.bash
+  assert [ -L "$BASH_IT/enabled/175---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---b.aliases.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  assert_line "0" "alias test_alias='a'"
+}
+
+@test "bash-it: load global aliases and plugins in priority order" {
+  mkdir -p $BASH_IT/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/enabled/150---a.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---b.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/c.plugin.bash $BASH_IT/enabled/250---c.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---c.plugin.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  assert_line "0" "alias test_alias='c'"
+}
+
+@test "bash-it: load global aliases and plugins in priority order, with one alias higher than plugins" {
+  mkdir -p $BASH_IT/enabled
+
+  ln -s $BASH_IT/plugins/available/base.plugin.bash $BASH_IT/enabled/250---base.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---base.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/a.aliases.bash $BASH_IT/enabled/350---a.aliases.bash
+  assert [ -L "$BASH_IT/enabled/350---a.aliases.bash" ]
+  ln -s $BASH_IT/aliases/available/b.aliases.bash $BASH_IT/enabled/150---b.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---b.aliases.bash" ]
+  ln -s $BASH_IT/plugins/available/c.plugin.bash $BASH_IT/enabled/250---c.plugin.bash
+  assert [ -L "$BASH_IT/enabled/250---c.plugin.bash" ]
+
+  # The `test_alias` alias should not exist
+  run alias test_alias &> /dev/null
+  assert_failure
+
+  load "$BASH_IT/bash_it.sh"
+
+  run alias test_alias &> /dev/null
+  assert_success
+  # This will be a, loaded from the a aliases, since the global directory
+  # loads all component types at once
+  assert_line "0" "alias test_alias='a'"
 }
 
 @test "bash-it: load enabled aliases from new structure, priority-based" {

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -37,36 +37,33 @@ function local_teardown {
   assert_success
 }
 
-@test "completion bash-it: provide the atom aliases when not enabled" {
-  COMP_WORDS=(bash-it enable alias ato)
+function __check_completion () {
+  # Get the parameters as an array
+  eval set -- "$@"
+  COMP_WORDS=("$@")
 
-  COMP_CWORD=3
+  # Get the parameters as a single value
+  COMP_LINE=$*
 
-  COMP_LINE='bash-it enable alias ato'
-
+  # Index of the cursor in the line
   COMP_POINT=${#COMP_LINE}
 
+  # Word index of the last word
+  COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
+
+  # Run the Bash-it completion function
   _bash-it-comp
 
+  # Return the completion output
   echo "${COMPREPLY[@]}"
-  all_results="${COMPREPLY[@]}"
+}
 
-  assert_equal "atom" "$all_results"
+@test "completion bash-it: provide the atom aliases when not enabled" {
+  run __check_completion 'bash-it enable alias ato'
+  assert_line "0" "atom"
 }
 
 @test "completion bash-it: provide the a* aliases when not enabled" {
-  COMP_WORDS=(bash-it enable alias a)
-
-  COMP_CWORD=3
-
-  COMP_LINE='bash-it enable alias a'
-
-  COMP_POINT=${#COMP_LINE}
-
-  _bash-it-comp
-
-  echo "${COMPREPLY[@]}"
-  all_results="${COMPREPLY[@]}"
-
-  assert_equal "all ag ansible apt atom" "$all_results"
+  run __check_completion 'bash-it enable alias a'
+  assert_line "0" "all ag ansible apt atom" "$all_results"
 }

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -77,6 +77,9 @@ function __check_completion () {
   ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/atom.aliases.bash
   assert [ -L "$BASH_IT/aliases/enabled/atom.aliases.bash" ]
 
+  ln -s $BASH_IT/completion/available/apm.completion.bash $BASH_IT/completion/enabled/apm.completion.bash
+  assert [ -L "$BASH_IT/completion/enabled/apm.completion.bash" ]
+
   run __check_completion 'bash-it disable alias a'
   assert_line "0" "all atom"
 }
@@ -85,6 +88,9 @@ function __check_completion () {
   ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/150---atom.aliases.bash
   assert [ -L "$BASH_IT/aliases/enabled/150---atom.aliases.bash" ]
 
+  ln -s $BASH_IT/completion/available/apm.completion.bash $BASH_IT/completion/enabled/350---apm.completion.bash
+  assert [ -L "$BASH_IT/completion/enabled/350---apm.completion.bash" ]
+
   run __check_completion 'bash-it disable alias a'
   assert_line "0" "all atom"
 }
@@ -92,6 +98,9 @@ function __check_completion () {
 @test "completion bash-it: disable - provide the a* aliases when atom is enabled with the new location and priority-based name" {
   ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/enabled/150---atom.aliases.bash
   assert [ -L "$BASH_IT/enabled/150---atom.aliases.bash" ]
+
+  ln -s $BASH_IT/completion/available/apm.completion.bash $BASH_IT/enabled/350---apm.completion.bash
+  assert [ -L "$BASH_IT/enabled/350---apm.completion.bash" ]
 
   run __check_completion 'bash-it disable alias a'
   assert_line "0" "all atom"

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -229,3 +229,27 @@ function __check_completion () {
   run __check_completion 'bash-it enable plugin docker'
   assert_line "0" "docker-compose docker-machine docker"
 }
+
+@test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and name" {
+  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/todo.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/todo.plugin.bash" ]
+
+  run __check_completion 'bash-it enable alias to'
+  assert_line "0" "todo.txt-cli"
+}
+
+@test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/350---todo.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/350---todo.plugin.bash" ]
+
+  run __check_completion 'bash-it enable alias to'
+  assert_line "0" "todo.txt-cli"
+}
+
+@test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/enabled/350---todo.plugin.bash
+  assert [ -L "$BASH_IT/enabled/350---todo.plugin.bash" ]
+
+  run __check_completion 'bash-it enable alias to'
+  assert_line "0" "todo.txt-cli"
+}

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -72,9 +72,74 @@ function __check_completion () {
   echo "${COMPREPLY[@]}"
 }
 
-@test "completion bash-it: help aliases" {
+@test "completion bash-it: help - show options" {
+  run __check_completion 'bash-it help '
+  assert_line "0" "aliases completions migrate plugins update"
+}
+
+@test "completion bash-it: help - aliases v" {
   run __check_completion 'bash-it help aliases v'
   assert_line "0" "vagrant vault vim"
+}
+
+@test "completion bash-it: update - show no options" {
+  run __check_completion 'bash-it update '
+  assert_line "0" ""
+}
+
+@test "completion bash-it: search - show no options" {
+  run __check_completion 'bash-it search '
+  assert_line "0" ""
+}
+
+@test "completion bash-it: migrate - show no options" {
+  run __check_completion 'bash-it migrate '
+  assert_line "0" ""
+}
+
+@test "completion bash-it: show options" {
+  run __check_completion 'bash-it '
+  assert_line "0" "disable enable help migrate search show update"
+}
+
+@test "completion bash-it: bash-ti - show options" {
+  run __check_completion 'bash-ti '
+  assert_line "0" "disable enable help migrate search show update"
+}
+
+@test "completion bash-it: shit - show options" {
+  run __check_completion 'shit '
+  assert_line "0" "disable enable help migrate search show update"
+}
+
+@test "completion bash-it: bashit - show options" {
+  run __check_completion 'bashit '
+  assert_line "0" "disable enable help migrate search show update"
+}
+
+@test "completion bash-it: batshit - show options" {
+  run __check_completion 'batshit '
+  assert_line "0" "disable enable help migrate search show update"
+}
+
+@test "completion bash-it: bash_it - show options" {
+  run __check_completion 'bash_it '
+  assert_line "0" "disable enable help migrate search show update"
+}
+
+@test "completion bash-it: show - show options" {
+  run __check_completion 'bash-it show '
+  assert_line "0" "aliases completions plugins"
+}
+
+@test "completion bash-it: enable - show options" {
+  run __check_completion 'bash-it enable '
+  assert_line "0" "alias completion plugin"
+}
+
+@test "completion bash-it: enable - show options a" {
+  run __check_completion 'bash-it enable a'
+  assert_line "0" "alias"
 }
 
 @test "completion bash-it: disable - show options" {
@@ -84,7 +149,6 @@ function __check_completion () {
 
 @test "completion bash-it: disable - show options a" {
   run __check_completion 'bash-it disable a'
-
   assert_line "0" "alias"
 }
 
@@ -253,6 +317,30 @@ function __check_completion () {
 
   run __check_completion 'bash-it enable plugin docker'
   assert_line "0" "docker-compose docker-machine docker"
+}
+
+@test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the old location and name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/docker-compose.aliases.bash" ]
+
+  run __check_completion 'bash-it enable completion docker'
+  assert_line "0" "docker docker-compose docker-machine"
+}
+
+@test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash" ]
+
+  run __check_completion 'bash-it enable completion docker'
+  assert_line "0" "docker docker-compose docker-machine"
+}
+
+@test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---docker-compose.aliases.bash" ]
+
+  run __check_completion 'bash-it enable completion docker'
+  assert_line "0" "docker docker-compose docker-machine"
 }
 
 @test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and name" {

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -65,6 +65,11 @@ function __check_completion () {
 
 @test "completion bash-it: disable - provide nothing when atom is not enabled" {
   run __check_completion 'bash-it disable alias ato'
+  assert_line "0" ""
+}
+
+@test "completion bash-it: disable - provide all when atom is not enabled" {
+  run __check_completion 'bash-it disable alias a'
   assert_line "0" "all"
 }
 

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -106,6 +106,72 @@ function __check_completion () {
   assert_line "0" "all atom"
 }
 
+@test "completion bash-it: disable - provide the docker-machine plugin when docker-machine is enabled with the old location and name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/docker-compose.aliases.bash" ]
+
+  ln -s $BASH_IT/plugins/available/docker-machine.plugin.bash $BASH_IT/plugins/enabled/docker-machine.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/docker-machine.plugin.bash" ]
+
+  run __check_completion 'bash-it disable plugin docker'
+  assert_line "0" "docker-machine"
+}
+
+@test "completion bash-it: disable - provide the docker-machine plugin when docker-machine is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash" ]
+
+  ln -s $BASH_IT/plugins/available/docker-machine.plugin.bash $BASH_IT/plugins/enabled/350---docker-machine.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/350---docker-machine.plugin.bash" ]
+
+  run __check_completion 'bash-it disable plugin docker'
+  assert_line "0" "docker-machine"
+}
+
+@test "completion bash-it: disable - provide the docker-machine plugin when docker-machine is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---docker-compose.aliases.bash" ]
+
+  ln -s $BASH_IT/plugins/available/docker-machine.plugin.bash $BASH_IT/enabled/350---docker-machine.plugin.bash
+  assert [ -L "$BASH_IT/enabled/350---docker-machine.plugin.bash" ]
+
+  run __check_completion 'bash-it disable plugin docker'
+  assert_line "0" "docker-machine"
+}
+
+@test "completion bash-it: disable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and name" {
+  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash" ]
+
+  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/todo.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/todo.plugin.bash" ]
+
+  run __check_completion 'bash-it disable alias to'
+  assert_line "0" "todo.txt-cli"
+}
+
+@test "completion bash-it: disable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash" ]
+
+  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/350---todo.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/350---todo.plugin.bash" ]
+
+  run __check_completion 'bash-it disable alias to'
+  assert_line "0" "todo.txt-cli"
+}
+
+@test "completion bash-it: disable - provide the todo.txt-cli aliases when todo plugin is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/enabled/150---todo.txt-cli.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash" ]
+
+  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/enabled/350---todo.plugin.bash
+  assert [ -L "$BASH_IT/enabled/350---todo.plugin.bash" ]
+
+  run __check_completion 'bash-it disable alias to'
+  assert_line "0" "todo.txt-cli"
+}
+
 @test "completion bash-it: enable - provide the atom aliases when not enabled" {
   run __check_completion 'bash-it enable alias ato'
   assert_line "0" "atom"
@@ -138,4 +204,28 @@ function __check_completion () {
 
   run __check_completion 'bash-it enable alias a'
   assert_line "0" "all ag ansible apt"
+}
+
+@test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the old location and name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/docker-compose.aliases.bash" ]
+
+  run __check_completion 'bash-it enable plugin docker'
+  assert_line "0" "docker-compose docker-machine docker"
+}
+
+@test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash" ]
+
+  run __check_completion 'bash-it enable plugin docker'
+  assert_line "0" "docker-compose docker-machine docker"
+}
+
+@test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---docker-compose.aliases.bash" ]
+
+  run __check_completion 'bash-it enable plugin docker'
+  assert_line "0" "docker-compose docker-machine docker"
 }

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -63,6 +63,11 @@ function __check_completion () {
   echo "${COMPREPLY[@]}"
 }
 
+@test "completion bash-it: help aliases" {
+  run __check_completion 'bash-it help aliases v'
+  assert_line "0" "vagrant vault vim"
+}
+
 @test "completion bash-it: disable - provide nothing when atom is not enabled" {
   run __check_completion 'bash-it disable alias ato'
   assert_line "0" ""

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -16,6 +16,11 @@ function local_setup {
   rm -rf "$BASH_IT"/completion/enabled
   rm -rf "$BASH_IT"/plugins/enabled
 
+  mkdir -p "$BASH_IT"/enabled
+  mkdir -p "$BASH_IT"/aliases/enabled
+  mkdir -p "$BASH_IT"/completion/enabled
+  mkdir -p "$BASH_IT"/plugins/enabled
+
   # Don't pollute the user's actual $HOME directory
   # Use a test home directory instead
   export BASH_IT_TEST_CURRENT_HOME="${HOME}"
@@ -58,12 +63,65 @@ function __check_completion () {
   echo "${COMPREPLY[@]}"
 }
 
-@test "completion bash-it: provide the atom aliases when not enabled" {
+@test "completion bash-it: disable - provide nothing when atom is not enabled" {
+  run __check_completion 'bash-it disable alias ato'
+  assert_line "0" "all"
+}
+
+@test "completion bash-it: disable - provide the a* aliases when atom is enabled with the old location and name" {
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/atom.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/atom.aliases.bash" ]
+
+  run __check_completion 'bash-it disable alias a'
+  assert_line "0" "all atom"
+}
+
+@test "completion bash-it: disable - provide the a* aliases when atom is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/150---atom.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---atom.aliases.bash" ]
+
+  run __check_completion 'bash-it disable alias a'
+  assert_line "0" "all atom"
+}
+
+@test "completion bash-it: disable - provide the a* aliases when atom is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/enabled/150---atom.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---atom.aliases.bash" ]
+
+  run __check_completion 'bash-it disable alias a'
+  assert_line "0" "all atom"
+}
+
+@test "completion bash-it: enable - provide the atom aliases when not enabled" {
   run __check_completion 'bash-it enable alias ato'
   assert_line "0" "atom"
 }
 
-@test "completion bash-it: provide the a* aliases when not enabled" {
+@test "completion bash-it: enable - provide the a* aliases when not enabled" {
   run __check_completion 'bash-it enable alias a'
-  assert_line "0" "all ag ansible apt atom" "$all_results"
+  assert_line "0" "all ag ansible apt atom"
+}
+
+@test "completion bash-it: enable - provide the a* aliases when atom is enabled with the old location and name" {
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/atom.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/atom.aliases.bash" ]
+
+  run __check_completion 'bash-it enable alias a'
+  assert_line "0" "all ag ansible apt"
+}
+
+@test "completion bash-it: enable - provide the a* aliases when atom is enabled with the old location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/150---atom.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---atom.aliases.bash" ]
+
+  run __check_completion 'bash-it enable alias a'
+  assert_line "0" "all ag ansible apt"
+}
+
+@test "completion bash-it: enable - provide the a* aliases when atom is enabled with the new location and priority-based name" {
+  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/enabled/150---atom.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---atom.aliases.bash" ]
+
+  run __check_completion 'bash-it enable alias a'
+  assert_line "0" "all ag ansible apt"
 }

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+load ../../lib/composure
+load ../../completion/available/bash-it.completion
+
+function local_setup {
+  mkdir -p "$BASH_IT"
+  lib_directory="$(cd "$(dirname "$0")" && pwd)"
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
+
+  # Don't pollute the user's actual $HOME directory
+  # Use a test home directory instead
+  export BASH_IT_TEST_CURRENT_HOME="${HOME}"
+  export BASH_IT_TEST_HOME="$(cd "${BASH_IT}/.." && pwd)/BASH_IT_TEST_HOME"
+  mkdir -p "${BASH_IT_TEST_HOME}"
+  export HOME="${BASH_IT_TEST_HOME}"
+}
+
+function local_teardown {
+  export HOME="${BASH_IT_TEST_CURRENT_HOME}"
+
+  rm -rf "${BASH_IT_TEST_HOME}"
+
+  assert_equal "${BASH_IT_TEST_CURRENT_HOME}" "${HOME}"
+}
+
+@test "completion bash-it: ensure that the _bash-it-comp function is available" {
+  type -a _bash-it-comp &> /dev/null
+  assert_success
+}
+
+@test "completion bash-it: provide the atom aliases when not enabled" {
+  COMP_WORDS=(bash-it enable alias ato)
+
+  COMP_CWORD=3
+
+  COMP_LINE='bash-it enable alias ato'
+
+  COMP_POINT=${#COMP_LINE}
+
+  _bash-it-comp
+
+  echo "${COMPREPLY[@]}"
+  all_results="${COMPREPLY[@]}"
+
+  assert_equal "atom" "$all_results"
+}
+
+@test "completion bash-it: provide the a* aliases when not enabled" {
+  COMP_WORDS=(bash-it enable alias a)
+
+  COMP_CWORD=3
+
+  COMP_LINE='bash-it enable alias a'
+
+  COMP_POINT=${#COMP_LINE}
+
+  _bash-it-comp
+
+  echo "${COMPREPLY[@]}"
+  all_results="${COMPREPLY[@]}"
+
+  assert_equal "all ag ansible apt atom" "$all_results"
+}

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -43,15 +43,24 @@ function local_teardown {
 }
 
 function __check_completion () {
+  # Get the parameters as a single value
+  COMP_LINE=$*
+
   # Get the parameters as an array
   eval set -- "$@"
   COMP_WORDS=("$@")
 
-  # Get the parameters as a single value
-  COMP_LINE=$*
-
   # Index of the cursor in the line
   COMP_POINT=${#COMP_LINE}
+
+  # Get the last character of the line that was entered
+  COMP_LAST=$((${COMP_POINT} - 1))
+
+  # If the last character was a space...
+  if [[ ${COMP_LINE:$COMP_LAST} = ' ' ]]; then
+    # ...then add an empty array item
+    COMP_WORDS+=('')
+  fi
 
   # Word index of the last word
   COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
@@ -66,6 +75,17 @@ function __check_completion () {
 @test "completion bash-it: help aliases" {
   run __check_completion 'bash-it help aliases v'
   assert_line "0" "vagrant vault vim"
+}
+
+@test "completion bash-it: disable - show options" {
+  run __check_completion 'bash-it disable '
+  assert_line "0" "alias completion plugin"
+}
+
+@test "completion bash-it: disable - show options a" {
+  run __check_completion 'bash-it disable a'
+
+  assert_line "0" "alias"
 }
 
 @test "completion bash-it: disable - provide nothing when atom is not enabled" {

--- a/test/fixtures/bash_it/aliases/available/a.aliases.bash
+++ b/test/fixtures/bash_it/aliases/available/a.aliases.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+alias test_alias="a"

--- a/test/fixtures/bash_it/aliases/available/b.aliases.bash
+++ b/test/fixtures/bash_it/aliases/available/b.aliases.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+alias test_alias="b"

--- a/test/fixtures/bash_it/plugins/available/c.plugin.bash
+++ b/test/fixtures/bash_it/plugins/available/c.plugin.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+alias test_alias="c"

--- a/test/install/install.bats
+++ b/test/install/install.bats
@@ -14,10 +14,16 @@ case $OSTYPE in
 esac
 
 function local_setup {
-  mkdir -p $BASH_IT
+  mkdir -p "$BASH_IT"
   lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  cp -r $lib_directory/../../* $BASH_IT/
-  rm -rf "$BASH_IT/aliases/enabled" "$BASH_IT/completion/enabled" "$BASH_IT/plugins/enabled"
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
 
   # Don't pollute the user's actual $HOME directory
   # Use a test home directory instead

--- a/test/install/install.bats
+++ b/test/install/install.bats
@@ -52,11 +52,11 @@ function local_teardown {
 
   assert [ -e "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE" ]
 
-  assert [ -L "$BASH_IT/aliases/enabled/150---general.aliases.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/250---base.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/365---alias-completion.plugin.bash" ]
-  assert [ -L "$BASH_IT/completion/enabled/350---bash-it.completion.bash" ]
-  assert [ -L "$BASH_IT/completion/enabled/350---system.completion.bash" ]
+  assert [ -L "$BASH_IT/enabled/150---general.aliases.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---base.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/365---alias-completion.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/350---bash-it.completion.bash" ]
+  assert [ -L "$BASH_IT/enabled/350---system.completion.bash" ]
 }
 
 @test "install: verify that a backup file is created" {

--- a/test/install/uninstall.bats
+++ b/test/install/uninstall.bats
@@ -14,9 +14,16 @@ case $OSTYPE in
 esac
 
 function local_setup {
-  mkdir -p $BASH_IT
+  mkdir -p "$BASH_IT"
   lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  cp -r $lib_directory/../../* $BASH_IT/
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
 
   # Don't pollute the user's actual $HOME directory
   # Use a test home directory instead

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -258,17 +258,17 @@ function __migrate_all_components() {
 
   ls ${BASH_IT}/${subdirectory}/enabled
 
-  all_available=$(compgen -G "${BASH_IT}/${subdirectory}/available/*.$one_type.bash" | wc -l)
-  all_enabled_old=$(compgen -G "${BASH_IT}/${subdirectory}/enabled/*.$one_type.bash" | wc -l)
+  all_available=$(compgen -G "${BASH_IT}/${subdirectory}/available/*.$one_type.bash" | wc -l | xargs)
+  all_enabled_old=$(compgen -G "${BASH_IT}/${subdirectory}/enabled/*.$one_type.bash" | wc -l | xargs)
 
   assert_equal "$all_available" "$all_enabled_old"
 
   run bash-it migrate
 
-  all_enabled_old_after=$(compgen -G "${BASH_IT}/${subdirectory}/enabled/*.$one_type.bash" | wc -l)
+  all_enabled_old_after=$(compgen -G "${BASH_IT}/${subdirectory}/enabled/*.$one_type.bash" | wc -l | xargs)
   assert_equal "0" "$all_enabled_old_after"
 
-  all_enabled_new_after=$(compgen -G "${BASH_IT}/enabled/*.$one_type.bash" | wc -l)
+  all_enabled_new_after=$(compgen -G "${BASH_IT}/enabled/*.$one_type.bash" | wc -l | xargs)
   assert_equal "$all_enabled_old" "$all_enabled_new_after"
 }
 

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -388,6 +388,20 @@ function __migrate_all_components() {
   _bash-it-plugins | grep "nvm" | grep "\[x\]"
 }
 
+@test "bash-it: describe the nvm plugin after enabling it in the old directory" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
+
+  _bash-it-plugins | grep "nvm" | grep "\[x\]"
+}
+
+@test "bash-it: describe the nvm plugin after enabling it in the old directory with priority" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+
+  _bash-it-plugins | grep "nvm" | grep "\[x\]"
+}
+
 @test "bash-it: describe the todo.txt-cli aliases without enabling them" {
   run _bash-it-aliases
   assert_line "todo.txt-cli          [ ]     todo.txt-cli abbreviations"

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -30,6 +30,17 @@ function local_setup {
 # TODO Create global __get_base_name function
 # TODO Create global __get_enabled_name function
 
+@test "helpers: bash-it help aliases ag" {
+  run bash-it help alias "ag"
+  assert_line "0" "ag='ag --smart-case --pager=\"less -MIRFX'"
+}
+
+@test "helpers: bash-it help aliases without any aliases enabled" {
+  run bash-it help alias
+  echo "${lines[@]}"
+  assert_line "0" ""
+}
+
 @test "helpers: enable the todo.txt-cli aliases through the bash-it function" {
   run bash-it enable alias "todo.txt-cli"
   assert_line "0" 'todo.txt-cli enabled with priority 150.'

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -55,12 +55,7 @@ function local_setup {
   assert_line "0" 'node enabled with priority 250.'
   assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 
-  # TODO Check for the link target - readlink
-  # target_path=$HOME/Code/slate/.slate.js
-  #
-  # if [ "`readlink $HOME/.slate.js`" -ef "$target_path" ]; then
-  #     rm -rf "$HOME/.slate.js"
-  # fi
+  assert_equal "../plugins/available/node.plugin.bash" "`readlink $BASH_IT/enabled/250---node.plugin.bash`"
 }
 
 @test "bash-it: enable the node plugin through the bash-it function" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -439,6 +439,57 @@ function __migrate_all_components() {
   assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
 }
 
+@test "helpers: disable all plugins in the old directory structure" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
+
+  ln -s $BASH_IT/plugins/available/node.plugin.bash $BASH_IT/plugins/enabled/node.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/node.plugin.bash" ]
+
+  local enabled=$(find $BASH_IT/plugins/enabled -name *.plugin.bash | wc -l | xargs)
+  assert_equal "2" "$enabled"
+
+  run _enable-alias "ag"
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+
+  run _disable-plugin "all"
+  local enabled2=$(find $BASH_IT/plugins/enabled -name *.plugin.bash | wc -l | xargs)
+  assert_equal "0" "$enabled2"
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+}
+
+@test "helpers: disable all plugins in the old directory structure with priority" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/250---nvm.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---nvm.plugin.bash" ]
+
+  ln -s $BASH_IT/plugins/available/node.plugin.bash $BASH_IT/plugins/enabled/250---node.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
+
+  local enabled=$(find $BASH_IT/plugins/enabled -name *.plugin.bash | wc -l | xargs)
+  assert_equal "2" "$enabled"
+
+  run _enable-alias "ag"
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+
+  run _disable-plugin "all"
+  local enabled2=$(find $BASH_IT/plugins/enabled -name *.plugin.bash | wc -l | xargs)
+  assert_equal "0" "$enabled2"
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+}
+
+@test "helpers: disable all plugins without anything enabled" {
+  local enabled=$(find $BASH_IT/enabled -name [0-9]*.plugin.bash | wc -l | xargs)
+  assert_equal "0" "$enabled"
+
+  run _enable-alias "ag"
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+
+  run _disable-plugin "all"
+  local enabled2=$(find $BASH_IT/enabled -name [0-9]*.plugin.bash | wc -l | xargs)
+  assert_equal "0" "$enabled2"
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+}
+
 @test "helpers: enable the ansible aliases through the bash-it function" {
   run bash-it enable alias "ansible"
   assert_line "0" 'ansible enabled with priority 150.'

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -9,90 +9,107 @@ cite _about _param _example _group _author _version
 load ../../lib/helpers
 
 function local_setup {
-  mkdir -p $BASH_IT
+  mkdir -p "$BASH_IT"
   lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  cp -r $lib_directory/../.. $BASH_IT
-  mkdir -p $BASH_IT/aliases/enabled
-  mkdir -p $BASH_IT/completion/enabled
-  mkdir -p $BASH_IT/plugins/enabled
+  cp -r $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
+
+  mkdir -p "$BASH_IT"/enabled
+  mkdir -p "$BASH_IT"/aliases/enabled
+  mkdir -p "$BASH_IT"/completion/enabled
+  mkdir -p "$BASH_IT"/plugins/enabled
 }
 
 @test "bash-it: enable the ansible aliases through the bash-it function" {
   run bash-it enable alias "ansible"
   assert_line "0" 'ansible enabled with priority 150.'
-  assert [ -L "$BASH_IT/aliases/enabled/150---ansible.aliases.bash" ]
+  assert [ -L "$BASH_IT/enabled/150---ansible.aliases.bash" ]
 }
 
 @test "bash-it: enable the todo.txt-cli aliases through the bash-it function" {
   run bash-it enable alias "todo.txt-cli"
   assert_line "0" 'todo.txt-cli enabled with priority 150.'
-  assert [ -L "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash" ]
+  assert [ -L "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash" ]
 }
 
 @test "bash-it: enable the curl aliases" {
   run _enable-alias "curl"
   assert_line "0" 'curl enabled with priority 150.'
-  assert [ -L "$BASH_IT/aliases/enabled/150---curl.aliases.bash" ]
+  assert [ -L "$BASH_IT/enabled/150---curl.aliases.bash" ]
 }
 
 @test "bash-it: enable the apm completion through the bash-it function" {
   run bash-it enable completion "apm"
   assert_line "0" 'apm enabled with priority 350.'
-  assert [ -L "$BASH_IT/completion/enabled/350---apm.completion.bash" ]
+  assert [ -L "$BASH_IT/enabled/350---apm.completion.bash" ]
 }
 
 @test "bash-it: enable the brew completion" {
   run _enable-completion "brew"
   assert_line "0" 'brew enabled with priority 350.'
-  assert [ -L "$BASH_IT/completion/enabled/350---brew.completion.bash" ]
+  assert [ -L "$BASH_IT/enabled/350---brew.completion.bash" ]
 }
 
 @test "bash-it: enable the node plugin" {
   run _enable-plugin "node"
   assert_line "0" 'node enabled with priority 250.'
-  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
 @test "bash-it: enable the node plugin through the bash-it function" {
   run bash-it enable plugin "node"
   assert_line "0" 'node enabled with priority 250.'
-  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
 @test "bash-it: enable the node and nvm plugins through the bash-it function" {
   run bash-it enable plugin "node" "nvm"
   assert_line "0" 'node enabled with priority 250.'
   assert_line "1" 'nvm enabled with priority 225.'
-  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
 @test "bash-it: enable the foo-unkown and nvm plugins through the bash-it function" {
   run bash-it enable plugin "foo-unknown" "nvm"
   assert_line "0" 'sorry, foo-unknown does not appear to be an available plugin.'
   assert_line "1" 'nvm enabled with priority 225.'
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
 @test "bash-it: enable the nvm plugin" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
 @test "bash-it: enable an unknown plugin" {
   run _enable-plugin "unknown-foo"
   assert_line "0" 'sorry, unknown-foo does not appear to be an available plugin.'
+
+  # Check for both old an new structure
   assert [ ! -L "$BASH_IT/plugins/enabled/250---unknown-foo.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/unknown-foo.plugin.bash" ]
+
+  assert [ ! -L "$BASH_IT/enabled/250---unknown-foo.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/unknown-foo.plugin.bash" ]
 }
 
 @test "bash-it: enable an unknown plugin through the bash-it function" {
   run bash-it enable plugin "unknown-foo"
   echo "${lines[@]}"
   assert_line "0" 'sorry, unknown-foo does not appear to be an available plugin.'
+
+  # Check for both old an new structure
   assert [ ! -L "$BASH_IT/plugins/enabled/250---unknown-foo.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/unknown-foo.plugin.bash" ]
+
+  assert [ ! -L "$BASH_IT/enabled/250---unknown-foo.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/unknown-foo.plugin.bash" ]
 }
 
 @test "bash-it: disable a plugin that is not enabled" {
@@ -103,11 +120,23 @@ function local_setup {
 @test "bash-it: enable and disable the nvm plugin" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+
+  run _disable-plugin "nvm"
+  assert_line "0" 'nvm disabled.'
+  assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
+}
+
+@test "bash-it: disable the nvm plugin if it was enabled with a priority, but in the component-specific directory" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 
   run _disable-plugin "nvm"
   assert_line "0" 'nvm disabled.'
   assert [ ! -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
 @test "bash-it: disable the nvm plugin if it was enabled without a priority" {
@@ -127,16 +156,28 @@ function local_setup {
   assert_line "0" 'nvm is already enabled.'
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
+}
+
+@test "bash-it: enable the nvm plugin if it was enabled with a priority, but in the component-specific directory" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+
+  run _enable-plugin "nvm"
+  assert_line "0" 'nvm is already enabled.'
+  assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
 @test "bash-it: enable the nvm plugin twice" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 
   run _enable-plugin "nvm"
   assert_line "0" 'nvm is already enabled.'
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
 @test "bash-it: migrate enabled plugins that don't use the new priority-based configuration" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -207,10 +207,10 @@ function local_setup {
 
 @test "bash-it: run the migrate command without anything to migrate" {
   run _enable-plugin "ssh"
-  assert [ -L "$BASH_IT/plugins/enabled/250---ssh.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
 
   run _bash-it-migrate
-  assert [ -L "$BASH_IT/plugins/enabled/250---ssh.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
 }
 
 @test "bash-it: verify that existing components are automatically migrated when something is enabled" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -90,10 +90,13 @@ function local_setup {
   assert_line "0" 'ag enabled with priority 150.'
   assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
 
-  run bash-it help aliases
+  run bash-it enable plugin "aws"
+  assert_line "0" 'aws enabled with priority 250.'
+  assert [ -L "$BASH_IT/enabled/250---aws.plugin.bash" ]
 
-  echo "${lines[@]}"
-  assert_line "2" "foo"
+  run bash-it help aliases
+  assert_line "0" "ag:"
+  assert_line "1" "ag='ag --smart-case --pager=\"less -MIRFX'"
 }
 
 @test "helpers: enable the todo.txt-cli aliases through the bash-it function" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -303,7 +303,7 @@ function local_setup {
 @test "bash-it: describe the nvm plugin after enabling it" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 
   _bash-it-plugins | grep "nvm" | grep "\[x\]"
 }

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -53,6 +53,22 @@ function local_setup {
   assert_line "0" "ag:"
 }
 
+@test "helpers: bash-it help list aliases with todo.txt-cli aliases enabled" {
+  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash" ]
+
+  run _help-list-aliases "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash"
+  assert_line "0" "todo.txt-cli:"
+}
+
+@test "helpers: bash-it help list aliases with docker-compose aliases enabled" {
+  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash" ]
+
+  run _help-list-aliases "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
+  assert_line "0" "docker-compose:"
+}
+
 @test "helpers: bash-it help list aliases with ag aliases enabled in global directory" {
   ln -s $BASH_IT/aliases/available/ag.aliases.bash $BASH_IT/enabled/150---ag.aliases.bash
   assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -251,6 +251,28 @@ function local_setup {
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
+@test "helpers: migrate plugins and completions that share the same name" {
+  ln -s $BASH_IT/completion/available/dirs.completion.bash $BASH_IT/completion/enabled/350---dirs.completion.bash
+  assert [ -L "$BASH_IT/completion/enabled/350---dirs.completion.bash" ]
+
+  ln -s $BASH_IT/plugins/available/dirs.plugin.bash $BASH_IT/plugins/enabled/250---dirs.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---dirs.plugin.bash" ]
+
+  run _bash-it-migrate
+  assert_line "0" 'Migrating plugin dirs.'
+  assert_line "1" 'dirs disabled.'
+  assert_line "2" 'dirs enabled with priority 250.'
+  assert_line "3" 'Migrating completion dirs.'
+  assert_line "4" 'dirs disabled.'
+  assert_line "5" 'dirs enabled with priority 350.'
+  assert_line "6" 'If any migration errors were reported, please try the following: reload && bash-it migrate'
+
+  assert [ -L "$BASH_IT/enabled/350---dirs.completion.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---dirs.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/completion/enabled/350----dirs.completion.bash" ]
+  assert [ ! -L "$BASH_IT/plugins/enabled/250----dirs.plugin.bash" ]
+}
+
 @test "helpers: migrate enabled plugins that don't use the new priority-based configuration" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
@@ -265,6 +287,9 @@ function local_setup {
   assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
 
   run _bash-it-migrate
+  assert_line "0" 'Migrating alias todo.txt-cli.'
+  assert_line "1" 'todo.txt-cli disabled.'
+  assert_line "2" 'todo.txt-cli enabled with priority 150.'
 
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
   assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -189,16 +189,40 @@ function local_setup {
   assert [ -L "$BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash" ]
 
   run _enable-plugin "ssh"
-  assert [ -L "$BASH_IT/plugins/enabled/250---ssh.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
 
   run _bash-it-migrate
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/250---ssh.plugin.bash" ]
-  assert [ -L "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash" ]
+
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/node.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
   assert [ ! -L "$BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash" ]
+}
+
+@test "bash-it: migrate enabled plugins that use the new priority-based configuration in the individual directories" {
+  ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+
+  ln -s $BASH_IT/plugins/available/node.plugin.bash $BASH_IT/plugins/enabled/250---node.plugin.bash
+  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
+
+  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/aliases/enabled/250---todo.txt-cli.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/250---todo.txt-cli.aliases.bash" ]
+
+  run _enable-plugin "ssh"
+  assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
+
+  run _bash-it-migrate
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash" ]
+  assert [ ! -L "$BASH_IT/plugins/enabled/225----node.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/plugins/enabled/250----nvm.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/aliases/enabled/250----todo.txt-cli.aliases.bash" ]
 }
 
 @test "bash-it: run the migrate command without anything to migrate and nothing enabled" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -247,8 +247,8 @@ function local_setup {
   assert_line "2" 'nvm enabled with priority 225.'
   assert_line "3" 'node enabled with priority 250.'
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
 @test "bash-it: verify that existing components are automatically migrated when something is disabled" {
@@ -263,8 +263,9 @@ function local_setup {
   assert_line "2" 'nvm enabled with priority 225.'
   assert_line "3" 'node disabled.'
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
-  assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
+  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
 @test "bash-it: enable all plugins" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -391,7 +391,8 @@ function __migrate_all_components() {
   assert_line "0" 'Migrating plugin nvm.'
   assert_line "1" 'nvm disabled.'
   assert_line "2" 'nvm enabled with priority 225.'
-  assert_line "3" 'node enabled with priority 250.'
+  assert_line "3" 'If any migration errors were reported, please try the following: reload && bash-it migrate'
+  assert_line "4" 'node enabled with priority 250.'
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
   assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
@@ -410,7 +411,8 @@ function __migrate_all_components() {
   assert_line "3" 'Migrating plugin nvm.'
   assert_line "4" 'nvm disabled.'
   assert_line "5" 'nvm enabled with priority 225.'
-  assert_line "6" 'node disabled.'
+  assert_line "6" 'If any migration errors were reported, please try the following: reload && bash-it migrate'
+  assert_line "7" 'node disabled.'
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -40,17 +40,36 @@ function local_setup {
   assert_line "0" ""
 }
 
+@test "helpers: bash-it help list aliases without any aliases enabled" {
+  run _help-list-aliases "$BASH_IT/aliases/available/ag.aliases.bash"
+  assert_line "0" "ag:"
+}
+
+@test "helpers: bash-it help list aliases with ag aliases enabled" {
+  ln -s $BASH_IT/aliases/available/ag.aliases.bash $BASH_IT/aliases/enabled/150---ag.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---ag.aliases.bash" ]
+
+  run _help-list-aliases "$BASH_IT/aliases/enabled/150---ag.aliases.bash"
+  assert_line "0" "ag:"
+}
+
+@test "helpers: bash-it help list aliases with ag aliases enabled in global directory" {
+  ln -s $BASH_IT/aliases/available/ag.aliases.bash $BASH_IT/enabled/150---ag.aliases.bash
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+
+  run _help-list-aliases "$BASH_IT/enabled/150---ag.aliases.bash"
+  assert_line "0" "ag:"
+}
+
 @test "helpers: bash-it help aliases one alias enabled in the old directory" {
   ln -s $BASH_IT/aliases/available/ag.aliases.bash $BASH_IT/aliases/enabled/150---ag.aliases.bash
   assert [ -L "$BASH_IT/aliases/enabled/150---ag.aliases.bash" ]
 
   run bash-it help aliases
-
-  echo "${lines[@]}"
   assert_line "0" "ag:"
 }
 
-@test "helpers: bash-it help aliases one alias enabled" {
+@test "helpers: bash-it help aliases one alias enabled in global directory" {
   run bash-it enable alias "ag"
   assert_line "0" 'ag enabled with priority 150.'
   assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -258,14 +258,17 @@ function local_setup {
   assert [ -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
 
   run bash-it disable plugin "node"
-  assert_line "0" 'Migrating plugin nvm.'
-  assert_line "1" 'nvm disabled.'
-  assert_line "2" 'nvm enabled with priority 225.'
-  assert_line "3" 'node disabled.'
+  assert_line "0" 'Migrating plugin node.'
+  assert_line "1" 'node disabled.'
+  assert_line "2" 'node enabled with priority 250.'
+  assert_line "3" 'Migrating plugin nvm.'
+  assert_line "4" 'nvm disabled.'
+  assert_line "5" 'nvm enabled with priority 225.'
+  assert_line "6" 'node disabled.'
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
   assert [ ! -L "$BASH_IT/plugins/enabled/250---node.plugin.bash" ]
-  assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
+  assert [ ! -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
 @test "bash-it: enable all plugins" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -31,14 +31,34 @@ function local_setup {
 # TODO Create global __get_enabled_name function
 
 @test "helpers: bash-it help aliases ag" {
-  run bash-it help alias "ag"
+  run bash-it help aliases "ag"
   assert_line "0" "ag='ag --smart-case --pager=\"less -MIRFX'"
 }
 
 @test "helpers: bash-it help aliases without any aliases enabled" {
-  run bash-it help alias
-  echo "${lines[@]}"
+  run bash-it help aliases
   assert_line "0" ""
+}
+
+@test "helpers: bash-it help aliases one alias enabled in the old directory" {
+  ln -s $BASH_IT/aliases/available/ag.aliases.bash $BASH_IT/aliases/enabled/150---ag.aliases.bash
+  assert [ -L "$BASH_IT/aliases/enabled/150---ag.aliases.bash" ]
+
+  run bash-it help aliases
+
+  echo "${lines[@]}"
+  assert_line "0" "ag:"
+}
+
+@test "helpers: bash-it help aliases one alias enabled" {
+  run bash-it enable alias "ag"
+  assert_line "0" 'ag enabled with priority 150.'
+  assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
+
+  run bash-it help aliases
+
+  echo "${lines[@]}"
+  assert_line "2" "foo"
 }
 
 @test "helpers: enable the todo.txt-cli aliases through the bash-it function" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -30,31 +30,31 @@ function local_setup {
 # TODO Create global __get_base_name function
 # TODO Create global __get_enabled_name function
 
-@test "bash-it: enable the todo.txt-cli aliases through the bash-it function" {
+@test "helpers: enable the todo.txt-cli aliases through the bash-it function" {
   run bash-it enable alias "todo.txt-cli"
   assert_line "0" 'todo.txt-cli enabled with priority 150.'
   assert [ -L "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash" ]
 }
 
-@test "bash-it: enable the curl aliases" {
+@test "helpers: enable the curl aliases" {
   run _enable-alias "curl"
   assert_line "0" 'curl enabled with priority 150.'
   assert [ -L "$BASH_IT/enabled/150---curl.aliases.bash" ]
 }
 
-@test "bash-it: enable the apm completion through the bash-it function" {
+@test "helpers: enable the apm completion through the bash-it function" {
   run bash-it enable completion "apm"
   assert_line "0" 'apm enabled with priority 350.'
   assert [ -L "$BASH_IT/enabled/350---apm.completion.bash" ]
 }
 
-@test "bash-it: enable the brew completion" {
+@test "helpers: enable the brew completion" {
   run _enable-completion "brew"
   assert_line "0" 'brew enabled with priority 350.'
   assert [ -L "$BASH_IT/enabled/350---brew.completion.bash" ]
 }
 
-@test "bash-it: enable the node plugin" {
+@test "helpers: enable the node plugin" {
   run _enable-plugin "node"
   assert_line "0" 'node enabled with priority 250.'
   assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
@@ -62,13 +62,13 @@ function local_setup {
   assert_equal "../plugins/available/node.plugin.bash" "`readlink $BASH_IT/enabled/250---node.plugin.bash`"
 }
 
-@test "bash-it: enable the node plugin through the bash-it function" {
+@test "helpers: enable the node plugin through the bash-it function" {
   run bash-it enable plugin "node"
   assert_line "0" 'node enabled with priority 250.'
   assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
-@test "bash-it: enable the node and nvm plugins through the bash-it function" {
+@test "helpers: enable the node and nvm plugins through the bash-it function" {
   run bash-it enable plugin "node" "nvm"
   assert_line "0" 'node enabled with priority 250.'
   assert_line "1" 'nvm enabled with priority 225.'
@@ -76,20 +76,20 @@ function local_setup {
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: enable the foo-unkown and nvm plugins through the bash-it function" {
+@test "helpers: enable the foo-unkown and nvm plugins through the bash-it function" {
   run bash-it enable plugin "foo-unknown" "nvm"
   assert_line "0" 'sorry, foo-unknown does not appear to be an available plugin.'
   assert_line "1" 'nvm enabled with priority 225.'
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: enable the nvm plugin" {
+@test "helpers: enable the nvm plugin" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: enable an unknown plugin" {
+@test "helpers: enable an unknown plugin" {
   run _enable-plugin "unknown-foo"
   assert_line "0" 'sorry, unknown-foo does not appear to be an available plugin.'
 
@@ -101,7 +101,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/enabled/unknown-foo.plugin.bash" ]
 }
 
-@test "bash-it: enable an unknown plugin through the bash-it function" {
+@test "helpers: enable an unknown plugin through the bash-it function" {
   run bash-it enable plugin "unknown-foo"
   echo "${lines[@]}"
   assert_line "0" 'sorry, unknown-foo does not appear to be an available plugin.'
@@ -114,12 +114,12 @@ function local_setup {
   assert [ ! -L "$BASH_IT/enabled/unknown-foo.plugin.bash" ]
 }
 
-@test "bash-it: disable a plugin that is not enabled" {
+@test "helpers: disable a plugin that is not enabled" {
   run _disable-plugin "sdkman"
   assert_line "0" 'sorry, sdkman does not appear to be an enabled plugin.'
 }
 
-@test "bash-it: enable and disable the nvm plugin" {
+@test "helpers: enable and disable the nvm plugin" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
@@ -130,7 +130,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: disable the nvm plugin if it was enabled with a priority, but in the component-specific directory" {
+@test "helpers: disable the nvm plugin if it was enabled with a priority, but in the component-specific directory" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
   assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
@@ -141,7 +141,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: disable the nvm plugin if it was enabled without a priority" {
+@test "helpers: disable the nvm plugin if it was enabled without a priority" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
 
@@ -150,7 +150,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
 }
 
-@test "bash-it: enable the nvm plugin if it was enabled without a priority" {
+@test "helpers: enable the nvm plugin if it was enabled without a priority" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
 
@@ -161,7 +161,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: enable the nvm plugin if it was enabled with a priority, but in the component-specific directory" {
+@test "helpers: enable the nvm plugin if it was enabled with a priority, but in the component-specific directory" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
 
@@ -172,7 +172,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: enable the nvm plugin twice" {
+@test "helpers: enable the nvm plugin twice" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
@@ -182,7 +182,7 @@ function local_setup {
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
 }
 
-@test "bash-it: migrate enabled plugins that don't use the new priority-based configuration" {
+@test "helpers: migrate enabled plugins that don't use the new priority-based configuration" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
 
@@ -206,7 +206,7 @@ function local_setup {
   assert [ ! -L "$BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash" ]
 }
 
-@test "bash-it: migrate enabled plugins that use the new priority-based configuration in the individual directories" {
+@test "helpers: migrate enabled plugins that use the new priority-based configuration in the individual directories" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
 
@@ -229,11 +229,11 @@ function local_setup {
   assert [ ! -L "$BASH_IT/aliases/enabled/250----todo.txt-cli.aliases.bash" ]
 }
 
-@test "bash-it: run the migrate command without anything to migrate and nothing enabled" {
+@test "helpers: run the migrate command without anything to migrate and nothing enabled" {
   run _bash-it-migrate
 }
 
-@test "bash-it: run the migrate command without anything to migrate" {
+@test "helpers: run the migrate command without anything to migrate" {
   run _enable-plugin "ssh"
   assert [ -L "$BASH_IT/enabled/250---ssh.plugin.bash" ]
 
@@ -272,49 +272,49 @@ function __migrate_all_components() {
   assert_equal "$all_enabled_old" "$all_enabled_new_after"
 }
 
-@test "bash-it: migrate all plugins" {
+@test "helpers: migrate all plugins" {
   subdirectory="plugins"
   one_type="plugin"
 
   __migrate_all_components "$subdirectory" "$one_type"
 }
 
-@test "bash-it: migrate all aliases" {
+@test "helpers: migrate all aliases" {
   subdirectory="aliases"
   one_type="aliases"
 
   __migrate_all_components "$subdirectory" "$one_type"
 }
 
-@test "bash-it: migrate all completions" {
+@test "helpers: migrate all completions" {
   subdirectory="completion"
   one_type="completion"
 
   __migrate_all_components "$subdirectory" "$one_type"
 }
 
-@test "bash-it: migrate all plugins with previous priority" {
+@test "helpers: migrate all plugins with previous priority" {
   subdirectory="plugins"
   one_type="plugin"
 
   __migrate_all_components "$subdirectory" "$one_type" "100"
 }
 
-@test "bash-it: migrate all aliases with previous priority" {
+@test "helpers: migrate all aliases with previous priority" {
   subdirectory="aliases"
   one_type="aliases"
 
   __migrate_all_components "$subdirectory" "$one_type" "100"
 }
 
-@test "bash-it: migrate all completions with previous priority" {
+@test "helpers: migrate all completions with previous priority" {
   subdirectory="completion"
   one_type="completion"
 
   __migrate_all_components "$subdirectory" "$one_type" "100"
 }
 
-@test "bash-it: verify that existing components are automatically migrated when something is enabled" {
+@test "helpers: verify that existing components are automatically migrated when something is enabled" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
 
@@ -328,7 +328,7 @@ function __migrate_all_components() {
   assert [ -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
-@test "bash-it: verify that existing components are automatically migrated when something is disabled" {
+@test "helpers: verify that existing components are automatically migrated when something is disabled" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
   ln -s $BASH_IT/plugins/available/node.plugin.bash $BASH_IT/plugins/enabled/250---node.plugin.bash
@@ -348,14 +348,14 @@ function __migrate_all_components() {
   assert [ ! -L "$BASH_IT/enabled/250---node.plugin.bash" ]
 }
 
-@test "bash-it: enable all plugins" {
+@test "helpers: enable all plugins" {
   run _enable-plugin "all"
   local available=$(find $BASH_IT/plugins/available -name *.plugin.bash | wc -l | xargs)
   local enabled=$(find $BASH_IT/enabled -name [0-9]*.plugin.bash | wc -l | xargs)
   assert_equal "$available" "$enabled"
 }
 
-@test "bash-it: disable all plugins" {
+@test "helpers: disable all plugins" {
   run _enable-plugin "all"
   local available=$(find $BASH_IT/plugins/available -name *.plugin.bash | wc -l | xargs)
   local enabled=$(find $BASH_IT/enabled -name [0-9]*.plugin.bash | wc -l | xargs)
@@ -370,17 +370,17 @@ function __migrate_all_components() {
   assert [ -L "$BASH_IT/enabled/150---ag.aliases.bash" ]
 }
 
-@test "bash-it: enable the ansible aliases through the bash-it function" {
+@test "helpers: enable the ansible aliases through the bash-it function" {
   run bash-it enable alias "ansible"
   assert_line "0" 'ansible enabled with priority 150.'
   assert [ -L "$BASH_IT/enabled/150---ansible.aliases.bash" ]
 }
 
-@test "bash-it: describe the nvm plugin without enabling it" {
+@test "helpers: describe the nvm plugin without enabling it" {
   _bash-it-plugins | grep "nvm" | grep "\[ \]"
 }
 
-@test "bash-it: describe the nvm plugin after enabling it" {
+@test "helpers: describe the nvm plugin after enabling it" {
   run _enable-plugin "nvm"
   assert_line "0" 'nvm enabled with priority 225.'
   assert [ -L "$BASH_IT/enabled/225---nvm.plugin.bash" ]
@@ -388,21 +388,21 @@ function __migrate_all_components() {
   _bash-it-plugins | grep "nvm" | grep "\[x\]"
 }
 
-@test "bash-it: describe the nvm plugin after enabling it in the old directory" {
+@test "helpers: describe the nvm plugin after enabling it in the old directory" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/nvm.plugin.bash" ]
 
   _bash-it-plugins | grep "nvm" | grep "\[x\]"
 }
 
-@test "bash-it: describe the nvm plugin after enabling it in the old directory with priority" {
+@test "helpers: describe the nvm plugin after enabling it in the old directory with priority" {
   ln -s $BASH_IT/plugins/available/nvm.plugin.bash $BASH_IT/plugins/enabled/225---nvm.plugin.bash
   assert [ -L "$BASH_IT/plugins/enabled/225---nvm.plugin.bash" ]
 
   _bash-it-plugins | grep "nvm" | grep "\[x\]"
 }
 
-@test "bash-it: describe the todo.txt-cli aliases without enabling them" {
+@test "helpers: describe the todo.txt-cli aliases without enabling them" {
   run _bash-it-aliases
   assert_line "todo.txt-cli          [ ]     todo.txt-cli abbreviations"
 }

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -30,6 +30,26 @@ function local_setup {
 # TODO Create global __get_base_name function
 # TODO Create global __get_enabled_name function
 
+@test "helpers: _command_exists function exists" {
+  type -a _command_exists &> /dev/null
+  assert_success
+}
+
+@test "helpers: _command_exists function positive test ls" {
+  run _command_exists ls
+  assert_success
+}
+
+@test "helpers: _command_exists function positive test bash-it" {
+  run _command_exists bash-it
+  assert_success
+}
+
+@test "helpers: _command_exists function negative test" {
+  run _command_exists __addfkds_dfdsjdf
+  assert_failure
+}
+
 @test "helpers: bash-it help aliases ag" {
   run bash-it help aliases "ag"
   assert_line "0" "ag='ag --smart-case --pager=\"less -MIRFX'"

--- a/test/lib/search.bats
+++ b/test/lib/search.bats
@@ -25,12 +25,12 @@ function local_setup {
   rm -rf "$BASH_IT"/plugins/enabled
 }
 
-@test "helpers search plugins" {
+@test "search: plugin base" {
   run _bash-it-search-component 'plugins' 'base'
   [[ "${lines[0]}" =~ 'plugins' && "${lines[0]}" =~ 'base' ]]
 }
 
-@test "helpers search ruby gem bundle rake rails" {
+@test "search: ruby gem bundle rake rails" {
   # first disable them all, so that  the output does not appear with a checkbox
   # and we can compare the result
   run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails' '--disable'
@@ -42,7 +42,7 @@ function local_setup {
   assert [ "${lines[2]/✓/}" == '  completions  =>   bundler gem rake' ]
 }
 
-@test "search ruby gem bundle -chruby rake rails" {
+@test "search: ruby gem bundle -chruby rake rails" {
   run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails' '--disable'
   run _bash-it-search 'ruby' 'gem' 'bundle' '-chruby' 'rake' 'rails'
   assert [ "${lines[0]/✓/}" == '      aliases  =>   bundler rails' ]
@@ -50,7 +50,7 @@ function local_setup {
   assert [ "${lines[2]/✓/}" == '  completions  =>   bundler gem rake' ]
 }
 
-@test "search (rails enabled) ruby gem bundle rake rails" {
+@test "search: (rails enabled) ruby gem bundle rake rails" {
   run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails' '--disable'
   run _enable-alias 'rails'
   run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails'
@@ -59,7 +59,7 @@ function local_setup {
   assert_line "2" '  completions  =>   bundler gem rake'
 }
 
-@test "search (all enabled) ruby gem bundle rake rails" {
+@test "search: (all enabled) ruby gem bundle rake rails" {
   run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' '-chruby' 'rails' '--enable'
   run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' '-chruby' 'rails'
   assert_line "0" '      aliases  =>   ✓bundler ✓rails'

--- a/test/lib/search.bats
+++ b/test/lib/search.bats
@@ -13,9 +13,16 @@ load ../../lib/search
 NO_COLOR=true
 
 function local_setup {
-  mkdir -p $BASH_IT
+  mkdir -p "$BASH_IT"
   lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  cp -r $lib_directory/../../* $BASH_IT/
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
 }
 
 @test "helpers search plugins" {

--- a/test/plugins/ruby.plugin.bats
+++ b/test/plugins/ruby.plugin.bats
@@ -15,6 +15,12 @@ load ../../plugins/available/ruby.plugin
     skip 'ruby not installed'
   fi
 
-  last_path_entry=$(echo $PATH | tr ":" "\n" | tail -1);
+  # Reset the path for this test to ensure that the ruby directory is not part of the path yet.
+  PATH="/usr/local/bin:/usr/bin:/bin"
+
+  # Then load the ruby plugin again to ensure that the ruby path is appended at the end of the path
+  load ../../plugins/available/ruby.plugin
+
+  local last_path_entry=$(echo $PATH | tr ":" "\n" | tail -1)
   [[ "${last_path_entry}" == "${HOME}"/.gem/ruby/*/bin ]]
 }

--- a/test/plugins/ruby.plugin.bats
+++ b/test/plugins/ruby.plugin.bats
@@ -5,6 +5,32 @@ load ../../lib/helpers
 load ../../lib/composure
 load ../../plugins/available/ruby.plugin
 
+function local_setup {
+  mkdir -p "$BASH_IT"
+  lib_directory="$(cd "$(dirname "$0")" && pwd)"
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
+
+  mkdir -p "$BASH_IT"/enabled
+  mkdir -p "$BASH_IT"/aliases/enabled
+  mkdir -p "$BASH_IT"/completion/enabled
+  mkdir -p "$BASH_IT"/plugins/enabled
+
+  export OLD_PATH="$PATH"
+  export PATH="/usr/bin:/bin:/usr/sbin"
+}
+
+function local_teardown {
+  export PATH="$OLD_PATH"
+  unset OLD_PATH
+}
+
 @test "plugins ruby: remove_gem is defined" {
   run type remove_gem
   assert_line 1 "remove_gem () "
@@ -14,6 +40,8 @@ load ../../plugins/available/ruby.plugin
   if ! which ruby >/dev/null; then
     skip 'ruby not installed'
   fi
+
+  load ../../plugins/available/ruby.plugin
 
   local last_path_entry=$(echo $PATH | tr ":" "\n" | tail -1)
   [[ "${last_path_entry}" == "${HOME}"/.gem/ruby/*/bin ]]

--- a/test/plugins/ruby.plugin.bats
+++ b/test/plugins/ruby.plugin.bats
@@ -21,6 +21,8 @@ load ../../plugins/available/ruby.plugin
   # Then load the ruby plugin again to ensure that the ruby path is appended at the end of the path
   load ../../plugins/available/ruby.plugin
 
+  echo $PATH
+
   local last_path_entry=$(echo $PATH | tr ":" "\n" | tail -1)
   [[ "${last_path_entry}" == "${HOME}"/.gem/ruby/*/bin ]]
 }

--- a/test/plugins/ruby.plugin.bats
+++ b/test/plugins/ruby.plugin.bats
@@ -15,14 +15,6 @@ load ../../plugins/available/ruby.plugin
     skip 'ruby not installed'
   fi
 
-  # Reset the path for this test to ensure that the ruby directory is not part of the path yet.
-  PATH="/usr/local/bin:/usr/bin:/bin"
-
-  # Then load the ruby plugin again to ensure that the ruby path is appended at the end of the path
-  load ../../plugins/available/ruby.plugin
-
-  echo $PATH
-
   local last_path_entry=$(echo $PATH | tr ":" "\n" | tail -1)
   [[ "${last_path_entry}" == "${HOME}"/.gem/ruby/*/bin ]]
 }

--- a/test/run
+++ b/test/run
@@ -9,5 +9,4 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
 fi
 
-# exec $bats_executable ${CI:+--tap} ${test_directory}/completion
 exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}

--- a/test/run
+++ b/test/run
@@ -9,5 +9,5 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
 fi
 
-exec $bats_executable ${CI:+--tap} ${test_directory}/completion
-# exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}
+# exec $bats_executable ${CI:+--tap} ${test_directory}/completion
+exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}

--- a/test/run
+++ b/test/run
@@ -9,5 +9,5 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
 fi
 
-# exec $bats_executable ${CI:+--tap} ${test_directory}/completion
-exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}
+exec $bats_executable ${CI:+--tap} ${test_directory}/completion
+# exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}

--- a/test/run
+++ b/test/run
@@ -9,5 +9,5 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
 fi
 
-#exec $bats_executable ${CI:+--tap} ${test_directory}/completion
+# exec $bats_executable ${CI:+--tap} ${test_directory}/completion
 exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}

--- a/test/run
+++ b/test/run
@@ -9,6 +9,5 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
 fi
 
-# TODO Add tests for bash-it completion
-
-exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,install,lib,plugins,themes}
+#exec $bats_executable ${CI:+--tap} ${test_directory}/completion
+exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}

--- a/test/run
+++ b/test/run
@@ -11,4 +11,4 @@ fi
 
 # TODO Add tests for bash-it completion
 
-exec $bats_executable ${CI:+--tap} ${test_directory}/{install,lib,plugins,themes}
+exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,install,lib,plugins,themes}

--- a/test/run
+++ b/test/run
@@ -9,4 +9,6 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
 fi
 
+# TODO Add tests for bash-it completion
+
 exec $bats_executable ${CI:+--tap} ${test_directory}/{install,lib,plugins,themes}

--- a/test/themes/base.theme.bats
+++ b/test/themes/base.theme.bats
@@ -2,7 +2,10 @@
 
 load ../test_helper
 load ../../lib/composure
-load ../../plugins/available/base.plugin
+
+cite _about _param _example _group _author _version
+
+load ../../lib/helpers
 load ../../themes/base.theme
 
 @test 'themes base: battery_percentage should not exist' {

--- a/themes/atomic/atomic.theme.bash
+++ b/themes/atomic/atomic.theme.bash
@@ -164,7 +164,7 @@ ___atomic_prompt_clock() {
 }
 
 ___atomic_prompt_battery() {
-  ! command_exists battery_percentage ||
+  ! _command_exists battery_percentage ||
   [ "${THEME_SHOW_BATTERY}" != "true" ] ||
   [ "$(battery_percentage)" = "no" ] && return
 

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -474,7 +474,7 @@ function battery_char {
     fi
 }
 
-if ! command_exists battery_charge ; then
+if ! _command_exists battery_charge ; then
     # if user has installed battery plugin, skip this...
     function battery_charge (){
 	# no op
@@ -484,7 +484,7 @@ fi
 
 # The battery_char function depends on the presence of the battery_percentage function.
 # If battery_percentage is not defined, then define battery_char as a no-op.
-if ! command_exists battery_percentage ; then
+if ! _command_exists battery_percentage ; then
     function battery_char (){
 	# no op
 	echo -n

--- a/themes/brainy/brainy.theme.bash
+++ b/themes/brainy/brainy.theme.bash
@@ -152,7 +152,7 @@ ___brainy_prompt_clock() {
 }
 
 ___brainy_prompt_battery() {
-	! command_exists battery_percentage ||
+	! _command_exists battery_percentage ||
 	[ "${THEME_SHOW_BATTERY}" != "true" ] ||
 	[ "$(battery_percentage)" = "no" ] && return
 

--- a/themes/demula/demula.theme.bash
+++ b/themes/demula/demula.theme.bash
@@ -84,7 +84,7 @@ ${D_BRANCH_COLOR}%b %r ${D_CHANGES_COLOR}%m%u ${D_DEFAULT_COLOR}"
 
 # checks if the plugin is installed before calling battery_charge
 safe_battery_charge() {
-  if command_exists battery_charge ;
+  if _command_exists battery_charge ;
   then
     battery_charge
   fi

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -43,9 +43,9 @@ function __powerline_user_info_prompt {
 function __powerline_ruby_prompt {
   local ruby_version=""
 
-  if command_exists rvm; then
+  if _command_exists rvm; then
     ruby_version="$(rvm_version_prompt)"
-  elif command_exists rbenv; then
+  elif _command_exists rbenv; then
     ruby_version=$(rbenv_version_prompt)
   fi
 

--- a/themes/rana/rana.theme.bash
+++ b/themes/rana/rana.theme.bash
@@ -117,7 +117,7 @@ ${D_BRANCH_COLOR}%b %r ${D_CHANGES_COLOR}%m%u ${D_DEFAULT_COLOR}"
 
 # checks if the plugin is installed before calling battery_charge
 safe_battery_charge() {
-  if command_exists battery_charge ;
+  if _command_exists battery_charge ;
   then
     battery_charge
   fi


### PR DESCRIPTION
This PR includes the second half of the functionality discussed in #944.

What has been changed:

* When enabling components (aliases, completions or plugins), they are now enabled in a global `$BASH_IT/enabled` directory, instead of having separate directories per component type (e.g. `$BASH_IT/aliases/enabled`). This allows for more flexible ordering of the load priority, where aliases, completions and plugins are mixed, instead of loading them one by one. See #974 for the first half that allows for defining a load order/priority for each enabled component.
* Moved the `command_exists` function from the `base` plugin to an internal function called `_command_exists` in the `helpers.bash` file, to break the dependency on the `base` plugin. See #1009 for an example of an error.
* Added lots of additional unit tests for verifying that loading/enabling/disabling/search/show etc. all work with the new global `enabled` directory.
* Updated the `bash-it migrate` command to move enabled components from the local `enabled` directories to the new global one.
* Fixed some issues that `shellcheck` complained about.

I've been using this new functionality in my own fork for a couple of weeks now, without any issues.

I'll leave this PR open for a couple of days before merging it into the `master` branch.