### PR TITLE
Improve documentation on prompt options for powerline themes

### DIFF
--- a/themes/powerline-multiline/README.md
+++ b/themes/powerline-multiline/README.md
@@ -46,14 +46,19 @@ The time/date is printed by the `date` command, so refer to its man page to chan
 
 The contents of both prompt sides can be "reordered", all the "segments" (every piece of information) can take any place. The currently available segments are:
 
-* battery
-* clock
-* cwd
-* in_vim
-* python_venv
-* ruby
-* scm
-* user_info
+* `battery` - Battery information (you'll need to enable the `battery` plugin)
+* `clock` - Current time in `HH:MM:SS` format
+* `cwd` - Current working directory including full folder hierarchy (c.f. `wd`)
+* `hostname` - Host name of machine
+* `in_vim` - Show identifier if running in `:terminal` from vim
+* `last_status` - Exit status of last run command
+* `python_venv` - Python virtual environment information (`virtualenv`, `venv`
+  and `conda` supported)
+* `ruby` - Current ruby version if using `rvm`
+* `scm` - Version control information, `git` 
+* `user_info` - Current user
+* `wd` - Working directory, like `cwd` but doesn't show the full folder
+  hierarchy, only the directory you're currently in.
 
 Two variables can be defined to set the order of the prompt segments:
 

--- a/themes/powerline-naked/README.md
+++ b/themes/powerline-naked/README.md
@@ -56,7 +56,7 @@ The contents of the prompt can be "reordered", all the "segments" (every piece o
 * `wd` - Working directory, like `cwd` but doesn't show the full folder
   hierarchy, only the directory you're currently in.
 
-A variables can be defined to set the order of the prompt segments:
+A variable can be defined to set the order of the prompt segments:
 
     POWERLINE_PROMPT="user_info scm python_venv ruby cwd"
 

--- a/themes/powerline-naked/README.md
+++ b/themes/powerline-naked/README.md
@@ -42,14 +42,19 @@ The time/date is printed by the `date` command, so refer to its man page to chan
 
 The contents of the prompt can be "reordered", all the "segments" (every piece of information) can take any place. The currently available segments are:
 
-* battery
-* clock
-* cwd
-* in_vim
-* python_venv
-* ruby
-* scm
-* user_info
+* `battery` - Battery information (you'll need to enable the `battery` plugin)
+* `clock` - Current time in `HH:MM:SS` format
+* `cwd` - Current working directory including full folder hierarchy (c.f. `wd`)
+* `hostname` - Host name of machine
+* `in_vim` - Show identifier if running in `:terminal` from vim
+* `last_status` - Exit status of last run command
+* `python_venv` - Python virtual environment information (`virtualenv`, `venv`
+  and `conda` supported)
+* `ruby` - Current ruby version if using `rvm`
+* `scm` - Version control information, `git` 
+* `user_info` - Current user
+* `wd` - Working directory, like `cwd` but doesn't show the full folder
+  hierarchy, only the directory you're currently in.
 
 A variables can be defined to set the order of the prompt segments:
 

--- a/themes/powerline-plain/README.md
+++ b/themes/powerline-plain/README.md
@@ -40,14 +40,19 @@ The time/date is printed by the `date` command, so refer to its man page to chan
 
 The contents of the prompt can be "reordered", all the "segments" (every piece of information) can take any place. The currently available segments are:
 
-* battery
-* clock
-* cwd
-* in_vim
-* python_venv
-* ruby
-* scm
-* user_info
+* `battery` - Battery information (you'll need to enable the `battery` plugin)
+* `clock` - Current time in `HH:MM:SS` format
+* `cwd` - Current working directory including full folder hierarchy (c.f. `wd`)
+* `hostname` - Host name of machine
+* `in_vim` - Show identifier if running in `:terminal` from vim
+* `last_status` - Exit status of last run command
+* `python_venv` - Python virtual environment information (`virtualenv`, `venv`
+  and `conda` supported)
+* `ruby` - Current ruby version if using `rvm`
+* `scm` - Version control information, `git` 
+* `user_info` - Current user
+* `wd` - Working directory, like `cwd` but doesn't show the full folder
+  hierarchy, only the directory you're currently in.
 
 A variables can be defined to set the order of the prompt segments:
 

--- a/themes/powerline-plain/README.md
+++ b/themes/powerline-plain/README.md
@@ -54,7 +54,7 @@ The contents of the prompt can be "reordered", all the "segments" (every piece o
 * `wd` - Working directory, like `cwd` but doesn't show the full folder
   hierarchy, only the directory you're currently in.
 
-A variables can be defined to set the order of the prompt segments:
+A variable can be defined to set the order of the prompt segments:
 
     POWERLINE_PROMPT="user_info scm python_venv ruby cwd"
 

--- a/themes/powerline/README.md
+++ b/themes/powerline/README.md
@@ -44,14 +44,19 @@ The time/date is printed by the `date` command, so refer to its man page to chan
 
 The contents of the prompt can be "reordered", all the "segments" (every piece of information) can take any place. The currently available segments are:
 
-* battery
-* clock
-* cwd
-* in_vim
-* python_venv
-* ruby
-* scm
-* user_info
+* `battery` - Battery information (you'll need to enable the `battery` plugin)
+* `clock` - Current time in `HH:MM:SS` format
+* `cwd` - Current working directory including full folder hierarchy (c.f. `wd`)
+* `hostname` - Host name of machine
+* `in_vim` - Show identifier if running in `:terminal` from vim
+* `last_status` - Exit status of last run command
+* `python_venv` - Python virtual environment information (`virtualenv`, `venv`
+  and `conda` supported)
+* `ruby` - Current ruby version if using `rvm`
+* `scm` - Version control information, `git` 
+* `user_info` - Current user
+* `wd` - Working directory, like `cwd` but doesn't show the full folder
+  hierarchy, only the directory you're currently in.
 
 A variables can be defined to set the order of the prompt segments:
 

--- a/themes/powerline/README.md
+++ b/themes/powerline/README.md
@@ -58,7 +58,7 @@ The contents of the prompt can be "reordered", all the "segments" (every piece o
 * `wd` - Working directory, like `cwd` but doesn't show the full folder
   hierarchy, only the directory you're currently in.
 
-A variables can be defined to set the order of the prompt segments:
+A variable can be defined to set the order of the prompt segments:
 
     POWERLINE_PROMPT="user_info scm python_venv ruby cwd"
 


### PR DESCRIPTION
I've collected the supported prompt options from reading `themes/powerline/powerline.base.bash` and documented them in all powerline* themes.