### PR TITLE
Speed up bash-it Search & support exact matches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bats
 *.sublime-workspace
 *.sublime-project
 enabled/*
+tmp/

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -70,7 +70,7 @@ bash-it ()
     example '$ bash-it disable alias hg [tmux]...'
     example '$ bash-it migrate'
     example '$ bash-it update'
-    example '$ bash-it search [-|@]term1 [-|@]term2 ... [--enable | --disable | --help | --refresh | --no-color ]'
+    example '$ bash-it search [-|@]term1 [-|@]term2 ... [ -e/--enable ] [ -d/--disable ] [ -r/--refresh ] [ -c/--no-color ]'
     example '$ bash-it version'
     example '$ bash-it reload'
     typeset verb=${1:-}
@@ -78,6 +78,7 @@ bash-it ()
     typeset component=${1:-}
     shift
     typeset func
+
     case $verb in
       show)
         func=_bash-it-$component;;
@@ -393,8 +394,7 @@ _disable-thing ()
         fi
     fi
 
-    local flag="DEFER_CACHE_CLEANUP_FOR_${file_type}"
-    [[ -z ${!flag} ]] && _bash_it_search_cache_clean "${file_type}"
+    _bash-it-clean-component-cache "${file_type}"
 
     if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then
         exec ${0/-/}
@@ -491,8 +491,7 @@ _enable-thing ()
         ln -s ../$subdirectory/available/$to_enable "${BASH_IT}/enabled/${use_load_priority}${BASH_IT_LOAD_PRIORITY_SEPARATOR}${to_enable}"
     fi
 
-    local flag="DEFER_CACHE_CLEANUP_FOR_${file_type}"
-    [[ -z ${!flag} ]] && _bash_it_search_cache_clean "${file_type}"
+    _bash-it-clean-component-cache "${file_type}"
 
     if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then
         exec ${0/-/}

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -70,7 +70,7 @@ bash-it ()
     example '$ bash-it disable alias hg [tmux]...'
     example '$ bash-it migrate'
     example '$ bash-it update'
-    example '$ bash-it search ruby [[-]rake]... [--enable | --disable]'
+    example '$ bash-it search [-|@]term1 [-|@]term2 ... [--enable | --disable | --help | --refresh | --no-color ]'
     example '$ bash-it version'
     example '$ bash-it reload'
     typeset verb=${1:-}
@@ -393,6 +393,9 @@ _disable-thing ()
         fi
     fi
 
+    local flag="DEFER_CACHE_CLEANUP_FOR_${file_type}"
+    [[ -z ${!flag} ]] && _bash_it_search_cache_clean "${file_type}"
+
     if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then
         exec ${0/-/}
     fi
@@ -487,6 +490,9 @@ _enable-thing ()
 
         ln -s ../$subdirectory/available/$to_enable "${BASH_IT}/enabled/${use_load_priority}${BASH_IT_LOAD_PRIORITY_SEPARATOR}${to_enable}"
     fi
+
+    local flag="DEFER_CACHE_CLEANUP_FOR_${file_type}"
+    [[ -z ${!flag} ]] && _bash_it_search_cache_clean "${file_type}"
 
     if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then
         exec ${0/-/}

--- a/lib/search.bash
+++ b/lib/search.bash
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # Search by Konstantin Gredeskoul «github.com/kigster»
 #———————————————————————————————————————————————————————————————————————————————
@@ -5,46 +6,172 @@
 # whose name or description matches one of the search terms provided as arguments.
 #
 # Usage:
-#    ❯ bash-it search term1 [[-]term2] ... [[-]termN] [ --enable | --disable ]
+#    ❯ bash-it search [-|@]term1 [-|@]term2 ... \
+#       [ --enable  | -e ] \
+#       [ --disable | -d ] \
+#       [ --refresh | -r ]
+#       [ --help    | -h ]
 #
-# Exmplanation:
 #    Single dash, as in "-chruby", indicates a negative search term.
 #    Double dash indicates a command that is to be applied to the search result.
-#    At the moment only --enable and --disable are supported.
+#    At the moment only --help, --enable and --disable are supported.
+#    An '@' sign indicates an exact (not partial) match.
 #
 # Examples:
 #    ❯ bash-it search ruby rbenv rvm gem rake
-#    aliases     :  bundler
-#    plugins     :  chruby chruby-auto rbenv ruby rvm
-#    completions :  gem rake
-
+#          aliases:  bundler
+#          plugins:  chruby chruby-auto ruby rbenv rvm ruby
+#      completions:  rvm gem rake
+#
 #    ❯ bash-it search ruby rbenv rvm gem rake -chruby
-#    aliases     :  bundler
-#    plugins     :  rbenv ruby rvm
-#    completions :  gem rake
+#          aliases:  bundler
+#          plugins:  ruby rbenv rvm ruby
+#      completions:  rvm gem rake
 #
 # Examples of enabling or disabling results of the search:
 #
 #    ❯ bash-it search ruby
-#    aliases  =>   bundler
-#    plugins  =>   chruby chruby-auto ruby
+#          aliases:  bundler
+#          plugins:  chruby chruby-auto ruby
 #
 #    ❯ bash-it search ruby -chruby --enable
-#    aliases  =>   ✓bundler
-#    plugins  =>   ✓ruby
+#          aliases:  bundler
+#          plugins:  ruby
 #
+# Examples of using exact match:
+
+#    ❯ bash-it search @git @ruby
+#          aliases:  git
+#          plugins:  git ruby
+#      completions:  git
 #
+
 _bash-it-search() {
   _about 'searches for given terms amongst bash-it plugins, aliases and completions'
   _param '1: term1'
   _param '2: [ term2 ]...'
-  _example '$ _bash-it-search ruby rvm rake bundler'
+  _example '$ _bash-it-search @git ruby -rvm rake bundler'
 
-  declare -a _components=(aliases plugins completions)
+  local component
+  export BASH_IT_SEARCH_USE_COLOR=true
+  export BASH_IT_GREP=${BASH_IT_GREP:-$(which egrep)}
+  declare -a BASH_IT_COMPONENTS=(aliases plugins completions)
 
-  for _component in "${_components[@]}" ; do
-    _bash-it-search-component  "${_component}" "$@"
+  if [[ -z "$*" ]] ; then
+    _bash-it-search-help
+    return 0
+  fi
+
+  local -a args=()
+  for word in $@; do
+    if [[ ${word} == "--help" || ${word} == "-h" ]]; then
+      _bash-it-search-help
+      return 0
+    elif [[ ${word} == "--refresh" || ${word} == "-r" ]]; then
+      _bash_it_search_cache_clean
+    elif [[ ${word} == "--no-color" ]]; then
+      export BASH_IT_SEARCH_USE_COLOR=false
+    else
+      args=(${args[@]} ${word})
+    fi
   done
+
+  for component in "${BASH_IT_COMPONENTS[@]}" ; do
+    _bash-it-search-component "${component}" "${args[@]}"
+  done
+
+  return 0
+}
+
+_bash-it-search-help() {
+  printf "${echo_normal}
+${echo_underline_yellow}USAGE${echo_normal}
+
+   bash-it search [-|@]term1 [-|@]term2 ... \\
+           [ --enable | --disable | --help | --refresh | --no-color ]
+
+${echo_underline_yellow}DESCRIPTION${echo_normal}
+
+   Use ${echo_bold_green}search${echo_normal} bash-it command to search for a list of terms or term negations
+   across all components: aliases, completions and plugins. Components that are
+   enabled are shown in green (or with a check box if --no-color option is used).
+
+   In addition to simply finding the right component, you can use the results
+   of the search to enable or disable all components that the search returns.
+
+   When search is used to enable/disable components it becomes clear that
+   you must be able to perform not just a partial match, but an exact match,
+   as well as be able to exclude some components.
+
+      * To exclude a component (or all components matching a substring) use
+        a search term with minus as a prefix, eg '-flow'
+
+      * To perform an exact match, use character '@' in front of the term,
+        eg. '@git' would only match aliases, plugins and completions named 'git'.
+
+${echo_underline_yellow}FLAGS${echo_normal}
+   --enable       ${echo_purple}Enable all matching componenents.${echo_normal}
+   --disable      ${echo_purple}Disable all matching componenents.${echo_normal}
+   --help         ${echo_purple}Print this help.${echo_normal}
+   --refresh      ${echo_purple}Force a refresh of the search cache.${echo_normal}
+   --no-color     ${echo_purple}Disable color output and use monochrome text.${echo_normal}
+
+${echo_underline_yellow}EXAMPLES${echo_normal}
+
+   For example, ${echo_bold_green}bash-it search git${echo_normal} would match any alias, completion
+   or plugin that has the word 'git' in either the module name or
+   it's description. You should see something like this when you run this
+   command:
+
+         ${echo_bold_green}❯ bash-it search git${echo_bold_blue}
+               ${echo_bold_yellow}aliases:  ${echo_bold_green}git ${echo_normal}gitsvn
+               ${echo_bold_yellow}plugins:  ${echo_normal}autojump fasd ${echo_bold_green}git ${echo_normal}git-subrepo jgitflow jump
+           ${echo_bold_yellow}completions:  ${echo_bold_green}git ${echo_normal}git_flow git_flow_avh${echo_normal}
+
+   You can exclude some terms by prefixing a term with a minus, eg:
+
+         ${echo_bold_green}❯ bash-it search git -flow -svn${echo_bold_blue}
+               ${echo_bold_yellow}aliases:  ${echo_normal}git
+               ${echo_bold_yellow}plugins:  ${echo_normal}autojump fasd git git-subrepo jump
+           ${echo_bold_yellow}completions:  ${echo_normal}git${echo_normal}
+
+   Finally, if you prefix a term with '@' symbol, that indicates an exact
+   match. Note, that we also pass the '--enable' flag, which would ensure
+   that all matches are automatically enabled. The example is below:
+
+         ${echo_bold_green}❯ bash-it search @git --enable${echo_bold_blue}
+               ${echo_bold_yellow}aliases:  ${echo_normal}git
+               ${echo_bold_yellow}plugins:  ${echo_normal}git
+           ${echo_bold_yellow}completions:  ${echo_normal}git${echo_normal}
+
+${echo_underline_yellow}SUMMARY${echo_normal}
+
+   Take advantage of the search functionality to discover what Bash-It can do
+   for you. Try searching for partial term matches, mix and match with the
+   negative terms, or specify an exact matches of any number of terms. Once
+   you created the search command that returns ONLY the modules you need,
+   simply append '--enable' or '--disable' at the end to activate/deactivate
+   each module.
+
+"
+}
+
+_bash-it-cache-file() {
+  local component="${1}"
+  local file="/tmp/bash_it/${component}.status"
+  mkdir -p $(dirname ${file})
+  printf ${file}
+}
+
+_bash_it_search_cache_clean() {
+  local component="$1"
+  if [[ -z ${component} ]] ; then
+    for component in "${BASH_IT_COMPONENTS[@]}" ; do
+      _bash_it_search_cache_clean "${component}"
+    done
+  else
+    rm -f $(_bash-it-cache-file ${component})
+  fi
 }
 
 #———————————————————————————————————————————————————————————————————————————————
@@ -58,137 +185,261 @@ _bash-it-array-contains-element () {
   echo -n $r
 }
 
+_bash-it-array-dedup() {
+  echo "$*" | tr ' ' '\n' | sort -u | tr '\n' ' '
+}
+
+_bash-it-grep() {
+  if [[ -z "${BASH_IT_GREP}" ]] ; then
+    export BASH_IT_GREP="$(which egrep || which grep || '/usr/bin/grep')"
+  fi
+  printf "%s " "${BASH_IT_GREP}"
+}
+
+_bash-it-is-partial-match() {
+  local component="$1"
+  local term="$2"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -i -q -- "${term}"
+}
+
+_bash-it-component-term-matches-negation() {
+  local match="$1"; shift
+  local negative
+  for negative in "$@"; do
+    [[ "${match}" =~ "${negative}" ]] && return 0
+  done
+
+  return 1
+}
+
+_bash-it-component-help() {
+  local component="$1"
+  local file=$(_bash-it-cache-file ${component})
+  if [[ ! -s "${file}" || -z $(find "${file}" -mmin -2) ]] ; then
+    rm -f "${file}" 2>/dev/null
+    local func="_bash-it-${component}"
+    ${func} | $(_bash-it-grep) -E '   \[' | cat > ${file}
+  fi
+  cat "${file}"
+}
+
+_bash-it-component-list() {
+  local component="$1"
+  _bash-it-component-help "${component}" | awk '{print $1}' | uniq | sort | tr '\n' ' '
+}
+
+_bash-it-component-list-matching() {
+  local component="$1"; shift
+  local term="$1"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -- "${term}" | awk '{print $1}' | sort | uniq
+}
+
+_bash-it-component-list-enabled() {
+  local component="$1"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E  '\[x\]' | awk '{print $1}' | uniq | sort | tr '\n' ' '
+}
+
+_bash-it-component-list-disabled() {
+  local component="$1"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -v '\[x\]' | awk '{print $1}' | uniq | sort | tr '\n' ' '
+}
+
+_bash-it-component-item-is-enabled() {
+  local component="$1"
+  local item="$2"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E '\[x\]' |  $(_bash-it-grep) -E -q -- "^${item}\s"
+}
+
+_bash-it-component-item-is-disabled() {
+  local component="$1"
+  local item="$2"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -v '\[x\]' |  $(_bash-it-grep) -E -q -- "^${item}\s"
+}
+
+
 _bash-it-search-component() {
-  _about 'searches for given terms amongst a given component'
-  _param '1: component type, one of: [ aliases | plugins | completions ]'
-  _param '2: term1 '
-  _param '3: [-]term2 [-]term3 ...'
-  _example '$ _bash-it-search-component aliases rake bundler -chruby'
-
-  _component=$1
-
-  local func=_bash-it-${_component}
-  local help=$($func)
+  local component="$1"
   shift
 
+  _about 'searches for given terms amongst a given component'
+  _param '1: component type, one of: [ aliases | plugins | completions ]'
+  _param '2: term1 term2 @term3'
+  _param '3: [-]term4 [-]term5 ...'
+  _example '$ _bash-it-search-component aliases @git rake bundler -chruby'
+
   # if one of the search terms is --enable or --disable, we will apply
-  # this action to the matches further down.
-  local action action_func component_singular
-  declare -a _search_commands=(enable disable)
-  for _search_command in "${_search_commands[@]}"; do
-    if [[ $(_bash-it-array-contains-element "--${_search_command}" "$@") == "true" ]]; then
-      action=$_search_command
-      component_singular=${_component}
+  # this action to the matches further  ` down.
+  local component_singular action action_func
+  local -a search_commands=(enable disable)
+  for search_command in "${search_commands[@]}"; do
+    if [[ $(_bash-it-array-contains-element "--${search_command}" "$@") == "true" ]]; then
+      component_singular=${component}
       component_singular=${component_singular/es/}  # aliases -> alias
       component_singular=${component_singular/ns/n} # plugins -> plugin
+
+      action="${search_command}"
       action_func="_${action}-${component_singular}"
       break
     fi
   done
 
-  local _grep=$((which --skip-alias grep 2> /dev/null || which grep) | tail -n 1)
+  local -a terms=($@)           # passed on the command line
 
-  declare -a terms=($@)           # passed on the command line
-  declare -a matches=()           # results that we found
-  declare -a negative_terms=()    # terms that began with a dash
+  unset exact_terms
+  unset partial_terms
+  unset negative_terms
+
+  local -a exact_terms=()       # terms that should be included only if they match exactly
+  local -a partial_terms=()     # terms that should be included if they match partially
+  local -a negative_terms=()    # negated partial terms that should be excluded
+
+  unset component_list
+  local -a component_list=( $(_bash-it-component-list "${component}") )
+  local term
 
   for term in "${terms[@]}"; do
-    # -- can only be used for the actions: enable/disable
-    [[ "${term:0:2}" == "--" ]] && continue
-    [[ "${term:0:1}" == "-"  ]] && negative_terms=(${negative_terms[@]} ${term:1}) && continue
-
-    # print asterisk next to each result that is already enabled by the user
-    local term_match=($(echo "${help}"| ${_grep} -i -- ${term} | ${_grep} -E '\[( |x)\]' | cut -b -30 | sed 's/ *\[ \]//g;s/ *\[x\]/*/g;' ))
-    [[ "${#term_match[@]}" -gt 0 ]] && {
-      matches=(${matches[@]} ${term_match[@]}) # append to the list of results
-    }
+    local search_term="${term:1}"
+    if [[ "${term:0:2}" == "--" ]] ; then
+      continue
+    elif [[ "${term:0:1}" == "-"  ]] ; then
+      negative_terms=(${negative_terms[@]} "${search_term}")
+    elif [[ "${term:0:1}" == "@"  ]] ; then
+      if [[ $(_bash-it-array-contains-element "${search_term}" "${component_list[@]}") == "true" ]]; then
+        exact_terms=(${exact_terms[@]} "${search_term}")
+      fi
+    else
+      partial_terms=(${partial_terms[@]} $(_bash-it-component-list-matching "${component}" "${term}") )
+    fi
   done
 
