### PR TITLE
Fixed battery low 

### DIFF
--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -55,8 +55,8 @@ battery_percentage(){
 
   if _command_exists upower;
   then
-    local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage | tail --bytes 5)
-    echo ${UPOWER_OUTPUT: : -1}
+    local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage | grep -o "[0-9]\+" | head -1)
+    echo ${UPOWER_OUTPUT:--1}
   elif _command_exists acpi;
   then
     local ACPI_OUTPUT=$(acpi -b)

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -66,7 +66,7 @@ battery_percentage(){
     COMMAND_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -1)
   elif _command_exists ioreg;
   then
-    COMMAND_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%d"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
+    COMMAND_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}' | grep -o "[0-9]\+" | head -1)
   elif _command_exists WMIC;
   then
     COMMAND_OUTPUT=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -1)

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -53,29 +53,28 @@ battery_percentage(){
   about 'displays battery charge as a percentage of full (100%)'
   group 'battery'
 
+  declare COMMAND_OUTPUT="no"
+
   if _command_exists upower;
   then
-    local UPOWER_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage | grep -o "[0-9]\+" | head -1)
-    echo ${UPOWER_OUTPUT:--1}
+    COMMAND_OUTPUT=$(upower --show-info $(upower --enumerate | grep BAT) | grep percentage | grep -o "[0-9]\+" | head -1)
   elif _command_exists acpi;
   then
-    local PERC_OUTPUT=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
-    echo ${PERC_OUTPUT:--1}
+    COMMAND_OUTPUT=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
   elif _command_exists pmset;
   then
-    local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -1)
-    echo ${PMSET_OUTPUT:--1}
+    COMMAND_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -1)
   elif _command_exists ioreg;
   then
-    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%d"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
-    echo ${IOREG_OUTPUT:--1}
+    COMMAND_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%d"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
   elif _command_exists WMIC;
   then
-    local WINPC=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -1)
-    echo ${WINPC:--1}
+    COMMAND_OUTPUT=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -1)
   else
-    echo "no"
+    COMMAND_OUTPUT="no"
   fi
+
+  echo ${COMMAND_OUTPUT:--1}
 }
 
 battery_charge(){

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -72,15 +72,8 @@ battery_percentage(){
     echo ${IOREG_OUTPUT:--1}
   elif _command_exists WMIC;
   then
-    local WINPC=$(echo porcent=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List) | grep -o '[0-9]*')
-    case $WINPC in
-      100*)
-        echo '100'
-      ;;
-      *)
-        echo $WINPC
-      ;;
-    esac
+    local WINPC=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -1)
+    echo ${WINPC:--1}
   else
     echo "no"
   fi

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -64,32 +64,12 @@ battery_percentage(){
     echo ${PERC_OUTPUT:--1}
   elif _command_exists pmset;
   then
-    local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p')
-    case $PMSET_OUTPUT in
-      100*)
-        echo '100'
-      ;;
-      *)
-        # This will cut off any decimals, and will get rid of the optional percentage sign at the end, too.
-        # Works for:
-        # - 100%
-        # - 100.0%
-        # - 99.8%
-        # - 4%
-        echo $PMSET_OUTPUT | grep -o "[0-9]\+" | head -1
-      ;;
-    esac
+    local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -1)
+    echo ${PMSET_OUTPUT:--1}
   elif _command_exists ioreg;
   then
