### PR TITLE
Allow theming git stash chars

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -39,6 +39,8 @@ SCM_GIT_BEHIND_CHAR="↓"
 SCM_GIT_UNTRACKED_CHAR="?:"
 SCM_GIT_UNSTAGED_CHAR="U:"
 SCM_GIT_STAGED_CHAR="S:"
+SCM_GIT_STASH_CHAR_PREFIX="{"
+SCM_GIT_STASH_CHAR_SUFFIX="}"
 
 SCM_HG='hg'
 SCM_HG_CHAR='☿'
@@ -271,7 +273,7 @@ function git_prompt_vars {
   [[ "${status}" =~ ${behind_re} ]] && SCM_BRANCH+=" ${SCM_GIT_BEHIND_CHAR}${BASH_REMATCH[1]}"
 
   local stash_count="$(git stash list 2> /dev/null | wc -l | tr -d ' ')"
-  [[ "${stash_count}" -gt 0 ]] && SCM_BRANCH+=" {${stash_count}}"
+  [[ "${stash_count}" -gt 0 ]] && SCM_BRANCH+=" ${SCM_GIT_STASH_CHAR_PREFIX}${stash_count}${SCM_GIT_STASH_CHAR_SUFFIX}"
 
   SCM_BRANCH+=${details}
 


### PR DESCRIPTION
This PR allows to theme the git stash count and it keeps the same color as the git branch.

<img width="388" alt="screen shot 2017-11-10 at 20 15 16" src="https://user-images.githubusercontent.com/597332/32676813-f83d4ffe-c653-11e7-9be5-775b89176a41.png">

With this PR, the style of the stash count can be changed:

<img width="343" alt="screen shot 2017-11-10 at 20 17 29" src="https://user-images.githubusercontent.com/597332/32676897-3a01dcfc-c654-11e7-89d5-5fe0fe75b916.png">

The PR introduces 2 new attributes: `SCM_GIT_STASH_CHAR_PREFIX` and `SCM_GIT_STASH_CHAR_SUFFIX`. I would prefer to keep consistency with the other git attributes, but this way it keeps compatibility with current themes.
