### PR TITLE
Fix table of contents link to its correct section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Stop polluting your `~/bin` directory and your `.bashrc` file, fork/clone Bash-i
   - [Searching with Negations](#searching-with-negations)
   - [Using Search to Enable or Disable Components](#using-search-to-enable-or-disable-components)
   - [Disabling ASCII Color](#disabling-ascii-color)
-- [Custom scripts, aliases, themes, and functions](#custom-scripts,-aliases,-themes,-and-functions)
+- [Custom scripts, aliases, themes, and functions](#custom-scripts-aliases-themes-and-functions)
 - [Themes](#themes)
 - [Uninstalling](#uninstalling)
 - [Misc](#misc)


### PR DESCRIPTION
GitHub strips commas from the auto-generated anchor links for section headings.

This PR fixes the TOC by removing the commas from  `Custom scripts, aliases, themes, and functions` link.