### PR TITLE
clean theme: Remove extra \

### DIFF
--- a/themes/clean/clean.theme.bash
+++ b/themes/clean/clean.theme.bash
@@ -13,7 +13,7 @@ function prompt_command() {
 
     if [ "$(whoami)" = root ]; then no_color=$red; else no_color=$white; fi
 
-    PS1="${no_color}\u${reset_color}:${blue}\W/${reset_color} \[\$(scm_prompt_info)\]$ "
+    PS1="${no_color}\u${reset_color}:${blue}\W/${reset_color} \[$(scm_prompt_info)\]$ "
     RPROMPT='[\t]'
 }
 


### PR DESCRIPTION
There is a bug in the clean theme. The `scm_prompt_info` function should be executed and not escaped. 