### PR TITLE
Alias laravel using /Users/andreas variable instead of /home/andreas.

### DIFF
--- a/aliases/available/laravel.aliases.bash
+++ b/aliases/available/laravel.aliases.bash
@@ -3,7 +3,7 @@ about-alias 'laravel artisan abbreviations'
 
 # A list of useful laravel aliases
 
-alias laravel="/home/${USER}/.composer/vendor/bin/laravel"
+alias laravel="${HOME}/.composer/vendor/bin/laravel"
 # asset
 alias a:apub='php artisan asset:publish'
 


### PR DESCRIPTION
On a mac where the homedirectory is in /User/{username} instead of /home/{username} this alias broke my laravel comand. This fix is tested on mac and on linux ubuntu.