### PR TITLE
Add a comparison URL to version

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -248,6 +248,7 @@ _bash-it-version() {
 
   echo "Current git SHA: $BASH_IT_GIT_VERSION_INFO"
   echo "$BASH_IT_GIT_URL/commit/$BASH_IT_GIT_SHA"
+  echo "Compare to latest: $BASH_IT_GIT_URL/compare/$BASH_IT_GIT_SHA...master"
 
   cd - &> /dev/null || return
 }


### PR DESCRIPTION
In order to make a swift comparison between the currently-installed
version vs the latest commits on `master`, emit a clickable URL that
will show the user the exact changes.

Signed-off-by: Mike Fiedler <miketheman@gmail.com>