### PR TITLE
bash-it themes must not set the TERM variable

### DIFF
--- a/themes/axin/axin.theme.bash
+++ b/themes/axin/axin.theme.bash
@@ -3,10 +3,6 @@
 # Axin Bash Prompt, inspired by theme "Sexy" and "Bobby"
 # thanks to them
 
-if [[ $COLORTERM = gnome-* && $TERM = xterm ]]  && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
-elif [[ $TERM != dumb ]] && infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
-fi
-
 if tput setaf 1 &> /dev/null; then
     if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
       MAGENTA=$(tput setaf 9)

--- a/themes/binaryanomaly/binaryanomaly.theme.bash
+++ b/themes/binaryanomaly/binaryanomaly.theme.bash
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 
-# Set term to 256color mode, if 256color is not supported, colors won't work properly
-if [[ $COLORTERM = gnome-* && $TERM = xterm ]] && infocmp gnome-256color >/dev/null 2>&1; then
-  export TERM=gnome-256color
-elif infocmp xterm-256color >/dev/null 2>&1; then
-  export TERM=xterm-256color
-fi
 
-# Detect whether a rebbot is required
+# Detect whether a reboot is required
 function show_reboot_required() {
   if [ ! -z "$_bf_prompt_reboot_info" ]; then
     if [ -f /var/run/reboot-required ]; then

--- a/themes/sexy/sexy.theme.bash
+++ b/themes/sexy/sexy.theme.bash
@@ -2,10 +2,6 @@
 # Screenshot: http://cloud.gf3.ca/M5rG
 # A big thanks to \amethyst on Freenode
 
-if [[ $COLORTERM = gnome-* && $TERM = xterm ]]  && infocmp gnome-256color >/dev/null 2>&1; then export TERM=gnome-256color
-elif [[ $TERM != dumb ]] && infocmp xterm-256color >/dev/null 2>&1; then export TERM=xterm-256color
-fi
-
 if tput setaf 1 &> /dev/null; then
     if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
       MAGENTA=$(tput setaf 9)


### PR DESCRIPTION
The used terminal emulator (urxvt, xterm, ...) is responsible to set this variable correctly. If the bash-it theme overrides this setting some applications behave unexpected, because they use the wrong escape sequences. Setting the TERM variable manually inside scripts is bad practice and shall be avoided.
See also https://unix.stackexchange.com/questions/108410/is-it-correct-to-set-the-term-variable-manually