### PR TITLE
Bugfix/bash completion debian

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -29,30 +29,27 @@ cite _about _param _example _group _author _version
 # libraries, but skip appearance (themes) for now
 LIB="${BASH_IT}/lib/*.bash"
 APPEARANCE_LIB="${BASH_IT}/lib/appearance.bash"
-for config_file in $LIB
+for _bash_it_config_file in $LIB
 do
-  if [ "$config_file" != "$APPEARANCE_LIB" ]; then
+  if [ "$_bash_it_config_file" != "$APPEARANCE_LIB" ]; then
     # shellcheck disable=SC1090
-    source "$config_file"
+    source "$_bash_it_config_file"
   fi
 done
 
 # Load the global "enabled" directory
-_load_global_bash_it_files
+# "family" param is empty so that files get sources in glob order
+for _bash_it_config_file in $(_list_global_bash_it_files "") ; do
+  . "${BASH_IT}/$_bash_it_config_file"
+done
 
 # Load enabled aliases, completion, plugins
 for file_type in "aliases" "plugins" "completion"
 do
-  _bash_it_list_bash_it_files_return=()
-  _list_bash_it_files $file_type
-
-  for config_file in "${_bash_it_list_bash_it_files_return[@]}" ; do
-    . "$config_file"
+  for _bash_it_config_file in $(_list_bash_it_files "$file_type") ; do
+    . "${BASH_IT}/$_bash_it_config_file"
   done
 done
-
-unset _bash_it_list_bash_it_files_return
-unset _bash_it_config_file
 
 # Load theme, if a theme was set
 if [[ ! -z "${BASH_IT_THEME}" ]]; then
@@ -83,15 +80,15 @@ done
 
 # Custom
 CUSTOM="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/*.bash ${BASH_IT_CUSTOM:=${BASH_IT}/custom}/**/*.bash"
-for config_file in $CUSTOM
+for _bash_it_config_file in $CUSTOM
 do
-  if [ -e "${config_file}" ]; then
+  if [ -e "${_bash_it_config_file}" ]; then
     # shellcheck disable=SC1090
-    source "$config_file"
+    source "$_bash_it_config_file"
   fi
 done
 
-unset config_file
+unset _bash_it_config_file
 if [[ $PROMPT ]]; then
   export PS1="\[""$PROMPT""\]"
 fi

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -43,8 +43,16 @@ _load_global_bash_it_files
 # Load enabled aliases, completion, plugins
 for file_type in "aliases" "plugins" "completion"
 do
-  _load_bash_it_files $file_type
+  _bash_it_list_bash_it_files_return=()
+  _list_bash_it_files $file_type
+
+  for config_file in "${_bash_it_list_bash_it_files_return[@]}" ; do
+    . "$config_file"
+  done
 done
+
+unset _bash_it_list_bash_it_files_return
+unset _bash_it_config_file
 
 # Load theme, if a theme was set
 if [[ ! -z "${BASH_IT_THEME}" ]]; then

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -14,16 +14,18 @@ function _command_exists ()
   type "$1" &> /dev/null ;
 }
 
