### PR TITLE
Fix wildcards and handle includes in ssh complete

### DIFF
--- a/completion/available/ssh.completion.bash
+++ b/completion/available/ssh.completion.bash
@@ -11,11 +11,16 @@ _sshcomplete() {
       local OPTIONS=" -- ${CURRENT_PROMPT}"
     fi
 
-
-    # parse all defined hosts from .ssh/config
-    if [ -r "$HOME/.ssh/config" ]; then
-        COMPREPLY=($(compgen -W "$(grep -i ^Host "$HOME/.ssh/config" | awk '{for (i=2; i<=NF; i++) print $i}' )" ${OPTIONS}) )
-    fi
+    # parse all defined hosts from .ssh/config and files included there
+    for fl in "$HOME/.ssh/config" \
+        $(grep -P "^\s*Include" "$HOME/.ssh/config" | 
+            awk '{for (i=2; i<=NF; i++) print $i}' | 
+            sed "s|^~/|$HOME/|")
+    do
+        if [ -r "$fl" ]; then
+            COMPREPLY=( ${COMPREPLY[@]} $(compgen -W "$(grep -i ^Host "$fl" |grep -v '[*!]' | awk '{for (i=2; i<=NF; i++) print $i}' )" ${OPTIONS}) )
+        fi
+    done
 
     # parse all hosts found in .ssh/known_hosts
     if [ -r "$HOME/.ssh/known_hosts" ]; then


### PR DESCRIPTION
Handle includes in `.ssh/config` and fix bug that caused `Host` entries with wildcards in them to be included in the autocomplete suggestions.

E.g. `Host *-server` host entry in `~/.ssh/config` leads to either the suggestion "*-server", or worse, the wildcard being expanded in `bash-it/completion/available/`. The latter would yield `my-server` if, a file `bash-it/completion/available/my-server` existed, i.e. the wildcard was successfully expanded in the script directory. 

This pull request also handles the `Include` directive in ssh config files (although non-recursive).

>     Include
>             Include the specified configuration file(s).  Multiple path‐
>             names may be specified and each pathname may contain glob(3)
>             wildcards and, for user configurations, shell-like ‘~’ refer‐
>             ences to user home directories.  Files without absolute paths
>             are assumed to be in ~/.ssh if included in a user configuration
>             file or /etc/ssh if included from the system configuration
>             file.  Include directive may appear inside a Match or Host
>             block to perform conditional inclusion.
>
See: http://man7.org/linux/man-pages/man5/ssh_config.5.html