### PR TITLE
Fix quoting in the Explain plugin

### DIFF
--- a/plugins/available/explain.plugin.bash
+++ b/plugins/available/explain.plugin.bash
@@ -5,7 +5,7 @@ explain () {
   about 'explain any bash command via mankier.com manpage API'
   param '1: Name of the command to explain'
   example '$ explain                # interactive mode. Type commands to explain in REPL'
-  example '$ explain 'cmd -o | ...' # one quoted command to explain it.'
+  example '$ explain '"'"'cmd -o | ...'"'"' # one quoted command to explain it.'
   group 'explain'
 
   if [ "$#" -eq 0 ]; then


### PR DESCRIPTION
Fixes bug where Bash prints a "command not found" message when the
function is run, due to incorrect quoting of the argument to the
meta function example.

See: https://stackoverflow.com/a/1250279/2573172