### PR TITLE
Do we need to explicity `rm` tempfiles?

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ For custom scripts, and aliases, just create the following files (they'll be ign
 
 Anything in the custom directory will be ignored, with the exception of `custom/example.bash`.
 
-Alternately, if you would like to keep your custom scripts under version control, you can set `BASH_IT_CUSTOM` in your `~/.bashrc` to another location outside of the `~/.bash_it` folder. In this case, any `*.bash` file under every directory below `BASH_IT_CUSTOM` folder will be used.
+Alternately, if you would like to keep your custom scripts under version control, you can set `BASH_IT_CUSTOM` in your `~/.bashrc` to another location outside of the `$BASH_IT` folder. In this case, any `*.bash` file under every directory below `BASH_IT_CUSTOM` folder will be used.
 
 ## Themes
 
-There are over 50+ Bash-it themes to pick from in `.bash_it/themes`. The default theme is `bobby`.  Set `BASH_IT_THEME` to the theme name you want, or if you've developed your own custom theme outside of `.bash_it/themes`, point the `BASH_IT_THEME` variable directly to the theme file.
+There are over 50+ Bash-it themes to pick from in `$BASH_IT/themes`. The default theme is `bobby`.  Set `BASH_IT_THEME` to the theme name you want, or if you've developed your own custom theme outside of `$BASH_IT/themes`, point the `BASH_IT_THEME` variable directly to the theme file.
 
 Examples:
 
@@ -195,7 +195,7 @@ This will restore your previous Bash profile. After the uninstall script finishe
 Bash-it creates a `reload` alias that makes it convenient to reload
 your Bash profile when you make changes.
 
-Additionally, if you export BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE as a non-null value, Bash-it will automatically reload itself after activating or deactivating plugins, aliases, or completions.
+Additionally, if you export `BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE` as a non-null value, Bash-it will automatically reload itself after activating or deactivating plugins, aliases, or completions.
 
 ### Prompt Version Control Check
 

--- a/lib/composure.bash
+++ b/lib/composure.bash
@@ -196,7 +196,7 @@ draft ()
         cmd=$(eval "history | grep '^[[:blank:]]*$num' | head -1" | sed 's/^[[:blank:][:digit:]]*//')
     fi
     eval "$func() { $cmd; }"
-    typeset file=$(mktemp /tmp/draft.XXXX)
+    typeset file=$(mktemp -t draft.XXXX)
     typeset -f $func > $file
     transcribe $func $file draft
     rm $file 2>/dev/null
@@ -300,7 +300,7 @@ revise ()
     group composure
 
     typeset func=$1
-    typeset temp=$(mktemp /tmp/revise.XXXX)
+    typeset temp=$(mktemp -t revise.XXXX)
 
     if [ -z "$func" ]; then
         printf '%s\n' 'missing parameter(s)'

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -500,7 +500,7 @@ _help-plugins()
 
     # display a brief progress message...
     printf '%s' 'please wait, building help...'
-    typeset grouplist=$(mktemp /tmp/grouplist.XXXXXX)
+    typeset grouplist=$(mktemp -t grouplist.XXXXXX)
     typeset func
     for func in $(typeset_functions)
     do
@@ -547,7 +547,7 @@ all_groups ()
     group 'lib'
 
     typeset func
-    typeset file=$(mktemp /tmp/composure.XXXX)
+    typeset file=$(mktemp -t composure.XXXX)
     for func in $(typeset_functions)
     do
         typeset -f $func | metafor group >> $file

--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -29,8 +29,7 @@ function alias_completion {
     (( ${#completions[@]} == 0 )) && return 0
 
     # create temporary file for wrapper functions and completions
-    rm -f "/tmp/${namespace}-*.tmp" # preliminary cleanup
-    local tmp_file; tmp_file="$(mktemp "/tmp/${namespace}-${RANDOM}XXX.tmp")" || return 1
+    local tmp_file; tmp_file="$(mktemp -t "${namespace}-${RANDOM}XXX.tmp")" || return 1
 
     local completion_loader; completion_loader="$(complete -p -D 2>/dev/null | sed -Ene 's/.* -F ([^ ]*).*/\1/p')"
 


### PR DESCRIPTION
https://github.com/Bash-it/bash-it/blob/517d4b2ca486945aa1bec3b496f946d3b8493350/plugins/available/alias-completion.plugin.bash#L32

This should normally be handled by the system, right?
The reason I'm asking is that in prefixed environments such as [Termux](https://wiki.termux.com/wiki/Differences_from_Linux) the temporary directory is not `/tmp`. 
A safer way to create temp files is to use `mktemp -t ` which will use `$TMPDIR` (or some other heuristics). 
Cleanup could also change to `rm $TMPDIR/...` but isn't it better to just leave that to the system? 