### PR TITLE
fix simple theme

### DIFF
--- a/themes/simple/simple.theme.bash
+++ b/themes/simple/simple.theme.bash
@@ -13,7 +13,7 @@ case $TERM in
 esac
 
 function prompt_command() {
-	PS1="${TITLEBAR}${orange}${reset_color}${green}\w${bold_blue}\[\$(scm_prompt_info)\]${normal} "
+	PS1="${TITLEBAR}${orange}${reset_color}${green}\w${bold_blue}\[$(scm_prompt_info)\]${normal} "
 }
 
 # scm themeing


### PR DESCRIPTION
simple theme had a wrongly escaped `$` which resulted in `~/.bash_it($(_git-friendly-ref) U:1 ✗)`
this should fix it
tested on macOS and linux