### PR TITLE
Update base.theme.bash with RUBY interpreter version check

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -383,8 +383,13 @@ function chruby_version_prompt {
   fi
 }
 
+function rb_interp_prompt {
+  rb_version=$(ruby --version | awk '{print $2;}') || return
+  echo -e "${RUBY_THEME_PROMPT_PREFIX}${rb_version}${RUBY_THEME_PROMPT_SUFFIX}"
+}
+
 function ruby_version_prompt {
-  echo -e "$(rbfu_version_prompt)$(rbenv_version_prompt)$(rvm_version_prompt)$(chruby_version_prompt)"
+  echo -e "$(rbfu_version_prompt)$(rbenv_version_prompt)$(rvm_version_prompt)$(chruby_version_prompt)$(rb_interp_prompt)"
 }
 
 function virtualenv_prompt {


### PR DESCRIPTION
Added feature to detect the ruby version interpreter
```bash
       rb_interp_prompt
```
and added to the existing function to be used in any theme.