### PR TITLE
Add reset launchpad layout function

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -95,5 +95,18 @@ function prevcurl() {
   curl "$*" | open -fa $PREVIEW
 }
 
+function refresh-launchpad() {
+  about 'Reset launchpad layout in macOS'
+  example '$ refresh-launchpad'
+  group 'osx'
+
+  if [ $(uname) = "Darwin" ];then
+    defaults write com.apple.dock ResetLaunchPad -bool TRUE
+    killall Dock
+  else
+    echo "Sorry, this only works on Mac OS X"
+  fi
+}
+
 # Make this backwards compatible
 alias pcurl='prevcurl'


### PR DESCRIPTION
The layout will have returned to the default, placing all bundled
apps onto the first screen of Launchpad, and third party apps onto
the secondary (and third, if applicable) screens