### PR TITLE
aws session token support on awskeys

### DIFF
--- a/plugins/available/aws.plugin.bash
+++ b/plugins/available/aws.plugin.bash
@@ -37,7 +37,7 @@ function __awskeys_help {
 function __awskeys_get {
     local ln=$(grep -n "\[ *$1 *\]" ~/.aws/credentials | cut -d ":" -f 1)
     if [[ -n "${ln}" ]]; then
-        tail -n +${ln} ~/.aws/credentials | egrep -m 2 "aws_access_key_id|aws_secret_access_key"
+        tail -n +${ln} ~/.aws/credentials | egrep -m 3 "aws_access_key_id|aws_secret_access_key|aws_session_token"
     fi
 }
 
@@ -79,7 +79,7 @@ function __awskeys_export {
 }
 
 function __awskeys_unset {
-    unset AWS_PROFILE AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+    unset AWS_PROFILE AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 }
 
 function __awskeys_comp {


### PR DESCRIPTION
Added support to awskeys to `AWS_SESSION_TOKEN`. This is needed if you are working with temporary credentials using STS

More details: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#using-temp-creds-sdk-cli