### PR TITLE
Allow custom aws config files path

### DIFF
--- a/plugins/available/aws.plugin.bash
+++ b/plugins/available/aws.plugin.bash
@@ -1,11 +1,14 @@
 cite about-plugin
 about-plugin 'AWS helper functions'
 
+AWS_CONFIG_FILE="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+AWS_SHARED_CREDENTIALS_FILE="${AWS_SHARED_CREDENTIALS_FILE:-$HOME/.aws/credentials}"
+
 function awskeys {
     about 'helper function for AWS credentials file'
     group 'aws'
 
-    if [[ ! -f ~/.aws/credentials ]]; then
+    if [[ ! -f "${AWS_SHARED_CREDENTIALS_FILE}" ]]; then
         echo "AWS credentials file not found"
         return 1
     fi
@@ -35,14 +38,14 @@ function __awskeys_help {
 }
 
 function __awskeys_get {
-    local ln=$(grep -n "\[ *$1 *\]" ~/.aws/credentials | cut -d ":" -f 1)
+    local ln=$(grep -n "\[ *$1 *\]" "${AWS_SHARED_CREDENTIALS_FILE}" | cut -d ":" -f 1)
     if [[ -n "${ln}" ]]; then
-        tail -n +${ln} ~/.aws/credentials | egrep -m 3 "aws_access_key_id|aws_secret_access_key|aws_session_token"
+        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | egrep -m 3 "aws_access_key_id|aws_secret_access_key|aws_session_token"
     fi
 }
 
 function __awskeys_list {
-    local credentials_list="$((egrep '^\[ *[a-zA-Z0-9_-]+ *\]$' ~/.aws/credentials; grep "\[profile" ~/.aws/config | sed "s|\[profile |\[|g") | sort | uniq)"
+    local credentials_list="$((egrep '^\[ *[a-zA-Z0-9_-]+ *\]$' "${AWS_SHARED_CREDENTIALS_FILE}"; grep "\[profile" "${AWS_CONFIG_FILE}" | sed "s|\[profile |\[|g") | sort | uniq)"
     if [[ -n $"{credentials_list}" ]]; then
         echo -e "Available credentials profiles:\n"
         for profile in ${credentials_list}; do


### PR DESCRIPTION
Honor the environment variables:

```
AWS_CONFIG_FILE
AWS_SHARED_CREDENTIALS_FILE
```

in the aws plugin.

+info:
https://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html