### PR TITLE
Adjust to only show merges into master

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -182,7 +182,7 @@ _bash-it_update() {
 
   if [[ -n "${status}" ]]; then
 
-    for i in $(git rev-list --merges master..${BASH_IT_REMOTE}); do
+    for i in $(git rev-list --merges --first-parent master..${BASH_IT_REMOTE}); do
       num_of_lines=$(git log -1 --format=%B $i | awk 'NF' | wc -l)
       if [ $num_of_lines -eq 1 ]; then
         description="%s"


### PR DESCRIPTION
Adding `--first-parent` ensures that only commits from the master branch are used when showing the history. I've verified this change directly by comparing the `rev-list` output for `703105c..97df5c45`:

```console
$ git rev-list --merges 703105c...97df5c4
97df5c4540534c57da2381b1675cd2461274b2a6
b5976ada25a351ee603fa6a2c4aee99d56f0cabe
$ git rev-list --merges --first-parent 703105c...97df5c4
97df5c4540534c57da2381b1675cd2461274b2a6
```

Note: I've created this branch from 703105c so that I can merge `master` into it and test `bash-it update` once merged.