### PR TITLE
Use custom SDKMAN_DIR if set

### DIFF
--- a/plugins/available/sdkman.plugin.bash
+++ b/plugins/available/sdkman.plugin.bash
@@ -1,5 +1,9 @@
 cite about-plugin
 about-plugin 'Load Software Development Kit Manager'
 
-export SDKMAN_DIR="$HOME/.sdkman"
+# Use $SDKMAN_DIR if defined,
+# otherwise default to ~/.sdkman
+export SDKMAN_DIR=${SDKMAN_DIR:-$HOME/.sdkman}
+
 [[ -s "${SDKMAN_DIR}/bin/sdkman-init.sh" ]] && source "${SDKMAN_DIR}/bin/sdkman-init.sh"
+


### PR DESCRIPTION
sdkman can be installed to any [arbitrary directory ](http://sdkman.io/install.html) by way of setting `SDKMAN_DIR`.

This is a small change to the sdkman plugin to use `SDKMAN_DIR` if already set, and fall back to `$HOME/.sdkman` if not.