### PR TITLE
[bugfix][wip] Fixed issue with Debian's bash-completion

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -43,8 +43,16 @@ _load_global_bash_it_files
 # Load enabled aliases, completion, plugins
 for file_type in "aliases" "plugins" "completion"
 do
-  _load_bash_it_files $file_type
+  _bash_it_list_bash_it_files_return=()
+  _list_bash_it_files $file_type
+
+  for config_file in "${_bash_it_list_bash_it_files_return[@]}" ; do
+    . "$config_file"
+  done
 done
+
+unset _bash_it_list_bash_it_files_return
+unset _bash_it_config_file
 
 # Load theme, if a theme was set
 if [[ ! -z "${BASH_IT_THEME}" ]]; then

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -14,16 +14,18 @@ function _command_exists ()
   type "$1" &> /dev/null ;
 }
 
-# Helper function loading various enable-able files
-function _load_bash_it_files() {
+# Helper function listing various enable-able files to be sourced
+# The files need to be sourced in global scope to preserve scope of 'declare'
+function _list_bash_it_files() {
   subdirectory="$1"
   if [ -d "${BASH_IT}/${subdirectory}/enabled" ]
   then
     FILES="${BASH_IT}/${subdirectory}/enabled/*.bash"
-    for config_file in $FILES
+
+    for _bash_it_config_file in $FILES
     do
-      if [ -e "${config_file}" ]; then
-        source $config_file
+      if [ -e "${_bash_it_config_file}" ]; then
+        _bash_it_list_bash_it_files_return+=("$_bash_it_config_file")
       fi
     done
   fi
@@ -43,20 +45,23 @@ function _load_global_bash_it_files() {
   fi
 }
 
-# Function for reloading aliases
-function reload_aliases() {
-  _load_bash_it_files "aliases"
+function _make_reload_alias() {
+  printf %s '\
+  _bash_it_list_bash_it_files_return=() ;\
+  _list_bash_it_files '"$1"' ;\
+  for _bash_it_config_file in "${_bash_it_list_bash_it_files_return[@]}"; do \
+    . "$_bash_it_config_file" ;\
+  done'
 }
 
-# Function for reloading auto-completion
-function reload_completion() {
-  _load_bash_it_files "completion"
-}
+# Alias for reloading aliases
+alias reload_aliases="$(_make_reload_alias aliases)"
 
-# Function for reloading plugins
-function reload_plugins() {
-  _load_bash_it_files "plugins"
-}
+# Alias for reloading auto-completion
+alias reload_completion="$(_make_reload_alias completion)"
+
+# Alias for reloading plugins
+alias reload_plugins="$(_make_reload_alias plugins)"
 
 bash-it ()
 {

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -51,7 +51,9 @@ function _make_reload_alias() {
   _list_bash_it_files '"$1"' ;\
   for _bash_it_config_file in "${_bash_it_list_bash_it_files_return[@]}"; do \
     . "$_bash_it_config_file" ;\
-  done'
+  done ;\
+  unset _bash_it_list_bash_it_files_return ;\
+  unset _bash_it_config_file'
 }
 
 # Alias for reloading aliases


### PR DESCRIPTION
This is a WIP fix for #1245 
In broad terms, the issue is that

- `declare` is local when run in a function.
- We source scripts (including, indirectly, system scripts out of our control) from within a function.
- Some of these scripts might use `declare` in their global scope, and expect declared variable to exist on subsequent calls. Sourcing them in function scope will (and does) lead to incorrect behavior.

`declare -g` is used in Bash 4.2+ to declare a global variable from within a function, but generally won't be used by scripts that are meant to be sourced directly from e.g. .bashrc.

AFAICT, this means we need to source scripts directly from global scope rather that from a function.
The same goes for reloading them.

This is less than ideal, but I don't see another way of ensuring correctness.

This PR is a WIP for several reasons:

- I have not applied the changes to _load_global_bash_it_files
- I used ugly prefixed global variables to avoid conflicting with the user's variables, especially since reload_* might be run at any time. Is there a reason why the code doesn't use `local`?
- I'm not too proud of the global array used to return a list of files - any better suggestion would be appreciated.