### PR TITLE
Update docker-compose plugin

### DIFF
--- a/plugins/available/docker-compose.plugin.bash
+++ b/plugins/available/docker-compose.plugin.bash
@@ -14,7 +14,7 @@ function docker-compose-fresh() {
   fi
 
   docker-compose $DCO_FILE_PARAM stop
-  docker-compose $DCO_FILE_PARAM rm -f --all
+  docker-compose $DCO_FILE_PARAM rm -f
   docker-compose $DCO_FILE_PARAM up -d
   docker-compose $DCO_FILE_PARAM logs -f --tail 100
 }


### PR DESCRIPTION
The `--all` flag was removed in docker-compose 1.7.0 last year. https://github.com/docker/compose/pull/3466

Currently produces:
```
WARNING: --all flag is obsolete. This is now the default behavior of `docker-compose rm`
```