### PR TITLE
Add `codeword` theme

### DIFF
--- a/themes/codeword/README.md
+++ b/themes/codeword/README.md
@@ -1,0 +1,22 @@
+# Single line PS1 theme w/realtime history among windows
+
+
+Minimal theme overrides from bash_it base theming
+
+
+## `user@host:path[virt-env][scm] $` 
+Breakdown of the segments:
+
+- **user@host:path** - *convienient for LAN based `ssh` and `scp` tasks*
+- [**virtualenv**] - *only appears when activated*
+- [**scm**] - *only appears when activated*
+- **marker** - *$ or # depending on current user*
+
+### Examples
+
+```bash
+user@example.lan:~ $ cd /tmp/foo/bar/baz
+user@example.lan:/tmp/foo/bar/baz $ cd $HOME/workspace
+user@example.lan:~/workspace $ cd sampleRepo/
+user@example.lan:~/workspace/sampleRepo [± |master ↑1 ↓3 {1} S:2 ?:1 ✗|] $
+```

--- a/themes/codeword/codeword.theme.bash
+++ b/themes/codeword/codeword.theme.bash
@@ -1,0 +1,38 @@
+SCM_THEME_PROMPT_PREFIX=${SCM_THEME_PROMPT_SUFFIX}
+SCM_THEME_PROMPT_DIRTY="${bold_red} ✗${normal}"
+SCM_THEME_PROMPT_CLEAN="${bold_green} ✓${normal}"
+SCM_GIT_CHAR="${green}±${normal}"
+
+scm_prompt() {
+    CHAR=$(scm_char)
+    if [ $CHAR = $SCM_NONE_CHAR ]
+        then
+            return
+        else
+            echo " [$(scm_char)$(scm_prompt_info)]"
+    fi
+}
+
+mark_prompt() {
+    echo "${green}\$${normal}"
+}
+
+user_host_path_prompt() {
+    ps_user="${green}\u${normal}";
+    ps_host="${blue}\H${normal}";
+    ps_path="${yellow}\w${normal}";
+    echo "$ps_user@$ps_host:$ps_path"
+}
+
+prompt() {
+  PS1="$(user_host_path_prompt)$(virtualenv_prompt)$(scm_prompt) $(mark_prompt) "
+}
+
+share_history() {
+  history -a
+  history -c
+  history -r
+}
+
+safe_append_prompt_command share_history
+safe_append_prompt_command prompt


### PR DESCRIPTION
- Single line PS1 with conveniences for `ssh` and `scp`
- Shares history in realtime among bash windows

Screenshots:
<img width="950" alt="codeword dark" src="https://user-images.githubusercontent.com/4543/40892964-c8ad68aa-6752-11e8-8eb0-120bf1bfa079.png">
<img width="950" alt="codeword light" src="https://user-images.githubusercontent.com/4543/40892965-c8c41ba4-6752-11e8-9c9c-5ce6ffeb743c.png">

