### PR TITLE
Fixes: 659ecd038818 plugins: percol: Check for alias zz before unalias

### DIFF
--- a/plugins/available/percol.plugin.bash
+++ b/plugins/available/percol.plugin.bash
@@ -35,7 +35,10 @@ if command -v percol>/dev/null; then
         bind -x '"\C-r": _replace_by_history'
 
         # bind zz to percol if fasd enable
-        unalias zz
+        if [[ $(type -t zz) == 'alias'  ]]; then
+          unalias zz
+        fi
+
         if command -v fasd>/dev/null; then
             function zz() {
                 local l=$(fasd -d | awk '{print $2}' | percol)


### PR DESCRIPTION
The original patch (659ecd038818c1b27bddaa2e60b0eb7f044f644a)
unaliases the percol alias, however, does not validate if the alias
is already defined. This leads to the following message that is shown
everytime a new bash session is spawned where this variable is not
defined when the percol plugin is enabled.

bash: unalias: zz: not found