### PR TITLE
fixed awskeys with all profiles

### DIFF
--- a/plugins/available/aws.plugin.bash
+++ b/plugins/available/aws.plugin.bash
@@ -42,7 +42,7 @@ function __awskeys_get {
 }
 
 function __awskeys_list {
-    local credentials_list="$(egrep '^\[ *[a-zA-Z0-9_-]+ *\]$' ~/.aws/credentials)"
+    local credentials_list="$((egrep '^\[ *[a-zA-Z0-9_-]+ *\]$' ~/.aws/credentials; grep "\[profile" ~/.aws/config | sed "s|\[profile |\[|g") | sort | uniq)"
     if [[ -n $"{credentials_list}" ]]; then
         echo -e "Available credentials profiles:\n"
         for profile in ${credentials_list}; do
@@ -64,12 +64,14 @@ function __awskeys_show {
 }
 
 function __awskeys_export {
-    local p_keys=( $(__awskeys_get $1 | tr -d " ") )
-    if [[ -n "${p_keys}" ]]; then
-        for p_key in ${p_keys[@]}; do
-            local key="${p_key%=*}"
-            export "$(echo ${key} | tr [:lower:] [:upper:])=${p_key#*=}"
-        done
+    if [[ $(__awskeys_list) == *"$1"* ]]; then
+        local p_keys=( $(__awskeys_get $1 | tr -d " ") )
+        if [[ -n "${p_keys}" ]]; then
+            for p_key in ${p_keys[@]}; do
+                local key="${p_key%=*}"
+                export "$(echo ${key} | tr [:lower:] [:upper:])=${p_key#*=}"
+            done
+        fi
         export AWS_DEFAULT_PROFILE="$1"
     else
         echo "Profile $1 not found in credentials file"


### PR DESCRIPTION
This change adds the support to assumed role profiles. To have the full list of profiles it gets it from .aws/config