### PR TITLE
Clipboard's aliases will now appear on bash-it help aliases

### DIFF
--- a/aliases/available/clipboard.aliases.bash
+++ b/aliases/available/clipboard.aliases.bash
@@ -4,7 +4,9 @@ about-alias 'pbcopy and pbpaste shortcuts to linux'
 case $OSTYPE in
   linux*)
     XCLIP=$(command -v xclip)
-    [[ $XCLIP ]] && alias pbcopy="$XCLIP -selection clipboard" && alias pbpaste="$XCLIP -selection clipboard -o"
+    [[ $XCLIP ]] && \
+    alias pbcopy="$XCLIP -selection clipboard" && \
+    alias pbpaste="$XCLIP -selection clipboard -o"
     ;;   
 esac
 


### PR DESCRIPTION
Breaking up alias declarations into their own lines so that bash-it help aliases will register them