### PR TITLE
Add ability to specify the path color

### DIFF
--- a/themes/purity/purity.theme.bash
+++ b/themes/purity/purity.theme.bash
@@ -12,10 +12,11 @@ GIT_THEME_PROMPT_SUFFIX=" ${reset_color})"
 
 STATUS_THEME_PROMPT_BAD="${bold_red}❯${reset_color}${normal} "
 STATUS_THEME_PROMPT_OK="${bold_green}❯${reset_color}${normal} "
+PURITY_THEME_PROMPT_COLOR="${PURITY_THEME_PROMPT_COLOR:=$blue}"
 
 function prompt_command() {
     local ret_status="$( [ $? -eq 0 ] && echo -e "$STATUS_THEME_PROMPT_OK" || echo -e "$STATUS_THEME_PROMPT_BAD")"
-    PS1="\n${blue}\w $(scm_prompt_info)\n${ret_status} "
+    PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status} "
 }
 
 safe_append_prompt_command prompt_command


### PR DESCRIPTION
By specifying `PURITY_THEME_PROMPT_COLOR` in your environment you can change the path to a different color. Useful for signifying that you're in a particular environment and such.