-  # now check if we found any negative terms, and subtract them
-  [[ ${#negative_terms} -gt 0 ]] && {
-    declare -a filtered_matches=()
-    for match in "${matches[@]}"; do
-      local negations=0
-      for nt in "${negative_terms[@]}"; do
-        [[ "${match}" =~ "${nt}" ]] && negations=$(($negations+1))
-      done
-      [[ $negations -eq 0 ]] && filtered_matches=(${filtered_matches[@]} ${match})
-    done
-    matches=(${filtered_matches[@]})
-  }
+  local -a total_matches=( $(_bash-it-array-dedup ${exact_terms[@]} ${partial_terms[@]}) )
 
-  _bash-it-search-result $action $action_func
-
-  unset matches filtered_matches terms
+  unset matches
+  declare -a matches=()
+  for match in ${total_matches[@]}; do
+    local include_match=true
+    if  [[ ${#negative_terms[@]} -gt 0 ]]; then
+      ( _bash-it-component-term-matches-negation "${match}" "${negative_terms[@]}" ) && include_match=false
+    fi
+    ( ${include_match} ) && matches=(${matches[@]} "${match}")
+  done
+  _bash-it-search-result "${component}" "${action}" "${action_func}" "${matches[@]}"
+  unset matches final_matches terms
 }
 
 _bash-it-search-result() {
-  local action=$1; shift
-  local action_func=$1; shift
+  local component="$1"; shift
+  local action="$1"; shift
+  local action_func="$1"; shift
+  local -a matches=($@)
+
   local color_component color_enable color_disable color_off
 
-  [[ -z "$NO_COLOR" ]] && {
+  color_sep=':'
+
+  ( ${BASH_IT_SEARCH_USE_COLOR} ) && {
     color_component='\e[1;34m'
     color_enable='\e[1;32m'
+    suffix_enable=''
+    suffix_disable=''
     color_disable='\e[0;0m'
     color_off='\e[0;0m'
-    color_sep=':'
   }
 
-  [[ -n "$NO_COLOR" ]] && {
+  ( ${BASH_IT_SEARCH_USE_COLOR} ) || {
     color_component=''
-    color_sep='  => '
-    color_enable='✓'
+    suffix_enable=' ✓ ︎'
+    suffix_disable='  '
+    color_enable=''
     color_disable=''
     color_off=''
   }
 
-  if [[ "${#matches[*]}" -gt 0 ]] ; then
-    printf "${color_component}%13s${color_sep} ${color_off}" "${_component}"
+  local match
+  local modified=0
 
-    sorted_matches=($(echo "${matches[*]}" | tr ' ' '\n' | sort | uniq))
+  local flag="DEFER_CACHE_CLEANUP_FOR_${component}"
+  eval "export ${flag}=true"
 
-    for match in "${sorted_matches[@]}"; do
-      local match_color compatible_action
-      if [[ $match =~ "*" ]]; then
-        match_color=$color_enable
+  if [[ "${#matches[@]}" -gt 0 ]] ; then
+    printf "${color_component}%13s${color_sep} ${color_off}" "${component}"
+
+    for match in "${matches[@]}"; do
+      local enabled=0
+      ( _bash-it-component-item-is-enabled "${component}" "${match}" ) && enabled=1
+
+      local match_color compatible_action suffix opposite_suffix
+
+      (( ${enabled} )) && {
+        match_color=${color_enable}
+        suffix=${suffix_enable}
+        opposite_suffix=${suffix_disable}
         compatible_action="disable"
-      else
-        match_color=$color_disable
-        compatible_action="enable"
-      fi
+      }
 
-      match_value=${match/\*/}  # remove asterisk
-      len=${#match_value}
-      if [[ -n $NO_COLOR ]]; then
-        local m="${match_color}${match_value}"
+      (( ${enabled} )) || {
+        match_color=${color_disable}
+        suffix=${suffix_disable}
+        opposite_suffix=${suffix_enable}
+        compatible_action="enable"
+      }
+
+      local len
+      if ( ${BASH_IT_SEARCH_USE_COLOR} ); then
+        local m="${match_color}${match}${suffix}"
+        len=${#m}
+      else
+        local m="${match}${suffix}"
         len=${#m}
       fi
 
-      printf " ${match_color}${match_value}"  # print current state
-
+      printf " ${match_color}${match}${suffix}"  # print current state
       if [[ "${action}" == "${compatible_action}" ]]; then
-        # oh, i see – we need to either disable enabled, or enable disabled
-        # component. Let's start with the most important part: redrawing
-        # the search result backwards. Because style.
-
-        printf "\033[${len}D"
-        for a in {0..30}; do
-          [[ $a -gt $len ]] && break
-          printf "%.*s" $a " "
-          sleep 0.07 # who knew you could sleep for fraction of the cost :)
-        done
-        printf "\033[${len}D"
-        result=$(${action_func} ${match_value})
+        if [[ ${action} == "enable" && ${BASH_IT_SEARCH_USE_COLOR} == false ]]; then
+          _bash-it-flash-term ${len} "${match}${suffix}"
+        else
+          _bash-it-erase-term ${len}
+        fi
+        modified=1
+        result=$(${action_func} ${match})
         local temp="color_${compatible_action}"
         match_color=${!temp}
-        printf "${match_color}${match_value}"
+        _bash-it-rewind ${len}
+        printf "${match_color}${match}${opposite_suffix}"
       fi
 
       printf "${color_off}"
     done
 
+    [[ ${modified} -gt 0 ]] && _bash_it_search_cache_clean ${component}
     printf "\n"
   fi
+}
 
+_bash-it-rewind() {
+  local len="$1"
+  printf "\033[${len}D"
+}
+
+_bash-it-flash-term() {
+  local len="$1"
+  local match="$2"
+  local delay=0.1
+  local color
+
+  for color in ${text_black} ${echo_bold_blue} ${bold_yellow} ${bold_red} ${echo_bold_green} ; do
+    sleep ${delay}
+    _bash-it-rewind "${len}"
+    printf "${color}${match}"
+  done
+}
+
+_bash-it-erase-term() {
+  local len="$1"
+  _bash-it-rewind ${len}
+  for a in {0..30}; do
+    [[ ${a} -gt ${len} ]] && break
+    printf "%.*s" $a " "
+    sleep 0.05
+  done
 }

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# A collection of reusable functions.
+
+###########################################################################
+# Component-specific functions (component is either an alias, a plugin, or a
+# completion).
+###########################################################################
+
+_bash-it-component-help() {
+  local component=$(_bash-it-pluralize-component "${1}")
+  local file=$(_bash-it-component-cache-file ${component})
+  if [[ ! -s "${file}" || -z $(find "${file}" -mmin -300) ]] ; then
+    rm -f "${file}" 2>/dev/null
+    local func="_bash-it-${component}"
+    ${func} | $(_bash-it-grep) -E '   \[' | cat > ${file}
+  fi
+  cat "${file}"
+}
+
+_bash-it-component-cache-file() {
+  local component=$(_bash-it-pluralize-component "${1}")
+  local file="${BASH_IT}/tmp/cache/${component}"
+  [[ -f ${file} ]] || mkdir -p $(dirname ${file})
+  printf "${file}"
+}
+
+_bash-it-pluralize-component() {
+  local component="${1}"
+  local len=$(( ${#component} - 1 ))
+  # pluralize component name for consistency
+  [[ ${component:${len}:1} != 's' ]] && component="${component}s"
+  [[ ${component} == "alias" ]] && component="aliases"
+  printf ${component}
+}
+
+_bash-it-clean-component-cache() {
+  local component="$1"
+  local cache
+  local -a BASH_IT_COMPONENTS=(aliases plugins completions)
+  if [[ -z ${component} ]] ; then
+    for component in "${BASH_IT_COMPONENTS[@]}" ; do
+      _bash-it-clean-component-cache "${component}"
+    done
+  else
+    cache="$(_bash-it-component-cache-file ${component})"
+    [[ -f "${cache}" ]] && rm -f "${cache}"
+  fi
+}
+
+###########################################################################
+# Generic utilies
+###########################################################################
+
+# This function searches an array for an exact match against the term passed
+# as the first argument to the function. This function exits as soon as
+# a match is found.
+#
+# Returns:
+#   0 when a match is found, otherwise 1.
+#
+# Examples:
+#   $ declare -a fruits=(apple orange pear mandarin)
+#
+#   $ _bash-it-array-contains-element apple "@{fruits[@]}" && echo 'contains apple'
+#   contains apple
+#
+#   $ if $(_bash-it-array-contains-element pear "${fruits[@]}"); then
+#       echo "contains pear!"
+#     fi
+#   contains pear!
+#
+#
+_bash-it-array-contains-element() {
+  local e
+  for e in "${@:2}"; do
+    [[ "$e" == "$1" ]] && return 0
+  done
+  return 1
+}
+
+# Dedupe a simple array of words without spaces.
+_bash-it-array-dedup() {
+  echo "$*" | tr ' ' '\n' | sort -u | tr '\n' ' '
+}
+
+# Outputs a full path of the gre found on the filesystem
+_bash-it-grep() {
+  if [[ -z "${BASH_IT_GREP}" ]] ; then
+    export BASH_IT_GREP="$(which egrep || which grep || '/usr/bin/grep')"
+  fi
+  printf "%s " "${BASH_IT_GREP}"
+}
+
+
+# Returns an array of items within each compoenent.
+_bash-it-component-list() {
+  local component="$1"
+  _bash-it-component-help "${component}" | awk '{print $1}' | uniq | sort | tr '\n' ' '
+}
+
+_bash-it-component-list-matching() {
+  local component="$1"; shift
+  local term="$1"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -- "${term}" | awk '{print $1}' | sort | uniq
+}
+
+_bash-it-component-list-enabled() {
+  local component="$1"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E  '\[x\]' | awk '{print $1}' | uniq | sort | tr '\n' ' '
+}
+
+_bash-it-component-list-disabled() {
+  local component="$1"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -v '\[x\]' | awk '{print $1}' | uniq | sort | tr '\n' ' '
+}
+
+# Checks if a given item is enabled for a particular component/file-type.
+# Uses the component cache if available.
+#
+# Returns:
+#    0 if an item of the component is enabled, 1 otherwise.
+#
+# Examples:
+#    _bash-it-component-item-is-enabled alias git && echo "git alias is enabled"
+_bash-it-component-item-is-enabled() {
+  local component="$1"
+  local item="$2"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E '\[x\]' |  $(_bash-it-grep) -E -q -- "^${item}\s"
+}
+
+# Checks if a given item is disabled for a particular component/file-type.
+# Uses the component cache if available.
+#
+# Returns:
+#    0 if an item of the component is enabled, 1 otherwise.
+#
+# Examples:
+#    _bash-it-component-item-is-disabled alias git && echo "git aliases are disabled"
+_bash-it-component-item-is-disabled() {
+  local component="$1"
+  local item="$2"
+  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -v '\[x\]' |  $(_bash-it-grep) -E -q -- "^${item}\s"
+}

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -2,6 +2,7 @@
 
 load ../test_helper
 load ../../lib/composure
+load ../../lib/utilities
 load ../../lib/search
 load ../../plugins/available/base.plugin
 

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -2,6 +2,7 @@
 
 load ../test_helper
 load ../../lib/composure
+load ../../lib/search
 load ../../plugins/available/base.plugin
 
 cite _about _param _example _group _author _version

--- a/test/lib/search.bats
+++ b/test/lib/search.bats
@@ -3,6 +3,7 @@
 load ../test_helper
 load ../../lib/composure
 load ../../lib/helpers
+load ../../lib/utilities
 load ../../lib/search
 load ../../plugins/available/base.plugin
 load ../../aliases/available/git.aliases
@@ -27,6 +28,7 @@ function local_setup {
   rm -rf "$BASH_IT"/aliases/enabled
   rm -rf "$BASH_IT"/completion/enabled
   rm -rf "$BASH_IT"/plugins/enabled
+  rm -rf "$BASH_IT"/tmp/cache
 
   mkdir -p "$BASH_IT"/enabled
   mkdir -p "$BASH_IT"/aliases/enabled

--- a/test/lib/search.bats
+++ b/test/lib/search.bats
@@ -1,16 +1,20 @@
 #!/usr/bin/env bats
 
 load ../test_helper
-
 load ../../lib/composure
+load ../../lib/helpers
+load ../../lib/search
 load ../../plugins/available/base.plugin
+load ../../aliases/available/git.aliases
+load ../../plugins/available/ruby.plugin
+load ../../plugins/available/rails.plugin
+load ../../completion/available/bundler.completion
+load ../../completion/available/gem.completion
+load ../../completion/available/rake.completion
 
 cite _about _param _example _group _author _version
 
 load ../../lib/helpers
-load ../../lib/search
-
-NO_COLOR=true
 
 function local_setup {
   mkdir -p "$BASH_IT"
@@ -23,46 +27,68 @@ function local_setup {
   rm -rf "$BASH_IT"/aliases/enabled
   rm -rf "$BASH_IT"/completion/enabled
   rm -rf "$BASH_IT"/plugins/enabled
+
+  mkdir -p "$BASH_IT"/enabled
+  mkdir -p "$BASH_IT"/aliases/enabled
+  mkdir -p "$BASH_IT"/completion/enabled
+  mkdir -p "$BASH_IT"/plugins/enabled
+
+  export OLD_PATH="$PATH"
+  export PATH="/usr/bin:/bin:/usr/sbin"
+}
+
+function local_teardown {
+  export PATH="$OLD_PATH"
+  unset OLD_PATH
 }
 
 @test "search: plugin base" {
+  export BASH_IT_SEARCH_USE_COLOR=false
   run _bash-it-search-component 'plugins' 'base'
-  [[ "${lines[0]}" =~ 'plugins' && "${lines[0]}" =~ 'base' ]]
+  assert_line -n 0 '      plugins:  base  '
+}
+
+@test "search: git" {
+  run _bash-it-search 'git' --no-color
+  assert_line -n 0 '      aliases:  git   gitsvn  '
+  assert_line -n 1 '      plugins:  autojump   fasd   git   git-subrepo   jgitflow   jump  '
+  assert_line -n 2 '  completions:  git   git_flow   git_flow_avh  '
 }
 
 @test "search: ruby gem bundle rake rails" {
-  # first disable them all, so that  the output does not appear with a checkbox
-  # and we can compare the result
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails' '--disable'
-  # Now perform the search
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails'
-  # And verify
-  assert [ "${lines[0]/✓/}" == '      aliases  =>   bundler rails' ]
-  assert [ "${lines[1]/✓/}" == '      plugins  =>   chruby chruby-auto rails ruby' ]
-  assert [ "${lines[2]/✓/}" == '  completions  =>   bundler gem rake' ]
+  run _bash-it-search rails ruby gem bundler rake --no-color
+
+  assert_line -n 0 '      aliases:  bundler   rails  '
+  assert_line -n 1 '      plugins:  chruby   chruby-auto   rails   ruby  '
+  assert_line -n 2 '  completions:  bundler   gem   rake  '
 }
 
-@test "search: ruby gem bundle -chruby rake rails" {
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails' '--disable'
-  run _bash-it-search 'ruby' 'gem' 'bundle' '-chruby' 'rake' 'rails'
-  assert [ "${lines[0]/✓/}" == '      aliases  =>   bundler rails' ]
-  assert [ "${lines[1]/✓/}" == '      plugins  =>   rails ruby' ]
-  assert [ "${lines[2]/✓/}" == '  completions  =>   bundler gem rake' ]
+@test "search: rails ruby gem bundler rake -chruby" {
+  run _bash-it-search rails ruby gem bundler rake -chruby --no-color
+
+  assert_line -n 0 '      aliases:  bundler   rails  '
+  assert_line -n 1 '      plugins:  rails   ruby  '
+  assert_line -n 2 '  completions:  bundler   gem   rake  '
 }
 
-@test "search: (rails enabled) ruby gem bundle rake rails" {
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails' '--disable'
-  run _enable-alias 'rails'
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' 'rails'
-  assert_line -n 0 '      aliases  =>   bundler ✓rails'
-  assert_line -n 1 '      plugins  =>   chruby chruby-auto rails ruby'
-  assert_line -n 2 '  completions  =>   bundler gem rake'
+@test "search: @git" {
+  run _bash-it-search '@git' --no-color
+  assert_line -n 0 '      aliases:  git  '
+  assert_line -n 1 '      plugins:  git  '
+  assert_line -n 2 '  completions:  git  '
 }
 
-@test "search: (all enabled) ruby gem bundle rake rails" {
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' '-chruby' 'rails' '--enable'
-  run _bash-it-search 'ruby' 'gem' 'bundle' 'rake' '-chruby' 'rails'
-  assert_line -n 0 '      aliases  =>   ✓bundler ✓rails'
-  assert_line -n 1 '      plugins  =>   ✓rails ✓ruby'
-  assert_line -n 2 '  completions  =>   ✓bundler ✓gem ✓rake'
+@test "search: @git --enable / --disable" {
+  set -e
+  run _bash-it-search '@git' --enable --no-color
+  run _bash-it-search '@git' --no-color
+
+  [[ "${lines[0]}"  =~ '✓' ]]
+
+  run _bash-it-search '@git' --disable --no-color
+  run _bash-it-search '@git' --no-color
+
+  assert_line -n 0 '      aliases:  git  '
+  assert_line -n 0 '      aliases:  git  '
+  assert_line -n 2 '  completions:  git  '
 }

--- a/test/lib/utilities.bats
+++ b/test/lib/utilities.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+load ../../lib/composure
+load ../../lib/helpers
+load ../../lib/utilities
+load ../../lib/search
+
+cite _about _param _example _group _author _version
+
+function local_setup {
+  mkdir -p "$BASH_IT"
+  lib_directory="$(cd "$(dirname "$0")" && pwd)"
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
+  rm -rf "$BASH_IT"/tmp/cache
+
+  mkdir -p "$BASH_IT"/enabled
+  mkdir -p "$BASH_IT"/aliases/enabled
+  mkdir -p "$BASH_IT"/completion/enabled
+  mkdir -p "$BASH_IT"/plugins/enabled
+}
+
+function has_match() {
+  $(_bash-it-array-contains-element ${@}) && echo "has" "$1"
+}
+
+function item_enabled() {
+  $(_bash-it-component-item-is-enabled ${@}) && echo "$1" "$2" "is enabled"
+}
+
+function item_disabled() {
+  $(_bash-it-component-item-is-disabled ${@}) && echo "$1" "$2" "is disabled"
+}
+
+@test "_bash-it-component-item-is-enabled() - for a disabled item" {
+  run item_enabled aliases svn
+  assert_line -n 0 ''
+}
+
+@test "_bash-it-component-item-is-enabled() - for an enabled/disabled item" {
+  run bash-it enable alias svn
+  assert_line -n 0 'svn enabled with priority 150.'
+
+  run item_enabled alias svn
+  assert_line -n 0 'alias svn is enabled'
+
+  run bash-it disable alias svn
+  assert_line -n 0 'svn disabled.'
+
+  run item_enabled alias svn
+  assert_line -n 0 ''
+}
+
+@test "_bash-it-component-item-is-disabled() - for a disabled item" {
+  run item_disabled alias svn
+  assert_line -n 0 'alias svn is disabled'
+}
+
+@test "_bash-it-component-item-is-disabled() - for an enabled/disabled item" {
+  run bash-it enable alias svn
+  assert_line -n 0 'svn enabled with priority 150.'
+
+  run item_disabled alias svn
+  assert_line -n 0 ''
+
+  run bash-it disable alias svn
+  assert_line -n 0 'svn disabled.'
+
+  run item_disabled alias svn
+  assert_line -n 0 'alias svn is disabled'
+}
+
+@test "_bash-it-array-contains-element() - when match is found, and is the first" {
+  declare -a fruits=(apple pear orange mandarin)
+  run has_match apple "${fruits[@]}"
+  assert_line -n 0 'has apple'
+}
+
+@test "_bash-it-array-contains-element() - when match is found, and is the last" {
+  declare -a fruits=(apple pear orange mandarin)
+  run has_match mandarin "${fruits[@]}"
+  assert_line -n 0 'has mandarin'
+}
+
+@test "_bash-it-array-contains-element() - when match is found, and is in the middle" {
+  declare -a fruits=(apple pear orange mandarin)
+  run has_match pear "${fruits[@]}"
+  assert_line -n 0 'has pear'
+}
+
+@test "_bash-it-array-contains-element() - when match is found, and it has spaces" {
+  declare -a fruits=(apple pear orange mandarin "yellow watermelon")
+  run has_match "yellow watermelon" "${fruits[@]}"
+  assert_line -n 0 'has yellow watermelon'
+}
+
+@test "_bash-it-array-contains-element() - when match is not found" {
+  declare -a fruits=(apple pear orange mandarin)
+  run has_match xyz "${fruits[@]}"
+  assert_line -n 0 ''
+}


### PR DESCRIPTION
This commit improves Bash-It search functionality in a couple of ways:

 * `bash-it search` (with no arguments) will print detailed help.
 * `bash-it search` now accepts terms prefixed with '@' sign, indicating an exact match.
 * `bash-it search` now performs smarter caching of the component listings/status
 * The cache is automatically wiped upon a component enable/disable.
 * The cache can be force-wiped by passing `--refresh` to the `bash-it search` command.
 * Search command should now be much much faster in general.

The slightly improved search syntax is as follows:

```bash
$ bash-it search [-|@]term1 [-|@]term2 ... \
      [ -e/--enable ] [ -d/--disable ] [ -r/--refresh ] [ -c/--no-color ]
```