-    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
-    case $IOREG_OUTPUT in
-      100*)
-        echo '100'
-      ;;
-      *)
-        echo $IOREG_OUTPUT | head -c 2
-      ;;
-    esac
+    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}'  | grep -o "[0-9]\+" | head -1)
+    echo ${IOREG_OUTPUT:--1}
   elif _command_exists WMIC;
   then
     local WINPC=$(echo porcent=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List) | grep -o '[0-9]*')

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -74,7 +74,11 @@ battery_percentage(){
     COMMAND_OUTPUT="no"
   fi
 
-  printf "%02d" "${COMMAND_OUTPUT:--1}"
+  if [ "${COMMAND_OUTPUT}" != "no" ]; then
+    printf "%02d" "${COMMAND_OUTPUT:--1}"
+  else
+    echo "${COMMAND_OUTPUT}"
+  fi
 }
 
 battery_charge(){

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -60,30 +60,8 @@ battery_percentage(){
   elif _command_exists acpi;
   then
     local ACPI_OUTPUT=$(acpi -b)
-    case $ACPI_OUTPUT in
-      *" Unknown"*)
-        local PERC_OUTPUT=$(echo $ACPI_OUTPUT | head -c 22 | tail -c 2)
-        case $PERC_OUTPUT in
-          *%)
-            echo "0${PERC_OUTPUT}" | head -c 2
-          ;;
-          *)
-            echo ${PERC_OUTPUT}
-          ;;
-        esac
-      ;;
-
-      *" Charging"* | *" Discharging"*)
-        local PERC_OUTPUT=$(echo $ACPI_OUTPUT | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
-        echo ${PERC_OUTPUT}
-      ;;
-      *" Full"*)
-        echo '100'
-      ;;
-      *)
-        echo '-1'
-      ;;
-    esac
+    local PERC_OUTPUT=$(echo $ACPI_OUTPUT | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
+    echo ${PERC_OUTPUT:--1}
   elif _command_exists pmset;
   then
     local PMSET_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p')

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -74,7 +74,7 @@ battery_percentage(){
     COMMAND_OUTPUT="no"
   fi
 
-  echo ${COMMAND_OUTPUT:--1}
+  printf "%02d" "${COMMAND_OUTPUT:--1}"
 }
 
 battery_charge(){

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -59,8 +59,7 @@ battery_percentage(){
     echo ${UPOWER_OUTPUT:--1}
   elif _command_exists acpi;
   then
-    local ACPI_OUTPUT=$(acpi -b)
-    local PERC_OUTPUT=$(echo $ACPI_OUTPUT | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
+    local PERC_OUTPUT=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
     echo ${PERC_OUTPUT:--1}
   elif _command_exists pmset;
   then

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -68,7 +68,7 @@ battery_percentage(){
     echo ${PMSET_OUTPUT:--1}
   elif _command_exists ioreg;
   then
-    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f%%"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}'  | grep -o "[0-9]\+" | head -1)
+    local IOREG_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%d"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}')
     echo ${IOREG_OUTPUT:--1}
   elif _command_exists WMIC;
   then

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -92,7 +92,13 @@ battery_percentage(){
         echo '100'
       ;;
       *)
-        echo $PMSET_OUTPUT | head -c 2
+        # This will cut off any decimals, and will get rid of the optional percentage sign at the end, too.
+        # Works for:
+        # - 100%
+        # - 100.0%
+        # - 99.8%
+        # - 4%
+        echo $PMSET_OUTPUT | grep -o "[0-9]\+" | head -1
       ;;
     esac
   elif _command_exists ioreg;

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -10,12 +10,6 @@ load ../../plugins/available/battery.plugin
 function setup_command_exists_pmset {
   function _command_exists {
     case "$1" in
-      "upower")
-        false
-      ;;
-      "acpi")
-        false
-      ;;
       "pmset")
         true
       ;;

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -26,12 +26,18 @@ function setup_command_exists_pmset {
   }
 }
 
+function setup_pmset {
+  percent="$1"
+
+  function pmset {
+    echo "-InternalBattery-0 (id=12345)	""${percent}""; discharging; 16:00 remaining present: true"
+  }
+}
+
 @test 'plugins battery: battery-percentage with pmset, 100%' {
   setup_command_exists_pmset
 
-  function pmset {
-    echo "-InternalBattery-0 (id=12345)	100%; discharging; 16:00 remaining present: true"
-  }
+  setup_pmset "100%"
 
   run battery_percentage
   assert_output "100"
@@ -40,9 +46,7 @@ function setup_command_exists_pmset {
 @test 'plugins battery: battery-percentage with pmset, 98%' {
   setup_command_exists_pmset
 
-  function pmset {
-    echo "-InternalBattery-0 (id=12345)	98%; discharging; 16:00 remaining present: true"
-  }
+  setup_pmset "98%"
 
   run battery_percentage
   assert_output "98"
@@ -51,9 +55,7 @@ function setup_command_exists_pmset {
 @test 'plugins battery: battery-percentage with pmset, 98.5%' {
   setup_command_exists_pmset
 
-  function pmset {
-    echo "-InternalBattery-0 (id=12345)	98.5%; discharging; 16:00 remaining present: true"
-  }
+  setup_pmset "98.5%"
 
   run battery_percentage
   assert_output "98"
@@ -62,9 +64,7 @@ function setup_command_exists_pmset {
 @test 'plugins battery: battery-percentage with pmset, 4%' {
   setup_command_exists_pmset
 
-  function pmset {
-    echo "-InternalBattery-0 (id=12345)	4%; discharging; 16:00 remaining present: true"
-  }
+  setup_pmset "4%"
 
   run battery_percentage
   assert_output "4"

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -7,6 +7,18 @@ cite _about _param _example _group _author _version
 
 load ../../plugins/available/battery.plugin
 
+# Sets up the `_command_exists` function so that it only responds `true` if called with
+# the name of the function that was passed in as an argument to `setup_command_exists`.
+# This is used to ensure that the test cases can test the various energy management tools
+# without actually having them. When called like
+#
+# setup_command_exists "pmset"
+#
+# then calling `_command_exists "pmset"` will return `true`,
+# while calling `_command_exists "ioreg"` (or other commands) will return `false`.
+#
+# It's cool that Bash allows to define functions within functions, works almost like
+# a closure in JavaScript.
 function setup_command_exists {
   success_command="$1"
 
@@ -27,6 +39,8 @@ function setup_command_exists {
 # pmset
 #
 
+# Creates a `pmset` function that simulates output like the real `pmset` command.
+# The passed in parameter is used for the remaining battery percentage.
 function setup_pmset {
   percent="$1"
 
@@ -85,6 +99,10 @@ function setup_pmset {
 # acpi
 #
 
+# Creates a `acpi` function that simulates output like the real `acpi` command.
+# The passed in parameters are used for
+# 1) the remaining battery percentage.
+# 2) the battery status
 function setup_acpi {
   percent="$1"
   status="$2"
@@ -162,6 +180,8 @@ function setup_acpi {
 # upower
 #
 
+# Creates a `upower` function that simulates output like the real `upower` command.
+# The passed in parameter is used for the remaining battery percentage.
 function setup_upower {
   percent="$1"
 
@@ -220,6 +240,8 @@ function setup_upower {
 # ioreg
 #
 
+# Creates a `ioreg` function that simulates output like the real `ioreg` command.
+# The passed in parameter is used for the remaining battery percentage.
 function setup_ioreg {
   percent="$1"
 
@@ -278,6 +300,8 @@ function setup_ioreg {
 # WMIC
 #
 
+# Creates a `WMIC` function that simulates output like the real `WMIC` command.
+# The passed in parameter is used for the remaining battery percentage.
 function setup_WMIC {
   percent="$1"
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -5,10 +5,30 @@ load ../../lib/composure
 
 cite _about _param _example _group _author _version
 
-load ../../lib/helpers
 load ../../plugins/available/battery.plugin
 
+function setup_command_exists_pmset {
+  function _command_exists {
+    case "$1" in
+      "upower")
+        false
+      ;;
+      "acpi")
+        false
+      ;;
+      "pmset")
+        true
+      ;;
+      *)
+        false
+      ;;
+    esac
+  }
+}
+
 @test 'plugins battery: battery-percentage with pmset, 100%' {
+  setup_command_exists_pmset
+
   function pmset {
     echo "-InternalBattery-0 (id=12345)	100%; discharging; 16:00 remaining present: true"
   }
@@ -18,6 +38,8 @@ load ../../plugins/available/battery.plugin
 }
 
 @test 'plugins battery: battery-percentage with pmset, 98%' {
+  setup_command_exists_pmset
+
   function pmset {
     echo "-InternalBattery-0 (id=12345)	98%; discharging; 16:00 remaining present: true"
   }
@@ -27,6 +49,8 @@ load ../../plugins/available/battery.plugin
 }
 
 @test 'plugins battery: battery-percentage with pmset, 98.5%' {
+  setup_command_exists_pmset
+
   function pmset {
     echo "-InternalBattery-0 (id=12345)	98.5%; discharging; 16:00 remaining present: true"
   }
@@ -36,6 +60,8 @@ load ../../plugins/available/battery.plugin
 }
 
 @test 'plugins battery: battery-percentage with pmset, 4%' {
+  setup_command_exists_pmset
+
   function pmset {
     echo "-InternalBattery-0 (id=12345)	4%; discharging; 16:00 remaining present: true"
   }

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -7,10 +7,12 @@ cite _about _param _example _group _author _version
 
 load ../../plugins/available/battery.plugin
 
-function setup_command_exists_pmset {
+function setup_command_exists {
+  success_command="$1"
+
   function _command_exists {
     case "$1" in
-      "pmset")
+      "${success_command}")
         true
       ;;
       *)
@@ -29,7 +31,7 @@ function setup_pmset {
 }
 
 @test 'plugins battery: battery-percentage with pmset, 100%' {
-  setup_command_exists_pmset
+  setup_command_exists "pmset"
 
   setup_pmset "100%"
 
@@ -38,7 +40,7 @@ function setup_pmset {
 }
 
 @test 'plugins battery: battery-percentage with pmset, 98%' {
-  setup_command_exists_pmset
+  setup_command_exists "pmset"
 
   setup_pmset "98%"
 
@@ -47,7 +49,7 @@ function setup_pmset {
 }
 
 @test 'plugins battery: battery-percentage with pmset, 98.5%' {
-  setup_command_exists_pmset
+  setup_command_exists "pmset"
 
   setup_pmset "98.5%"
 
@@ -56,7 +58,7 @@ function setup_pmset {
 }
 
 @test 'plugins battery: battery-percentage with pmset, 4%' {
-  setup_command_exists_pmset
+  setup_command_exists "pmset"
 
   setup_pmset "4%"
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -289,10 +289,13 @@ function setup_ioreg {
 @test 'plugins battery: battery-percentage with ioreg, no status' {
   setup_command_exists "ioreg"
 
-  setup_ioreg ""
+  # Simulate that no battery is present
+  function ioreg {
+    printf ""
+  }
 
   run battery_percentage
-  assert_output "00"
+  assert_output "-1"
 }
 
 #######################

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -80,7 +80,7 @@ function setup_acpi {
   percent="$1"
 
   function acpi {
-    echo "-InternalBattery-0 (id=12345)	""${percent}""; discharging; 16:00 remaining present: true"
+    printf "Battery 0: Charging, %s, 01:02:48 until charged" "${percent}"
   }
 }
 
@@ -97,15 +97,6 @@ function setup_acpi {
   setup_command_exists "acpi"
 
   setup_acpi "98%"
-
-  run battery_percentage
-  assert_output "98"
-}
-
-@test 'plugins battery: battery-percentage with acpi, 98.5%' {
-  setup_command_exists "acpi"
-
-  setup_acpi "98.5%"
 
   run battery_percentage
   assert_output "98"

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -36,6 +36,18 @@ function setup_command_exists {
 
 #######################
 #
+# no tool
+#
+
+@test 'plugins battery: battery-percentage with no tool' {
+  setup_command_exists "fooooo"
+
+  run battery_percentage
+  assert_output "no"
+}
+
+#######################
+#
 # pmset
 #
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -129,14 +129,14 @@ function setup_upower {
   percent="$1"
 
   function upower {
-    echo "-InternalBattery-0 (id=12345)	""${percent}""; discharging; 16:00 remaining present: true"
+    printf "voltage:             12.191 V\n    time to full:        57.3 minutes\n    percentage:          %s\n    capacity:            84.6964" "${percent}"
   }
 }
 
 @test 'plugins battery: battery-percentage with upower, 100%' {
   setup_command_exists "upower"
 
-  setup_upower "100%"
+  setup_upower "100.00%"
 
   run battery_percentage
   assert_output "100"
@@ -145,7 +145,7 @@ function setup_upower {
 @test 'plugins battery: battery-percentage with upower, 98%' {
   setup_command_exists "upower"
 
-  setup_upower "98%"
+  setup_upower "98.4567%"
 
   run battery_percentage
   assert_output "98"
@@ -163,10 +163,19 @@ function setup_upower {
 @test 'plugins battery: battery-percentage with upower, 4%' {
   setup_command_exists "upower"
 
-  setup_upower "4%"
+  setup_upower "4.2345%"
 
   run battery_percentage
   assert_output "4"
+}
+
+@test 'plugins battery: battery-percentage with upower, no output' {
+  setup_command_exists "upower"
+
+  setup_upower ""
+
+  run battery_percentage
+  assert_output "-1"
 }
 
 #######################

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -22,6 +22,11 @@ function setup_command_exists {
   }
 }
 
+#######################
+#
+# pmset
+#
+
 function setup_pmset {
   percent="$1"
 
@@ -61,6 +66,153 @@ function setup_pmset {
   setup_command_exists "pmset"
 
   setup_pmset "4%"
+
+  run battery_percentage
+  assert_output "4"
+}
+
+#######################
+#
+# acpi
+#
+
+function setup_acpi {
+  percent="$1"
+
+  function acpi {
+    echo "-InternalBattery-0 (id=12345)	""${percent}""; discharging; 16:00 remaining present: true"
+  }
+}
+
+@test 'plugins battery: battery-percentage with acpi, 100%' {
+  setup_command_exists "acpi"
+
+  setup_acpi "100%"
+
+  run battery_percentage
+  assert_output "100"
+}
+
+@test 'plugins battery: battery-percentage with acpi, 98%' {
+  setup_command_exists "acpi"
+
+  setup_acpi "98%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with acpi, 98.5%' {
+  setup_command_exists "acpi"
+
+  setup_acpi "98.5%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with acpi, 4%' {
+  setup_command_exists "acpi"
+
+  setup_acpi "4%"
+
+  run battery_percentage
+  assert_output "4"
+}
+
+#######################
+#
+# upower
+#
+
+function setup_upower {
+  percent="$1"
+
+  function upower {
+    echo "-InternalBattery-0 (id=12345)	""${percent}""; discharging; 16:00 remaining present: true"
+  }
+}
+
+@test 'plugins battery: battery-percentage with upower, 100%' {
+  setup_command_exists "upower"
+
+  setup_upower "100%"
+
+  run battery_percentage
+  assert_output "100"
+}
+
+@test 'plugins battery: battery-percentage with upower, 98%' {
+  setup_command_exists "upower"
+
+  setup_upower "98%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with upower, 98.5%' {
+  setup_command_exists "upower"
+
+  setup_upower "98.5%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with upower, 4%' {
+  setup_command_exists "upower"
+
+  setup_upower "4%"
+
+  run battery_percentage
+  assert_output "4"
+}
+
+#######################
+#
+# ioreg
+#
+
+function setup_ioreg {
+  percent="$1"
+
+  function ioreg {
+    printf "\"MaxCapacity\" = 100\n\"CurrentCapacity\" = %s" "${percent}"
+  }
+}
+
+@test 'plugins battery: battery-percentage with ioreg, 100%' {
+  setup_command_exists "ioreg"
+
+  setup_ioreg "100%"
+
+  run battery_percentage
+  assert_output "100"
+}
+
+@test 'plugins battery: battery-percentage with ioreg, 98%' {
+  setup_command_exists "ioreg"
+
+  setup_ioreg "98%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with ioreg, 98.5%' {
+  setup_command_exists "ioreg"
+
+  setup_ioreg "98.5%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with ioreg, 4%' {
+  setup_command_exists "ioreg"
+
+  setup_ioreg "4%"
 
   run battery_percentage
   assert_output "4"

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -68,7 +68,7 @@ function setup_pmset {
   setup_pmset "4%"
 
   run battery_percentage
-  assert_output "4"
+  assert_output "04"
 }
 
 @test 'plugins battery: battery-percentage with pmset, no status' {
@@ -136,7 +136,7 @@ function setup_acpi {
   setup_acpi "4%" "Charging"
 
   run battery_percentage
-  assert_output "4"
+  assert_output "04"
 }
 
 @test 'plugins battery: battery-percentage with acpi, 4% no status' {
@@ -145,7 +145,7 @@ function setup_acpi {
   setup_acpi "4%" ""
 
   run battery_percentage
-  assert_output "4"
+  assert_output "04"
 }
 
 @test 'plugins battery: battery-percentage with acpi, no status' {
@@ -203,7 +203,7 @@ function setup_upower {
   setup_upower "4.2345%"
 
   run battery_percentage
-  assert_output "4"
+  assert_output "04"
 }
 
 @test 'plugins battery: battery-percentage with upower, no output' {
@@ -261,7 +261,7 @@ function setup_ioreg {
   setup_ioreg "4%"
 
   run battery_percentage
-  assert_output "4"
+  assert_output "04"
 }
 
 @test 'plugins battery: battery-percentage with ioreg, no status' {
@@ -270,7 +270,7 @@ function setup_ioreg {
   setup_ioreg ""
 
   run battery_percentage
-  assert_output "0"
+  assert_output "00"
 }
 
 #######################
@@ -319,7 +319,7 @@ function setup_WMIC {
   setup_WMIC "4%"
 
   run battery_percentage
-  assert_output "4"
+  assert_output "04"
 }
 
 @test 'plugins battery: battery-percentage with WMIC, no status' {

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -26,6 +26,15 @@ load ../../plugins/available/battery.plugin
   assert_output "98"
 }
 
+@test 'plugins battery: battery-percentage with pmset, 98.5%' {
+  function pmset {
+    echo "-InternalBattery-0 (id=12345)	98.5%; discharging; 16:00 remaining present: true"
+  }
+
+  run battery_percentage
+  assert_output "98"
+}
+
 @test 'plugins battery: battery-percentage with pmset, 4%' {
   function pmset {
     echo "-InternalBattery-0 (id=12345)	4%; discharging; 16:00 remaining present: true"

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -31,7 +31,7 @@ function setup_pmset {
   percent="$1"
 
   function pmset {
-    echo "-InternalBattery-0 (id=12345)	""${percent}""; discharging; 16:00 remaining present: true"
+    printf "\-InternalBattery-0 (id=12345)	%s; discharging; 16:00 remaining present: true" "${percent}"
   }
 }
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -136,6 +136,15 @@ function setup_acpi {
   setup_acpi "4%" ""
 
   run battery_percentage
+  assert_output "4"
+}
+
+@test 'plugins battery: battery-percentage with acpi, no status' {
+  setup_command_exists "acpi"
+
+  setup_acpi "" ""
+
+  run battery_percentage
   assert_output "-1"
 }
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -71,6 +71,15 @@ function setup_pmset {
   assert_output "4"
 }
 
+@test 'plugins battery: battery-percentage with pmset, no status' {
+  setup_command_exists "pmset"
+
+  setup_pmset ""
+
+  run battery_percentage
+  assert_output "-1"
+}
+
 #######################
 #
 # acpi
@@ -253,4 +262,13 @@ function setup_ioreg {
 
   run battery_percentage
   assert_output "4"
+}
+
+@test 'plugins battery: battery-percentage with ioreg, no status' {
+  setup_command_exists "ioreg"
+
+  setup_ioreg ""
+
+  run battery_percentage
+  assert_output "0"
 }

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+load ../../lib/composure
+
+cite _about _param _example _group _author _version
+
+load ../../lib/helpers
+load ../../plugins/available/battery.plugin
+
+@test 'plugins battery: battery-percentage with pmset, 100%' {
+  function pmset {
+    echo "-InternalBattery-0 (id=12345)	100%; discharging; 16:00 remaining present: true"
+  }
+
+  run battery_percentage
+  assert_output "100"
+}
+
+@test 'plugins battery: battery-percentage with pmset, 98%' {
+  function pmset {
+    echo "-InternalBattery-0 (id=12345)	98%; discharging; 16:00 remaining present: true"
+  }
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with pmset, 4%' {
+  function pmset {
+    echo "-InternalBattery-0 (id=12345)	4%; discharging; 16:00 remaining present: true"
+  }
+
+  run battery_percentage
+  assert_output "4"
+}

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -78,37 +78,65 @@ function setup_pmset {
 
 function setup_acpi {
   percent="$1"
+  status="$2"
 
   function acpi {
-    printf "Battery 0: Charging, %s, 01:02:48 until charged" "${percent}"
+    printf "Battery 0: %s, %s, 01:02:48 until charged" "${status}" "${percent}"
   }
 }
 
-@test 'plugins battery: battery-percentage with acpi, 100%' {
+@test 'plugins battery: battery-percentage with acpi, 100% Full' {
   setup_command_exists "acpi"
 
-  setup_acpi "100%"
+  setup_acpi "100%" "Full"
 
   run battery_percentage
   assert_output "100"
 }
 
-@test 'plugins battery: battery-percentage with acpi, 98%' {
+@test 'plugins battery: battery-percentage with acpi, 98% Charging' {
   setup_command_exists "acpi"
 
-  setup_acpi "98%"
+  setup_acpi "98%" "Charging"
 
   run battery_percentage
   assert_output "98"
 }
 
-@test 'plugins battery: battery-percentage with acpi, 4%' {
+@test 'plugins battery: battery-percentage with acpi, 98% Discharging' {
   setup_command_exists "acpi"
 
-  setup_acpi "4%"
+  setup_acpi "98%" "Discharging"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with acpi, 98% Unknown' {
+  setup_command_exists "acpi"
+
+  setup_acpi "98%" "Unknown"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with acpi, 4% Charging' {
+  setup_command_exists "acpi"
+
+  setup_acpi "4%" "Charging"
 
   run battery_percentage
   assert_output "4"
+}
+
+@test 'plugins battery: battery-percentage with acpi, 4% no status' {
+  setup_command_exists "acpi"
+
+  setup_acpi "4%" ""
+
+  run battery_percentage
+  assert_output "-1"
 }
 
 #######################

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -272,3 +272,61 @@ function setup_ioreg {
   run battery_percentage
   assert_output "0"
 }
+
+#######################
+#
+# WMIC
+#
+
+function setup_WMIC {
+  percent="$1"
+
+  function WMIC {
+    printf "Charge: %s" "${percent}"
+  }
+}
+
+@test 'plugins battery: battery-percentage with WMIC, 100%' {
+  setup_command_exists "WMIC"
+
+  setup_WMIC "100%"
+
+  run battery_percentage
+  assert_output "100"
+}
+
+@test 'plugins battery: battery-percentage with WMIC, 98%' {
+  setup_command_exists "WMIC"
+
+  setup_WMIC "98%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with WMIC, 98.5%' {
+  setup_command_exists "WMIC"
+
+  setup_WMIC "98.5%"
+
+  run battery_percentage
+  assert_output "98"
+}
+
+@test 'plugins battery: battery-percentage with WMIC, 4%' {
+  setup_command_exists "WMIC"
+
+  setup_WMIC "4%"
+
+  run battery_percentage
+  assert_output "4"
+}
+
+@test 'plugins battery: battery-percentage with WMIC, no status' {
+  setup_command_exists "WMIC"
+
+  setup_WMIC ""
+
+  run battery_percentage
+  assert_output "-1"
+}

--- a/test/run
+++ b/test/run
@@ -10,4 +10,10 @@ if [ -z "${BASH_IT}" ]; then
   export BASH_IT
 fi
 
-exec $bats_executable ${CI:+--tap} ${test_directory}/{bash_it,completion,install,lib,plugins,themes}
+if [ -z "$1" ]; then
+  test_dirs=( ${test_directory}/{bash_it,completion,install,lib,plugins,themes} )
+else
+  test_dirs=( "$1" )
+fi
+
+exec $bats_executable ${CI:+--tap} "${test_dirs[@]}"


### PR DESCRIPTION
Fixes #1022 
This could also help with #948 

Added lots of test case for the `battery_percentage` function, and tried to consolidate the output format for the function, all numbers should be formatted as two digits with leading zeroes (except for the "100").

Since this has only been tested with the test cases, it would be good if people with different operating systems (Linux, Windows) could test this locally...