### PR TITLE
Change default $GOPATH to $HOME/go

### DIFF
--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -7,5 +7,5 @@ about-plugin 'go environment variables & path configuration'
 
 export GOROOT=${GOROOT:-$(go env | grep GOROOT | cut -d'"' -f2)}
 pathmunge "${GOROOT}/bin"
-export GOPATH=${GOPATH:-"$HOME/.go"}
+export GOPATH=${GOPATH:-"$HOME/go"}
 pathmunge "${GOPATH}/bin"


### PR DESCRIPTION
As of Go v1.8, $HOME/go is the default $GOPATH. See https://github.com/golang/go/issues/17262 for the discussion.