### PR TITLE
Fix bold text issue

### DIFF
--- a/themes/candy/candy.theme.bash
+++ b/themes/candy/candy.theme.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function prompt_command() {
-    PS1="${green}\u@\h $(clock_prompt) ${reset_color}${white}\w${reset_color}$(scm_prompt_info)${blue} →${bold_blue} ${reset_color} ";
+    PS1="${green}\u@\h $(clock_prompt) ${reset_color}${white}\w${reset_color}$(scm_prompt_info)${blue} →${bold_blue} ${reset_color} ${normal}";
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$blue"}


### PR DESCRIPTION
The default text style was not being set back to normal so terminal output was rendering bold, e.g. for an ls command