### PR TITLE
Suggestion verification root user

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -18,7 +18,7 @@ function __powerline_user_info_prompt {
   local color=${USER_INFO_THEME_PROMPT_COLOR}
 
   if [[ "${THEME_CHECK_SUDO}" = true ]]; then
-    if sudo -n uptime 2>&1 | grep -q "load"; then
+    if id 2>&1 | grep -q "root"; then
       color=${USER_INFO_THEME_PROMPT_COLOR_SUDO}
     fi
   fi


### PR DESCRIPTION
I a problem, the group maintenance receives at all times messages when I launches orders.
It is better check if the user is root with "id" commande.