### PR TITLE
explicitly use python2 for svn proxy functions

### DIFF
--- a/plugins/available/proxy.plugin.bash
+++ b/plugins/available/proxy.plugin.bash
@@ -236,11 +236,11 @@ svn-show-proxy ()
 	about 'Shows SVN proxy settings'
 	group 'proxy'
 
-	if $(command -v svn &> /dev/null) && $(command -v python &> /dev/null) ; then
+	if $(command -v svn &> /dev/null) && $(command -v python2 &> /dev/null) ; then
 		echo ""
 		echo "SVN Proxy Settings"
 		echo "=================="
-		python - <<END
+		python2 - <<END
 import ConfigParser, os
 config = ConfigParser.ConfigParser()
 config.read(os.path.expanduser('~/.subversion/servers'))
@@ -266,8 +266,8 @@ svn-disable-proxy ()
 	about 'Disables SVN proxy settings'
 	group 'proxy'
 
-	if $(command -v svn &> /dev/null) && $(command -v python &> /dev/null) ; then
-		python - <<END
+	if $(command -v svn &> /dev/null) && $(command -v python2 &> /dev/null) ; then
+		python2 - <<END
 import ConfigParser, os
 config = ConfigParser.ConfigParser()
 config.read(os.path.expanduser('~/.subversion/servers'))
@@ -295,10 +295,10 @@ svn-enable-proxy ()
 	about 'Enables SVN proxy settings'
 	group 'proxy'
 
-	if $(command -v svn &> /dev/null) && $(command -v python &> /dev/null) ; then
+	if $(command -v svn &> /dev/null) && $(command -v python2 &> /dev/null) ; then
 		local my_http_proxy=${1:-$BASH_IT_HTTP_PROXY}
 
-		python - "$my_http_proxy" "$BASH_IT_NO_PROXY" <<END
+		python2 - "$my_http_proxy" "$BASH_IT_NO_PROXY" <<END
 import ConfigParser, os, sys, urlparse
 pieces = urlparse.urlparse(sys.argv[1])
 host = pieces.hostname


### PR DESCRIPTION
many setups have `python` set to `python3`, causing a syntax error

```
$ svn-show-proxy

SVN Proxy Settings
==================
  File "<stdin>", line 14
    print 'http-proxy-host      : ' + proxy_host
                                  ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print('http-proxy-host      : ' + proxy_host)?
```

explicitly using `python2` fixes this