### PR TITLE
Update pipenv completion

### DIFF
--- a/completion/available/pipenv.completion.bash
+++ b/completion/available/pipenv.completion.bash
@@ -1,1 +1,1 @@
-[[ -x "$(which pipenv)" ]] && source <(env _PIPENV_COMPLETE="source-bash" pipenv)
+[[ -x "$(which pipenv)" ]] && eval "$(pipenv --completion)"


### PR DESCRIPTION
use `--completion` from pypa/pipenv docs instead of old `_PIPENV_COMPLETE`