### PR TITLE
Add SCM_GIT_SHOW_STASH_INFO flag #914

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,19 @@ Also, with this flag to false, Bash-it will not show the repository as dirty whe
 
 **NOTE:** If you set in git configuration file the option to ignore *untracked* files, this flag has no effect, and Bash-it will ignore *untracked* files always.
 
+### Stash item count
+
+When `SCM_GIT_SHOW_DETAILS` is enabled, you can get the count of *stashed* items. This feature can be useful when a user has a lot of stash items.
+This feature is controlled through the flag `SCM_GIT_SHOW_STASH_INFO` as follows:
+
+Set `SCM_GIT_SHOW_STASH_INFO` to 'true' (the default value) to **show** the count of stashed items:
+
+* `export SCM_GIT_SHOW_STASH_INFO=true`
+
+Set `SCM_GIT_SHOW_STASH_INFO` to 'false' to **don't show** it:
+
+* `export SCM_GIT_SHOW_STASH_INFO=false`
+
 ### Git user
 
 In some environments, it is useful to know the value of the current git user, which is used to mark all new commits.

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -32,6 +32,7 @@ SCM_GIT_SHOW_REMOTE_INFO=${SCM_GIT_SHOW_REMOTE_INFO:=auto}
 SCM_GIT_IGNORE_UNTRACKED=${SCM_GIT_IGNORE_UNTRACKED:=false}
 SCM_GIT_SHOW_CURRENT_USER=${SCM_GIT_SHOW_CURRENT_USER:=false}
 SCM_GIT_SHOW_MINIMAL_INFO=${SCM_GIT_SHOW_MINIMAL_INFO:=false}
+SCM_GIT_SHOW_STASH_INFO=${SCM_GIT_SHOW_STASH_INFO:=true}
 
 SCM_GIT='git'
 SCM_GIT_CHAR='±'
@@ -181,9 +182,11 @@ function git_prompt_vars {
   [[ "${commits_ahead}" -gt 0 ]] && SCM_BRANCH+=" ${SCM_GIT_AHEAD_CHAR}${commits_ahead}"
   [[ "${commits_behind}" -gt 0 ]] && SCM_BRANCH+=" ${SCM_GIT_BEHIND_CHAR}${commits_behind}"
 
-  local stash_count
-  stash_count="$(git stash list 2> /dev/null | wc -l | tr -d ' ')"
-  [[ "${stash_count}" -gt 0 ]] && SCM_BRANCH+=" ${SCM_GIT_STASH_CHAR_PREFIX}${stash_count}${SCM_GIT_STASH_CHAR_SUFFIX}"
+  if [[ "${SCM_GIT_SHOW_STASH_INFO}" = "true" ]]; then
+    local stash_count
+    stash_count="$(git stash list 2> /dev/null | wc -l | tr -d ' ')"
+    [[ "${stash_count}" -gt 0 ]] && SCM_BRANCH+=" ${SCM_GIT_STASH_CHAR_PREFIX}${stash_count}${SCM_GIT_STASH_CHAR_SUFFIX}"
+  fi
 
   SCM_STATE=${GIT_THEME_PROMPT_CLEAN:-$SCM_THEME_PROMPT_CLEAN}
   if ! _git-hide-status; then


### PR DESCRIPTION
In order to make `git_prompt_vars` run faster
As a user with slow `git stash list`
I want to be able to optionally disable running `git stash list` when
`git_prompt_vars` is executed

Note that this doesn't implement the complete feature set proposed in #914 