### PR TITLE
Display only first line of Python 3.7 version

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -347,7 +347,7 @@ function condaenv_prompt {
 }
 
 function py_interp_prompt {
-  py_version=$(python --version 2>&1 | awk '{print "py-"$2;}') || return
+  py_version=$(python --version 2>&1 | awk 'NR==1{print "py-"$2;}') || return
   echo -e "${PYTHON_THEME_PROMPT_PREFIX}${py_version}${PYTHON_THEME_PROMPT_SUFFIX}"
 }
 


### PR DESCRIPTION
Python 3.7 version prompt now includes compiler version in the second line. Bash it would print both Python and GCC version as the "py" version.
Before:
```
py-3.7.0
py-5.4.0 localhost in ~
```
After:
`py-3.7.0 localhost in ~
`