### PR TITLE
Fix "sdkman use" version completion

### DIFF
--- a/completion/available/sdkman.completion.bash
+++ b/completion/available/sdkman.completion.bash
@@ -53,8 +53,7 @@ _sdkman_candidate_versions(){
 
 __sdkman_cleanup_local_versions(){
 
-  __sdkman_build_version_csv $1
-  echo $CSV | tr ',' ' '
+  __sdkman_build_version_csv $1 | tr ',' ' '
 
 }
 


### PR DESCRIPTION
There is no more the CSV variable after __sdkman_build_version_csv