### PR TITLE
Fallback value for alias irc

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -45,7 +45,7 @@ alias pager="$PAGER"
 
 alias q='exit'
 
-alias irc="$IRC_CLIENT"
+alias irc="${IRC_CLIENT:=irc}"
 
 # Language aliases
 alias rb='ruby'


### PR DESCRIPTION
If `IRC_CLIENT` is not set then `alias irc` is set to an empty string. So executing `irc` in that case will return an empty output which is kind of misleading. Expected behavior could be `-bash: irc: command not found`.

<img width="267" alt="screen shot 2017-12-13 at 12 24 25 am" src="https://user-images.githubusercontent.com/6568319/33902753-0afacb24-df9c-11e7-9ea9-6ba181715ecd.png">


To achieve the expected behaviour I have made `alias irc` fallback to value `irc` if `IRC_CLIENT` is not set 

