### PR TITLE
Update brew completion

### DIFF
--- a/completion/available/brew.completion.bash
+++ b/completion/available/brew.completion.bash
@@ -1,6 +1,6 @@
 if which brew >/dev/null 2>&1; then
-  if [ -f `brew --prefix`/etc/bash_completion ]; then
-    . `brew --prefix`/etc/bash_completion
+  if [ -f `brew --prefix`/etc/bash_completion.d/brew ]; then
+    . `brew --prefix`/etc/bash_completion.d/brew
   fi
 
   if [ -f `brew --prefix`/Library/Contributions/brew_bash_completion.sh ]; then

--- a/completion/available/brew.completion.bash
+++ b/completion/available/brew.completion.bash
@@ -1,9 +1,11 @@
 if which brew >/dev/null 2>&1; then
-  if [ -f `brew --prefix`/etc/bash_completion.d/brew ]; then
-    . `brew --prefix`/etc/bash_completion.d/brew
+  BREW_PREFIX=$(brew --prefix)
+
+  if [ -f "$BREW_PREFIX"/etc/bash_completion.d/brew ]; then
+    . "$BREW_PREFIX"/etc/bash_completion.d/brew
   fi
 
-  if [ -f `brew --prefix`/Library/Contributions/brew_bash_completion.sh ]; then
-    . `brew --prefix`/Library/Contributions/brew_bash_completion.sh
+  if [ -f "$BREW_PREFIX"/Library/Contributions/brew_bash_completion.sh ]; then
+    . "$BREW_PREFIX"/Library/Contributions/brew_bash_completion.sh
   fi
 fi


### PR DESCRIPTION
Two commits, split for clarity.

The first addresses the brew bash completion file path, as discussed in #1046.

The second is a performance optimization to reduce the forks called during evaluation, as [seen in this pattern](https://github.com/Bash-it/bash-it/blob/a75a53b7863cd63d489bb3f8669c1b293278c52c/completion/available/system.completion.bash#L17-L22). A naive test for the second commit:

```console
$ sudo dtruss -f -t 'syscall::fork*' -c bash completion/available/brew.completion.bash 2>&1 | grep ^fork

### before
fork                                           25

### after
fork                                           15
```

Happy to squash, or split, depending on what is desired.