### PR TITLE
Add priliminary support for perforce SCM

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -60,6 +60,8 @@ done
 source "${BASH_IT}/themes/colors.theme.bash"
 # shellcheck source=./themes/githelpers.theme.bash
 source "${BASH_IT}/themes/githelpers.theme.bash"
+# shellcheck source=./themes/p4helpers.theme.bash
+source "${BASH_IT}/themes/p4helpers.theme.bash"
 # shellcheck source=./themes/base.theme.bash
 source "${BASH_IT}/themes/base.theme.bash"
 

--- a/themes/p4helpers.theme.bash
+++ b/themes/p4helpers.theme.bash
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+function _p4-opened {
+  timeout 2.0s p4 opened -s 2> /dev/null
+}
+
+function _p4-opened-counts {
+  # Return the following counts seperated by tabs:
+  #  - count of opened files
+  #  - count of pending changesets (other than defaults)
+  #  - count of files in the default changeset
+  #  - count of opened files in add mode
+  #  - count of opened files in edit mode
+  #  - count of opened files in delete mode
+  _p4-opened | awk '
+  BEGIN {
+    opened=0;
+    type_array["edit"]=0;
+    type_array["add"]=0;
+    type_array["delete"]=0;
+    change_array["change"]=0;
+  }
+  {
+    # p4 opened prints one file per line, and all lines begin with "//"
+    # Here is an examples:
+    #
+    #   $ p4 opened
+    #   //depot/some/file.py#4 - edit change 716431 (text)
+    #   //depot/another/file.py - edit default change (text)
+    #   //now/add/a/newfile.sh -  add change 435645 (text+k)
+    #
+    #
+    if ($1 ~ /^\/\//) {
+        opened += 1
+        change_array[$5] += 1
+        type_array[$3] += 1
+    }
+  }
+  END {
+    default_changes=change_array["change"];
+    non_default_changes=length(change_array) - 1;
+    print opened "\t" non_default_changes "\t" default_changes "\t" type_array["add"] "\t" type_array["edit"] "\t" type_array["delete"]
+  }
+'
+}

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -84,6 +84,8 @@ function __powerline_scm_prompt {
     fi
     if [[ "${SCM_GIT_CHAR}" == "${SCM_CHAR}" ]]; then
       scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
+    elif [[ "${SCM_P4_CHAR}" == "${SCM_CHAR}" ]]; then
+      scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
     fi
     echo "${scm_prompt}${scm}|${color}"
   fi


### PR DESCRIPTION
This patch adds very simple support for the Perforce SCM:
>   https://www.perforce.com/

Although perforce is proprietary software, it's somewhat prevalent in enterprise
companies. This patch looks to provide some basic bash_it functionality that
I've come to love for git. I base everything off of two perforce commands:
    `$ p4 set`
This command does not require a connection the perforce server, it simply tells
us if a directory is managed by the Perforce SCM or not. In addition the
command:
    `$ p4 opened`

is used to provide the list of pending changes in the client and the number of
opened files in the client. The `p4 opened` command requires a connection to the
perforce server, hence it's run under a `timeout` command. The "p4 opened"
processing into it's own bash file that now has to be sourced at the top-level
bash-it.sh. Since the processing in simple the newly added: _p4-opened-counts
function returns a number of things that are not currently used, but since I had
awk open and doing the processing, I've chosen to include them in the output
anyway.

Testing:
  - Tested with the powerline-multiline theme in a few perforce based
    workspaces/clients
  - Ran:
      `❯ shellcheck themes/p4helpers.theme.bash`
    and fixed all the errors
  - Ran the test suite:
```
  ❯ test/run
  [...]
  182 tests, 0 failures, 1 skipped```