### PR TITLE
Function scm_prompt_info does not work properly if a vcs tool is missing

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -75,12 +75,12 @@ RBFU_THEME_PROMPT_SUFFIX='|'
 
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE
-  elif [[ -f .git/HEAD ]]; then SCM=$SCM_GIT
+  elif [[ -f .git/HEAD ]] && which git &> /dev/null; then SCM=$SCM_GIT
   elif which git &> /dev/null && [[ -n "$(git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
   elif which p4 &> /dev/null && [[ -n "$(p4 set P4CLIENT 2> /dev/null)" ]]; then SCM=$SCM_P4
-  elif [[ -d .hg ]]; then SCM=$SCM_HG
+  elif [[ -d .hg ]] && which hg &> /dev/null; then SCM=$SCM_HG
   elif which hg &> /dev/null && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
-  elif [[ -d .svn ]]; then SCM=$SCM_SVN
+  elif [[ -d .svn ]] && which svn &> /dev/null; then SCM=$SCM_SVN
   else SCM=$SCM_NONE
   fi
 }


### PR DESCRIPTION
On some hosts if a vcs tool is missing, eg. git, function scm_prompt_info does work properly. 
I noticed this behavior on a host without the git.