-# Helper function loading various enable-able files
-function _load_bash_it_files() {
+# Helper function listing various enable-able files to be sourced
+# The files need to be sourced in global scope to preserve scope of 'declare'
+function _list_bash_it_files() {
   subdirectory="$1"
   if [ -d "${BASH_IT}/${subdirectory}/enabled" ]
   then
     FILES="${BASH_IT}/${subdirectory}/enabled/*.bash"
-    for config_file in $FILES
+
+    for _bash_it_config_file in $FILES
     do
-      if [ -e "${config_file}" ]; then
-        source $config_file
+      if [ -e "${_bash_it_config_file}" ]; then
+        _bash_it_list_bash_it_files_return+=("$_bash_it_config_file")
       fi
     done
   fi
@@ -43,20 +45,23 @@ function _load_global_bash_it_files() {
   fi
 }
 
-# Function for reloading aliases
-function reload_aliases() {
-  _load_bash_it_files "aliases"
+function _make_reload_alias() {
+  printf %s '\
+  _bash_it_list_bash_it_files_return=() ;\
+  _list_bash_it_files '"$1"' ;\
+  for _bash_it_config_file in "${_bash_it_list_bash_it_files_return[@]}"; do \
+    . "$_bash_it_config_file" ;\
+  done'
 }
 
-# Function for reloading auto-completion
-function reload_completion() {
-  _load_bash_it_files "completion"
-}
+# Alias for reloading aliases
+alias reload_aliases="$(_make_reload_alias aliases)"
 
-# Function for reloading plugins
-function reload_plugins() {
-  _load_bash_it_files "plugins"
-}
+# Alias for reloading auto-completion
+alias reload_completion="$(_make_reload_alias completion)"
+
+# Alias for reloading plugins
+alias reload_plugins="$(_make_reload_alias plugins)"
 
 bash-it ()
 {

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -62,14 +62,12 @@ function _make_reload_alias() {
   local subdirectory="$2"
 
   printf %s '
-  for _bash_it_config_file in $(_list_global_bash_it_files '"$global_family"'); do \
-    . "${BASH_IT}/$_bash_it_config_file" ;\
+  for _bash_it_config_file in $(_list_global_bash_it_files '"$global_family"'); do
+    . "${BASH_IT}/$_bash_it_config_file"
   done ;\
-  \
-  for _bash_it_config_file in $(_list_bash_it_files '"$subdirectory"'); do \
-    . "${BASH_IT}/$_bash_it_config_file" ;\
+  for _bash_it_config_file in $(_list_bash_it_files '"$subdirectory"'); do
+    . "${BASH_IT}/$_bash_it_config_file"
   done ;\
-  \
   unset _bash_it_config_file'
 }
 

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -56,26 +56,28 @@ function _list_global_bash_it_files() {
 }
 
 function _make_reload_alias() {
-  printf %s '
+  local global_family="$1"
+  local subdirectory="$2"
 
-  for _bash_it_config_file in $(_list_global_bash_it_files '"$1"'); do \
+  printf %s '
+  for _bash_it_config_file in $(_list_global_bash_it_files '"$global_family"'); do \
     . "${BASH_IT}/$_bash_it_config_file" ;
   done ;
 
-  for _bash_it_config_file in $(_list_bash_it_files '"$1"'); do
+  for _bash_it_config_file in $(_list_bash_it_files '"$subdirectory"'); do
     . "${BASH_IT}/$_bash_it_config_file" ;
   done ;
   unset _bash_it_config_file'
 }
 
 # Alias for reloading aliases
-alias reload_aliases="$(_make_reload_alias aliases)"
+alias reload_aliases="$(_make_reload_alias alias aliases)"
 
 # Alias for reloading auto-completion
-alias reload_completion="$(_make_reload_alias completion)"
+alias reload_completion="$(_make_reload_alias completion completion)"
 
 # Alias for reloading plugins
-alias reload_plugins="$(_make_reload_alias plugins)"
+alias reload_plugins="$(_make_reload_alias plugin plugins)"
 
 bash-it ()
 {

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -17,42 +17,54 @@ function _command_exists ()
 # Helper function listing various enable-able files to be sourced
 # The files need to be sourced in global scope to preserve scope of 'declare'
 function _list_bash_it_files() {
-  subdirectory="$1"
-  if [ -d "${BASH_IT}/${subdirectory}/enabled" ]
+  local subdirectory="$1"
+  pushd "${BASH_IT}" >/dev/null
+
+  if [ -d "./${subdirectory}/enabled" ]
   then
-    FILES="${BASH_IT}/${subdirectory}/enabled/*.bash"
+    local FILES="./${subdirectory}/enabled/*.bash"
+    local _bash_it_config_file
 
     for _bash_it_config_file in $FILES
     do
       if [ -e "${_bash_it_config_file}" ]; then
-        _bash_it_list_bash_it_files_return+=("$_bash_it_config_file")
+        printf "$_bash_it_config_file\n"
       fi
     done
   fi
+
+  popd >/dev/null
 }
 
-function _load_global_bash_it_files() {
+function _list_global_bash_it_files() {
+  local family="$1"
+  pushd "${BASH_IT}" >/dev/null
+
   # In the new structure
-  if [ -d "${BASH_IT}/enabled" ]
+  if [ -d "./enabled" ]
   then
-    FILES="${BASH_IT}/enabled/*.bash"
-    for config_file in $FILES
+    local FILES="./enabled/*$family.bash"
+    local _bash_it_config_file
+
+    for _bash_it_config_file in $FILES
     do
-      if [ -e "${config_file}" ]; then
-        source $config_file
+      if [ -e "${_bash_it_config_file}" ]; then
+        printf "$_bash_it_config_file\n"
       fi
     done
   fi
 }
 
 function _make_reload_alias() {
-  printf %s '\
-  _bash_it_list_bash_it_files_return=() ;\
-  _list_bash_it_files '"$1"' ;\
-  for _bash_it_config_file in "${_bash_it_list_bash_it_files_return[@]}"; do \
-    . "$_bash_it_config_file" ;\
-  done ;\
-  unset _bash_it_list_bash_it_files_return ;\
+  printf %s '
+
+  for _bash_it_config_file in $(_list_global_bash_it_files '"$1"'); do \
+    . "${BASH_IT}/$_bash_it_config_file" ;
+  done ;
+
+  for _bash_it_config_file in $(_list_bash_it_files '"$1"'); do
+    . "${BASH_IT}/$_bash_it_config_file" ;
+  done ;
   unset _bash_it_config_file'
 }
 

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -51,7 +51,9 @@ function _make_reload_alias() {
   _list_bash_it_files '"$1"' ;\
   for _bash_it_config_file in "${_bash_it_list_bash_it_files_return[@]}"; do \
     . "$_bash_it_config_file" ;\
-  done'
+  done ;\
+  unset _bash_it_list_bash_it_files_return ;\
+  unset _bash_it_config_file'
 }
 
 # Alias for reloading aliases

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -53,6 +53,8 @@ function _list_global_bash_it_files() {
       fi
     done
   fi
+
+  popd >/dev/null
 }
 
 function _make_reload_alias() {
@@ -61,12 +63,13 @@ function _make_reload_alias() {
 
   printf %s '
   for _bash_it_config_file in $(_list_global_bash_it_files '"$global_family"'); do \
-    . "${BASH_IT}/$_bash_it_config_file" ;
-  done ;
-
-  for _bash_it_config_file in $(_list_bash_it_files '"$subdirectory"'); do
-    . "${BASH_IT}/$_bash_it_config_file" ;
-  done ;
+    . "${BASH_IT}/$_bash_it_config_file" ;\
+  done ;\
+  \
+  for _bash_it_config_file in $(_list_bash_it_files '"$subdirectory"'); do \
+    . "${BASH_IT}/$_bash_it_config_file" ;\
+  done ;\
+  \
   unset _bash_it_config_file'
 }
 


### PR DESCRIPTION
This is a WIP fix for #1245 
In broad terms, the issue is that

- `declare` is local when run in a function.
- We source scripts (including, indirectly, system scripts out of our control) from within a function.
- Some of these scripts might use `declare` in their global scope, and expect declared variable to exist on subsequent calls. Sourcing them in function scope will (and does) lead to incorrect behavior.

`declare -g` is used in Bash 4.2+ to declare a global variable from within a function, but generally won't be used by scripts that are meant to be sourced directly from e.g. .bashrc.

AFAICT, this means we need to source scripts directly from global scope rather that from a function.
The same goes for reloading them.

This is less than ideal, but I don't see another way of ensuring correctness.

This PR is a WIP for several reasons:

- I have not applied the changes to _load_global_bash_it_files
- I used ugly prefixed global variables to avoid conflicting with the user's variables, especially since reload_* might be run at any time. Is there a reason why the code doesn't use `local`?
- I'm not too proud of the global array used to return a list of files - any better suggestion would be appreciated.