### PR TITLE
Avoid double semicolon in the PROMPT_COMMAND

### DIFF
--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -5,7 +5,7 @@ about-plugin 'osx-specific functions'
 if [ $(uname) = "Darwin" ]; then
   if type update_terminal_cwd > /dev/null 2>&1 ; then
     if ! [[ $PROMPT_COMMAND =~ (^|;)update_terminal_cwd($|;) ]] ; then
-      PROMPT_COMMAND="$PROMPT_COMMAND;update_terminal_cwd"
+      PROMPT_COMMAND="${PROMPT_COMMAND%;};update_terminal_cwd"
       declared="$(declare -p PROMPT_COMMAND)"
       [[ "$declared" =~ \ -[aAilrtu]*x[aAilrtu]*\  ]] 2>/dev/null
       [[ $? -eq 0 ]] && export PROMPT_COMMAND


### PR DESCRIPTION
The direnv bash hook already adds a semicolon to the PROMPT_COMMAND and this
plugin will add another one if direnv is installed. This commit will avoid to have double semicolon by removing trailing semicolon from PROMPT_COMMAND if presented before appends "update_terminal_cmd" function