### PR TITLE
The function _git-hide-status is invoked to late

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -389,6 +389,7 @@ function user_host_prompt {
 
 # backwards-compatibility
 function git_prompt_info {
+  _git-hide-status && return
   git_prompt_vars
   echo -e "${SCM_PREFIX}${SCM_BRANCH}${SCM_STATE}${SCM_SUFFIX}"
 }


### PR DESCRIPTION
```
login@host:~  |master → origin/master ↑1 ✓| 0
$ env | grep SCM_GIT
SCM_GIT_SHOW_REMOTE_INFO=true
SCM_GIT_SHOW_DETAILS=false
SCM_GIT_SHOW_MINIMAL_INFO=false
SCM_GIT_IGNORE_UNTRACKED=true
login@host:~  |master → origin/master ↑1 ✓| 0
$ git config --get bash-it.hide-status
1
login@host:~  |master → origin/master ↑1 ✓| 0
# after changes
$ bash -l
login@host:~  0
```

I've marked a repository to not check git status but despite this, bash-it checks it. 

Ps. I could not upload an image.
