### PR TITLE
Use fd for fzf if available on system

### DIFF
--- a/plugins/available/fzf.plugin.bash
+++ b/plugins/available/fzf.plugin.bash
@@ -6,6 +6,8 @@ about-plugin 'load fzf, if you are using it'
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
+command -v fd &> /dev/null && export FZF_DEFAULT_COMMAND='fd --type f'
+
 fe() {
   about "Open the selected file in the default editor"
   group "fzf"

--- a/plugins/available/fzf.plugin.bash
+++ b/plugins/available/fzf.plugin.bash
@@ -6,7 +6,9 @@ about-plugin 'load fzf, if you are using it'
 
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 
-command -v fd &> /dev/null && export FZF_DEFAULT_COMMAND='fd --type f'
+if [ -z ${FZF_DEFAULT_COMMAND+x}  ]; then
+  command -v fd &> /dev/null && export FZF_DEFAULT_COMMAND='fd --type f'
+fi
 
 fe() {
   about "Open the selected file in the default editor"


### PR DESCRIPTION
fd is orders of magnitude faster when searching for files. This patch
will force fzf to use fd instead of find.

This change is implemented per the recommendation:
https://github.com/junegunn/fzf#environment-variables