### PR TITLE
Update powerline theme to avoid overlapping left and right prompt

### DIFF
--- a/themes/powerline-multiline/powerline-multiline.base.bash
+++ b/themes/powerline-multiline/powerline-multiline.base.bash
@@ -51,6 +51,8 @@ function __powerline_prompt_command {
       local info="$(__powerline_${segment}_prompt)"
       [[ -n "${info}" ]] && __powerline_right_segment "${info}"
     done
+    RIGHT_PAD=$(printf "%.s " $(seq 1 $RIGHT_PROMPT_LENGTH))
+    LEFT_PROMPT+="${RIGHT_PAD}${move_cursor_rightmost}"
     LEFT_PROMPT+="\033[${RIGHT_PROMPT_LENGTH}D"
   fi
 

--- a/themes/powerline-multiline/powerline-multiline.base.bash
+++ b/themes/powerline-multiline/powerline-multiline.base.bash
@@ -46,7 +46,7 @@ function __powerline_prompt_command {
 
   ## right prompt ##
   if [[ -n "${POWERLINE_RIGHT_PROMPT}" ]]; then
-    LEFT_PROMPT+="${move_cursor_rightmost}"
+    # LEFT_PROMPT+="${move_cursor_rightmost}"
     for segment in $POWERLINE_RIGHT_PROMPT; do
       local info="$(__powerline_${segment}_prompt)"
       [[ -n "${info}" ]] && __powerline_right_segment "${info}"


### PR DESCRIPTION
During usage I noticed that a lot of the times when the path is long enough to reach the right side prompt but not long enough to enter a second line, the part that overlaps with the right prompt gets covered and it's very inconvenient:

If I'm inside a folder at `~/Documents/some/long/path/to/folder`, it would show
```
~/Documents/some/long/path/to/fo<12:00:00 <user
>
```
whereas after the edit it will correctly show
```
~/Documents/some/long/path/to/folder>
                                <12:00:00 <user
>
```