### PR TITLE
Show upgrades before blindly upgrading

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -181,18 +181,31 @@ _bash-it_update() {
   status="$(git rev-list master..${BASH_IT_REMOTE}/master 2> /dev/null)"
 
   if [[ -n "${status}" ]]; then
-    git pull --rebase &> /dev/null
-    if [[ $? -eq 0 ]]; then
-      echo "Bash-it successfully updated."
-      echo ""
-      echo "Migrating your installation to the latest version now..."
-      _bash-it-migrate
-      echo ""
-      echo "All done, enjoy!"
-      bash-it reload
-    else
-      echo "Error updating Bash-it, please, check if your Bash-it installation folder (${BASH_IT}) is clean."
-    fi
+    git log --merges --format="%h: %b (%an)" master..${BASH_IT_REMOTE}/master
+    echo ""
+    read -e -n 1 -p "Would you like to update to $(git log -1 --format=%h origin/master)? [Y/n] " RESP
+    case $RESP in
+      [yY]|"")
+        git pull --rebase &> /dev/null
+        if [[ $? -eq 0 ]]; then
+          echo "Bash-it successfully updated."
+          echo ""
+          echo "Migrating your installation to the latest version now..."
+          _bash-it-migrate
+          echo ""
+          echo "All done, enjoy!"
+          bash-it reload
+        else
+          echo "Error updating Bash-it, please, check if your Bash-it installation folder (${BASH_IT}) is clean."
+        fi
+        ;;
+      [nN])
+        echo "Not upgrading…"
+        ;;
+      *)
+        echo -e "\033[91mPlease choose y or n.\033[m"
+        ;;
+      esac
   else
     echo "Bash-it is up to date, nothing to do!"
   fi

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -181,7 +181,16 @@ _bash-it_update() {
   status="$(git rev-list master..${BASH_IT_REMOTE}/master 2> /dev/null)"
 
   if [[ -n "${status}" ]]; then
-    git log --merges --format="%h: %b (%an)" master..${BASH_IT_REMOTE}/master
+
+    for i in $(git rev-list --merges master..${BASH_IT_REMOTE}); do
+      num_of_lines=$(git log -1 --format=%B $i | awk 'NF' | wc -l)
+      if [ $num_of_lines -eq 1 ]; then
+        description="%s"
+      else
+        description="%b"
+      fi
+      git log --format="%h: $description (%an)" -1 $i
+    done
     echo ""
     read -e -n 1 -p "Would you like to update to $(git log -1 --format=%h origin/master)? [Y/n] " RESP
     case $RESP in


### PR DESCRIPTION
This fixes #1038 by showing the merge commits prior to upgrading and prompting the user to accept them. 

This is a bit crazy to test. Here's how I went about it:

```console
> git log --merges origin/master
# walk back the the history and grab an older merge commit, ideally a few back
> git checkout master && git reset $commit_id_from_previous_step
> git cherry-pick --no-commit feature/show-upgrades^
> git cherry-pick --no-commit feature/show-upgrades
> git commit -m "Just for testing purposes…"
> bash-it reload && bash-it update
```

After I confirmed that, I reset back against `origin/master`.