### PR TITLE
Fixed issue introduced in #1109

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -202,7 +202,7 @@ function git_prompt_vars {
   SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
   if [[ "$(git config --get bash-it.hide-status)" != "1" ]]; then
     [[ "${SCM_GIT_IGNORE_UNTRACKED}" = "true" ]] && local git_status_flags='-uno'
-    local status_lines=$($(git status --porcelain ${git_status_flags} -b 2> /dev/null ||
+    local status_lines=$((git status --porcelain ${git_status_flags} -b 2> /dev/null ||
                           git status --porcelain ${git_status_flags}    2> /dev/null) | git_status_summary)
     local status=$(awk 'NR==1' <<< "$status_lines")
     local counts=$(awk 'NR==2' <<< "$status_lines")


### PR DESCRIPTION
With the added $ in there, it would show an error in Git repos:

-bash: ##: command not found

This was introduced in #1109.