### PR TITLE
Buf unit test

### DIFF
--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -51,6 +51,22 @@ load ../../plugins/available/base.plugin
 @test 'plugins base: buf()' {
   declare -r file="${BASH_IT_ROOT}/file"
   touch $file
+
+  # Take one timestamp before running the `buf` function
+  declare -r stamp1=$(date +%Y%m%d_%H%M%S)
+
   run buf $file
-  assert_file_exist ${file}_$(date +%Y%m%d_%H%M%S)
+
+  # Take another timestamp after running `buf`.
+  declare -r stamp2=$(date +%Y%m%d_%H%M%S)
+
+  # Verify that the backup file ends with one of the two timestamps.
+  # This is done to avoid race conditions where buf is run close to the end
+  # of a second, in which case the second timestamp might be in the next second,
+  # causing the test to fail.
+  # By using `or` for the two checks, we can verify that one of the two files is present.
+  # In most cases, it's going to have the same timestamp anyway.
+  # We can't use `assert_file_exist` here, since it only checks for a single file name.
+  assert [ -e "${file}_${stamp1}" \
+    -o -e "${file}_${stamp2}" ]
 }

--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -36,8 +36,15 @@ load ../../plugins/available/base.plugin
 
 @test 'plugins base: mkcd()' {
   cd "${BASH_IT_ROOT}"
-  run mkcd -dir_with_dash
+  declare -r dir_name="-dir_with_dash"
+
+  # Make sure that the directory does not exist prior to the test
+  rm -rf "${BASH_IT_ROOT}/${dir_name}"
+
+  mkcd "${dir_name}"
   assert_success
+  assert_file_exist "${BASH_IT_ROOT}/${dir_name}"
+  assert_equal $(pwd) "${BASH_IT_ROOT}/${dir_name}"
 }
 
 @test 'plugins base: lsgrep()' {
@@ -45,7 +52,7 @@ load ../../plugins/available/base.plugin
   cd $BASH_IT_TEST_DIR
   run lsgrep 2
   assert_success
-  assert_equal 2 $output
+  assert_equal $output 2
 }
 
 @test 'plugins base: buf()' {

--- a/test/run
+++ b/test/run
@@ -5,7 +5,9 @@ bats_executable="${test_directory}/../test_lib/bats-core/bin/bats"
 git submodule init && git submodule update
 
 if [ -z "${BASH_IT}" ]; then
-  export BASH_IT=$(cd ${test_directory} && dirname $(pwd))
+  declare BASH_IT
+  BASH_IT=$(cd ${test_directory} && dirname "$(pwd)")
+  export BASH_IT
 fi
 
 exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}


### PR DESCRIPTION
Fixes #1059 

Checking for several file names as part of the test for the `buf` function, since that seems to fail from time to time (corner case).

Also fixed a couple of smaller issues in the test cases for the base plugin.