### PR TITLE
Add multiple path support to go plugin

### DIFF
--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -6,9 +6,16 @@ about-plugin 'go environment variables & path configuration'
 [ ! command -v go &>/dev/null ] && return
 
 function _split_path_reverse() {
+  local a=( ${@//:/ } )
+  local i=${#a[@]}
   local r=
-  for p in ${@//:/ } ; do
-    r="$p $r"
+  while [ $i -gt 0 ] ; do
+    i=$(( i - 1 ))
+    if [ $(( i + 1 )) -eq ${#a[@]} ] ; then
+      r="${a[i]}"
+    else
+      r="${r} ${a[i]}"
+    fi
   done
   echo "$r"
 }

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -5,7 +5,18 @@ about-plugin 'go environment variables & path configuration'
 
 [ ! command -v go &>/dev/null ] && return
 
+function _split_path_reverse() {
+  local r=
+  for p in ${@//:/ } ; do
+    r="$p $r"
+  done
+  echo "$r"
+}
+
 export GOROOT=${GOROOT:-$(go env GOROOT)}
 pathmunge "${GOROOT}/bin"
+
 export GOPATH=${GOPATH:-$(go env GOPATH)}
-pathmunge "${GOPATH}/bin"
+for p in $( _split_path_reverse ${GOPATH} ) ; do
+  pathmunge "${p}/bin"
+done

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+#load ../test_helper
+load ../../lib/helpers
+load ../../lib/composure
+load ../../plugins/available/go.plugin
+
+@test 'plugins go: reverse path: single entry' {
+  run _split_path_reverse '/foo'
+  echo "output = ${output}"
+  [ "$output" = "/foo" ]
+}
+
+@test 'plugins go: reverse path: single entry, colon empty' {
+  run _split_path_reverse '/foo:'
+  echo "output = ${output}"
+  [ "$output" = "/foo" ]
+}
+
+@test 'plugins go: reverse path: single entry, colon whitespace' {
+  run _split_path_reverse '/foo: '
+  echo "output = ${output}"
+  [ "$output" = "/foo" ]
+}
+
+@test 'plugins go: reverse path: multiple entries' {
+  run _split_path_reverse '/foo:/bar'
+  echo "output = ${output}"
+  [ "$output" = "/bar /foo" ]
+}
+
+@test 'plugins go: multiple entries in GOPATH' {
+  export GOPATH="/foo:/bar"
+  load ../../plugins/available/go.plugin
+  echo "$(echo $PATH | cut -d':' -f1,2)"
+  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/bar/bin" ]
+}

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -29,6 +29,13 @@ load ../../plugins/available/go.plugin
   [ "$output" = "/bar /foo" ]
 }
 
+@test 'plugins go: single entry in GOPATH' {
+  export GOPATH="/foo"
+  load ../../plugins/available/go.plugin
+  echo "$(echo $PATH | cut -d':' -f1,2)"
+  [ "$(echo $PATH | cut -d':' -f1)" = "/foo/bin" ]
+}
+
 @test 'plugins go: multiple entries in GOPATH' {
   export GOPATH="/foo:/bar"
   load ../../plugins/available/go.plugin


### PR DESCRIPTION
Because `GOPATH` supports a colon (`:`) separated list of directories, the current strategy of using `pathmunge` results in a wrong path appended to `PATH`.

This PR isolates the solution to the `go` plugin, but I could see the value of moving this logic to `pathmunge` if you agree as well. Let me know what you think.

## Environment
```
$ echo $GOPATH
/home/cornfeedhobo/go:/usr/share/go/1.9/contrib
```
## Result
```
$ echo -e ${PATH//:/\\n}
/home/cornfeedhobo/go
/usr/share/go/1.9/contrib/bin
/usr/lib64/go/1.9/bin
...
```

## Expected
```
$ echo -e ${PATH//:/\\n}
/home/cornfeedhobo/go/bin
/usr/share/go/1.9/contrib/bin
/usr/lib64/go/1.9/bin
...
```