### PR TITLE
Simplify multiple path support in go plugin

### DIFF
--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -5,25 +5,15 @@ about-plugin 'go environment variables & path configuration'
 
 [ ! command -v go &>/dev/null ] && return
 
-function _split_path_reverse() {
-  local a=( ${@//:/ } )
+function _go_pathmunge_wrap() {
+  IFS=':' local -a 'a=($1)'
   local i=${#a[@]}
-  local r=
   while [ $i -gt 0 ] ; do
     i=$(( i - 1 ))
-    if [ $(( i + 1 )) -eq ${#a[@]} ] ; then
-      r="${a[i]}"
-    else
-      r="${r} ${a[i]}"
-    fi
+    pathmunge "${a[i]}/bin"
   done
-  echo "$r"
 }
 
-export GOROOT=${GOROOT:-$(go env GOROOT)}
-pathmunge "${GOROOT}/bin"
-
-export GOPATH=${GOPATH:-$(go env GOPATH)}
-for p in $( _split_path_reverse ${GOPATH} ) ; do
-  pathmunge "${p}/bin"
-done
+export GOROOT="${GOROOT:-$(go env GOROOT)}"
+export GOPATH="${GOPATH:-$(go env GOPATH)}"
+_go_pathmunge_wrap "${GOPATH}:${GOROOT}"

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -16,6 +16,4 @@ function _go_pathmunge_wrap() {
 
 export GOROOT="${GOROOT:-$(go env GOROOT)}"
 export GOPATH="${GOPATH:-$(go env GOPATH)}"
-echo $PATH
 _go_pathmunge_wrap "${GOPATH}:${GOROOT}"
-echo $PATH

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -16,4 +16,6 @@ function _go_pathmunge_wrap() {
 
 export GOROOT="${GOROOT:-$(go env GOROOT)}"
 export GOPATH="${GOPATH:-$(go env GOPATH)}"
+echo $PATH
 _go_pathmunge_wrap "${GOPATH}:${GOROOT}"
+echo $PATH

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -3,7 +3,7 @@
 cite about-plugin
 about-plugin 'go environment variables & path configuration'
 
-[ ! command -v go &>/dev/null ] && return
+command -v go &>/dev/null || return
 
 function _go_pathmunge_wrap() {
   IFS=':' local -a 'a=($1)'

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -10,7 +10,8 @@ function _go_pathmunge_wrap() {
   local i=${#a[@]}
   while [ $i -gt 0 ] ; do
     i=$(( i - 1 ))
-    pathmunge "${a[i]}/bin"
+    echo "${a[i]}/bin"
+    # pathmunge "${a[i]}/bin"
   done
 }
 

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -10,8 +10,7 @@ function _go_pathmunge_wrap() {
   local i=${#a[@]}
   while [ $i -gt 0 ] ; do
     i=$(( i - 1 ))
-    echo "${a[i]}/bin"
-    # pathmunge "${a[i]}/bin"
+    pathmunge "${a[i]}/bin"
   done
 }
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -17,6 +17,10 @@ load ../../plugins/available/go.plugin
   assert_equal $(go env GOROOT) 'dummy'
 }
 
+@test 'ensure _go_pathmunge_wrap is defined' {
+  [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
+}
+
 @test 'plugins go: single entry in GOPATH' {
   export GOROOT='/baz'
   export GOPATH='/foo'

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -8,11 +8,8 @@ load ../../lib/composure
   export GOPATH="/foo"
   load ../../plugins/available/go.plugin
 
-  echo "$(echo $PATH | cut -d':' -f1)"
-  [ "$(echo $PATH | cut -d':' -f1)" = "/foo/bin" ]
-
-  echo "$(echo $PATH | cut -d':' -f2)"
-  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
+  [[ "$(echo $PATH | cut -d':' -f1)" = '/foo/bin' ]]
+  [[ "$(echo $PATH | cut -d':' -f2)" = '/baz/bin' ]]
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -4,11 +4,11 @@ load ../../lib/helpers
 load ../../lib/composure
 
 @test 'plugins go: single entry in GOPATH' {
-  export GOROOT="/baz"
-  export GOPATH="/foo"
+  export GOROOT='/baz'
+  export GOPATH='/foo'
   load ../../plugins/available/go.plugin
 
-  [[ "$(cut -d':' -f1,2 <<<$PATH)" == '/foo/bin:/baz/bin' ]]
+  [[ "$(cut -d':' -f1,2 <<<$PATH | tr -d '\n')" == '/foo/bin:/baz/bin' ]]
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 
+load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -2,12 +2,43 @@
 
 ##
 # Travis notes:
-#   - `which go`
-#     - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin/go
-#   - `go env GOROOT` & `$GOROOT`
-#     - /home/travis/.gimme/versions/go1.7.4.linux.amd64
-#   - `go env GOPATH` & `GOPATH`
-#     - /home/travis/gopath
+# - `$PATH`
+#   - /home/travis/build/Bash-it/bash-it/test_lib/bats-core/libexec
+#   - /home/travis/bin
+#   - /home/travis/.local/bin
+#   - /opt/pyenv/shims
+#   - /home/travis/.phpenv/shims
+#   - /home/travis/perl5/perlbrew/bin
+#   - /home/travis/.nvm/versions/node/v8.9.1/bin
+#   - /home/travis/.kiex/elixirs/elixir-1.4.5/bin
+#   - /home/travis/.kiex/bin
+#   - /home/travis/.rvm/gems/ruby-2.4.1/bin
+#   - /home/travis/.rvm/gems/ruby-2.4.1@global/bin
+#   - /home/travis/.rvm/rubies/ruby-2.4.1/bin
+#   - /home/travis/gopath/bin
+#   - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin
+#   - /usr/local/phantomjs/bin
+#   - /usr/local/phantomjs
+#   - /usr/local/neo4j-3.2.7/bin
+#   - /usr/local/maven-3.5.2/bin
+#   - /usr/local/cmake-3.9.2/bin
+#   - /usr/local/clang-5.0.0/bin
+#   - /usr/local/sbin
+#   - /usr/local/bin
+#   - /usr/sbin
+#   - /usr/bin
+#   - /sbin
+#   - /bin
+#   - /home/travis/.rvm/bin
+#   - /home/travis/.phpenv/bin
+#   - /opt/pyenv/bin
+#   - /home/travis/.yarn/bin
+# - `which go`
+#   - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin/go
+# - `go env GOROOT` & `$GOROOT`
+#   - /home/travis/.gimme/versions/go1.7.4.linux.amd64
+# - `go env GOPATH` & `GOPATH`
+#   - /home/travis/gopath
 #
 
 load ../test_helper
@@ -16,11 +47,8 @@ load ../../lib/composure
 
 @test 'ensure _go_pathmunge_wrap is defined' {
   load ../../plugins/available/go.plugin
-  [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
-}
-
-@test 'debug path in travis' {
-  assert_equal $PATH 'dummy'
+  run type -t remove_gem
+  assert_line 'function'
 }
 
 @test 'debug travis' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -22,8 +22,9 @@ load ../../plugins/available/go.plugin
 }
 
 @test 'debug goroot in travis, after load' {
-  export GOROOT='/baz'
+  export GOROOT='/tmp'
   load ../../plugins/available/go.plugin
+  assert_equal $GOROOT 'dummy'
   assert_equal $(go env GOROOT) 'dummy'
 }
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -8,8 +8,7 @@ load ../../lib/composure
   export GOPATH="/foo"
   load ../../plugins/available/go.plugin
 
-  [[ "$(echo $PATH | cut -d':' -f1)" = '/foo/bin' ]]
-  [[ "$(echo $PATH | cut -d':' -f2)" = '/baz/bin' ]]
+  [[ "$(cut -z -d':' -f1,2 <<<$PATH)" = '/foo/bin:/baz/bin' ]]
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -1,44 +1,76 @@
 #!/usr/bin/env bats
 
-#load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure
-load ../../plugins/available/go.plugin
-
-@test 'plugins go: reverse path: single entry' {
-  run _split_path_reverse '/foo'
-  echo "output = ${output}"
-  [ "$output" = "/foo" ]
-}
-
-@test 'plugins go: reverse path: single entry, colon empty' {
-  run _split_path_reverse '/foo:'
-  echo "output = ${output}"
-  [ "$output" = "/foo" ]
-}
-
-@test 'plugins go: reverse path: single entry, colon whitespace' {
-  run _split_path_reverse '/foo: '
-  echo "output = ${output}"
-  [ "$output" = "/foo" ]
-}
-
-@test 'plugins go: reverse path: multiple entries' {
-  run _split_path_reverse '/foo:/bar'
-  echo "output = ${output}"
-  [ "$output" = "/bar /foo" ]
-}
 
 @test 'plugins go: single entry in GOPATH' {
+  export GOROOT="/baz"
   export GOPATH="/foo"
   load ../../plugins/available/go.plugin
-  echo "$(echo $PATH | cut -d':' -f1,2)"
+
+  echo "$(echo $PATH | cut -d':' -f1)"
   [ "$(echo $PATH | cut -d':' -f1)" = "/foo/bin" ]
+
+  echo "$(echo $PATH | cut -d':' -f2)"
+  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
+}
+
+@test 'plugins go: single entry in GOPATH, with space' {
+  export GOROOT="/baz"
+  export GOPATH="/foo bar"
+  load ../../plugins/available/go.plugin
+
+  echo "$(echo $PATH | cut -d':' -f1)"
+  [ "$(echo $PATH | cut -d':' -f1)" = "/foo bar/bin" ]
+
+  echo "$(echo $PATH | cut -d':' -f2)"
+  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
+}
+
+@test 'plugins go: single entry in GOPATH, with escaped space' {
+  export GOROOT="/baz"
+  export GOPATH="/foo\ bar"
+  load ../../plugins/available/go.plugin
+
+  echo "$(echo $PATH | cut -d':' -f1)"
+  [ "$(echo $PATH | cut -d':' -f1)" = "/foo\ bar/bin" ]
+
+  echo "$(echo $PATH | cut -d':' -f2)"
+  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
 }
 
 @test 'plugins go: multiple entries in GOPATH' {
+  export GOROOT="/baz"
   export GOPATH="/foo:/bar"
   load ../../plugins/available/go.plugin
+
   echo "$(echo $PATH | cut -d':' -f1,2)"
   [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/bar/bin" ]
+
+  echo "$(echo $PATH | cut -d':' -f3)"
+  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
+}
+
+@test 'plugins go: multiple entries in GOPATH, with space' {
+  export GOROOT="/baz"
+  export GOPATH="/foo:/foo bar"
+  load ../../plugins/available/go.plugin
+
+  echo "$(echo $PATH | cut -d':' -f1,2)"
+  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo bar/bin" ]
+
+  echo "$(echo $PATH | cut -d':' -f3)"
+  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
+}
+
+@test 'plugins go: multiple entries in GOPATH, with escaped space' {
+  export GOROOT="/baz"
+  export GOPATH="/foo:/foo\ bar"
+  load ../../plugins/available/go.plugin
+
+  echo "$(echo $PATH | cut -d':' -f1,2)"
+  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo\ bar/bin" ]
+
+  echo "$(echo $PATH | cut -d':' -f3)"
+  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
 }

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -8,7 +8,7 @@ load ../../lib/composure
   export GOPATH="/foo"
   load ../../plugins/available/go.plugin
 
-  [[ "$(cut -z -d':' -f1,2 <<<$PATH)" = '/foo/bin:/baz/bin' ]]
+  [[ "$(cut -z -d':' -f1,2 <<<$PATH)" == '/foo/bin:/baz/bin' ]]
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -54,7 +54,6 @@ load ../../lib/composure
 @test 'debug travis' {
   export GOROOT='/foo'
   export GOPATH='/bar'
-  export PATH='/usr/bin:/bin:/usr/sbin'
 
   load ../../plugins/available/go.plugin
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -17,14 +17,13 @@ load ../../plugins/available/go.plugin
   assert_equal $(go env GOROOT) 'dummy'
 }
 
-#@test 'plugins go: single entry in GOPATH' {
-#  export GOROOT='/baz'
-#  export GOPATH='/foo'
-#  load ../../plugins/available/go.plugin
-#
-#  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
-#}
-#
+@test 'plugins go: single entry in GOPATH' {
+  export GOROOT='/baz'
+  export GOPATH='/foo'
+  load ../../plugins/available/go.plugin
+  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
+}
+
 #@test 'plugins go: single entry in GOPATH, with space' {
 #  export GOROOT="/baz"
 #  export GOPATH="/foo bar"

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,14 +5,38 @@ load ../../lib/helpers
 load ../../lib/composure
 load ../../plugins/available/go.plugin
 
+function local_setup {
+  mkdir -p "$BASH_IT"
+  lib_directory="$(cd "$(dirname "$0")" && pwd)"
+  # Use rsync to copy Bash-it to the temp folder
+  # rsync is faster than cp, since we can exclude the large ".git" folder
+  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../../.. "$BASH_IT"
+
+  rm -rf "$BASH_IT"/enabled
+  rm -rf "$BASH_IT"/aliases/enabled
+  rm -rf "$BASH_IT"/completion/enabled
+  rm -rf "$BASH_IT"/plugins/enabled
+
+  mkdir -p "$BASH_IT"/enabled
+  mkdir -p "$BASH_IT"/aliases/enabled
+  mkdir -p "$BASH_IT"/completion/enabled
+  mkdir -p "$BASH_IT"/plugins/enabled
+
+  export OLD_PATH="$PATH"
+  export PATH="/usr/bin:/bin:/usr/sbin"
+}
+
+function local_teardown {
+  export PATH="$OLD_PATH"
+  unset OLD_PATH
+}
 
 @test 'plugins go: single entry in GOPATH' {
   export GOROOT='/baz'
   export GOPATH='/foo'
   load ../../plugins/available/go.plugin
 
-  assert_equal $PATH 'foobar'
-  assert_equal $(cut -d':' -f1,2 <<<$PATH | tr -d '\n') '/foo/bin:/baz/bin'
+  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -8,7 +8,7 @@ load ../../lib/composure
   export GOPATH='/foo'
   load ../../plugins/available/go.plugin
 
-  [[ "$(cut -d':' -f1,2 <<<$PATH | tr -d '\n')" == '/foo/bin:/baz/bin' ]]
+  assert_equal $(cut -d':' -f1,2 <<<$PATH | tr -d '\n') '/foo/bin:/baz/bin'
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -1,46 +1,5 @@
 #!/usr/bin/env bats
 
-##
-# Travis notes:
-# - `$PATH`
-#   - /home/travis/build/Bash-it/bash-it/test_lib/bats-core/libexec
-#   - /home/travis/bin
-#   - /home/travis/.local/bin
-#   - /opt/pyenv/shims
-#   - /home/travis/.phpenv/shims
-#   - /home/travis/perl5/perlbrew/bin
-#   - /home/travis/.nvm/versions/node/v8.9.1/bin
-#   - /home/travis/.kiex/elixirs/elixir-1.4.5/bin
-#   - /home/travis/.kiex/bin
-#   - /home/travis/.rvm/gems/ruby-2.4.1/bin
-#   - /home/travis/.rvm/gems/ruby-2.4.1@global/bin
-#   - /home/travis/.rvm/rubies/ruby-2.4.1/bin
-#   - /home/travis/gopath/bin
-#   - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin
-#   - /usr/local/phantomjs/bin
-#   - /usr/local/phantomjs
-#   - /usr/local/neo4j-3.2.7/bin
-#   - /usr/local/maven-3.5.2/bin
-#   - /usr/local/cmake-3.9.2/bin
-#   - /usr/local/clang-5.0.0/bin
-#   - /usr/local/sbin
-#   - /usr/local/bin
-#   - /usr/sbin
-#   - /usr/bin
-#   - /sbin
-#   - /bin
-#   - /home/travis/.rvm/bin
-#   - /home/travis/.phpenv/bin
-#   - /opt/pyenv/bin
-#   - /home/travis/.yarn/bin
-# - `which go`
-#   - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin/go
-# - `go env GOROOT` & `$GOROOT`
-#   - /home/travis/.gimme/versions/go1.7.4.linux.amd64
-# - `go env GOPATH` & `GOPATH`
-#   - /home/travis/gopath
-#
-
 load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,96 +5,78 @@ load ../../lib/helpers
 load ../../lib/composure
 load ../../plugins/available/go.plugin
 
-function local_setup {
-  mkdir -p "$BASH_IT"
-  lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  # Use rsync to copy Bash-it to the temp folder
-  # rsync is faster than cp, since we can exclude the large ".git" folder
-  rsync -qavrKL -d --delete-excluded --exclude=.git $lib_directory/../../.. "$BASH_IT"
-
-  rm -rf "$BASH_IT"/enabled
-  rm -rf "$BASH_IT"/aliases/enabled
-  rm -rf "$BASH_IT"/completion/enabled
-  rm -rf "$BASH_IT"/plugins/enabled
-
-  mkdir -p "$BASH_IT"/enabled
-  mkdir -p "$BASH_IT"/aliases/enabled
-  mkdir -p "$BASH_IT"/completion/enabled
-  mkdir -p "$BASH_IT"/plugins/enabled
-
-  export OLD_PATH="$PATH"
-  export PATH="/usr/bin:/bin:/usr/sbin"
+@test 'debug gopath in travis' {
+  assert_equal $(go env GOPATH) 'dummy'
 }
 
-function local_teardown {
-  export PATH="$OLD_PATH"
-  unset OLD_PATH
+@test 'debug goroot in travis' {
+  assert_equal $(go env GOROOT) 'dummy'
 }
 
-@test 'plugins go: single entry in GOPATH' {
-  export GOROOT='/baz'
-  export GOPATH='/foo'
-  load ../../plugins/available/go.plugin
-
-  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
-}
-
-@test 'plugins go: single entry in GOPATH, with space' {
-  export GOROOT="/baz"
-  export GOPATH="/foo bar"
-  load ../../plugins/available/go.plugin
-
-  echo "$(echo $PATH | cut -d':' -f1)"
-  [ "$(echo $PATH | cut -d':' -f1)" = "/foo bar/bin" ]
-
-  echo "$(echo $PATH | cut -d':' -f2)"
-  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
-}
-
-@test 'plugins go: single entry in GOPATH, with escaped space' {
-  export GOROOT="/baz"
-  export GOPATH="/foo\ bar"
-  load ../../plugins/available/go.plugin
-
-  echo "$(echo $PATH | cut -d':' -f1)"
-  [ "$(echo $PATH | cut -d':' -f1)" = "/foo\ bar/bin" ]
-
-  echo "$(echo $PATH | cut -d':' -f2)"
-  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
-}
-
-@test 'plugins go: multiple entries in GOPATH' {
-  export GOROOT="/baz"
-  export GOPATH="/foo:/bar"
-  load ../../plugins/available/go.plugin
-
-  echo "$(echo $PATH | cut -d':' -f1,2)"
-  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/bar/bin" ]
-
-  echo "$(echo $PATH | cut -d':' -f3)"
-  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
-}
-
-@test 'plugins go: multiple entries in GOPATH, with space' {
-  export GOROOT="/baz"
-  export GOPATH="/foo:/foo bar"
-  load ../../plugins/available/go.plugin
-
-  echo "$(echo $PATH | cut -d':' -f1,2)"
-  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo bar/bin" ]
-
-  echo "$(echo $PATH | cut -d':' -f3)"
-  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
-}
-
-@test 'plugins go: multiple entries in GOPATH, with escaped space' {
-  export GOROOT="/baz"
-  export GOPATH="/foo:/foo\ bar"
-  load ../../plugins/available/go.plugin
-
-  echo "$(echo $PATH | cut -d':' -f1,2)"
-  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo\ bar/bin" ]
-
-  echo "$(echo $PATH | cut -d':' -f3)"
-  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
-}
+#@test 'plugins go: single entry in GOPATH' {
+#  export GOROOT='/baz'
+#  export GOPATH='/foo'
+#  load ../../plugins/available/go.plugin
+#
+#  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
+#}
+#
+#@test 'plugins go: single entry in GOPATH, with space' {
+#  export GOROOT="/baz"
+#  export GOPATH="/foo bar"
+#  load ../../plugins/available/go.plugin
+#
+#  echo "$(echo $PATH | cut -d':' -f1)"
+#  [ "$(echo $PATH | cut -d':' -f1)" = "/foo bar/bin" ]
+#
+#  echo "$(echo $PATH | cut -d':' -f2)"
+#  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
+#}
+#
+#@test 'plugins go: single entry in GOPATH, with escaped space' {
+#  export GOROOT="/baz"
+#  export GOPATH="/foo\ bar"
+#  load ../../plugins/available/go.plugin
+#
+#  echo "$(echo $PATH | cut -d':' -f1)"
+#  [ "$(echo $PATH | cut -d':' -f1)" = "/foo\ bar/bin" ]
+#
+#  echo "$(echo $PATH | cut -d':' -f2)"
+#  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
+#}
+#
+#@test 'plugins go: multiple entries in GOPATH' {
+#  export GOROOT="/baz"
+#  export GOPATH="/foo:/bar"
+#  load ../../plugins/available/go.plugin
+#
+#  echo "$(echo $PATH | cut -d':' -f1,2)"
+#  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/bar/bin" ]
+#
+#  echo "$(echo $PATH | cut -d':' -f3)"
+#  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
+#}
+#
+#@test 'plugins go: multiple entries in GOPATH, with space' {
+#  export GOROOT="/baz"
+#  export GOPATH="/foo:/foo bar"
+#  load ../../plugins/available/go.plugin
+#
+#  echo "$(echo $PATH | cut -d':' -f1,2)"
+#  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo bar/bin" ]
+#
+#  echo "$(echo $PATH | cut -d':' -f3)"
+#  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
+#}
+#
+#@test 'plugins go: multiple entries in GOPATH, with escaped space' {
+#  export GOROOT="/baz"
+#  export GOPATH="/foo:/foo\ bar"
+#  load ../../plugins/available/go.plugin
+#
+#  echo "$(echo $PATH | cut -d':' -f1,2)"
+#  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo\ bar/bin" ]
+#
+#  echo "$(echo $PATH | cut -d':' -f3)"
+#  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
+#}

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,21 +5,13 @@ load ../../lib/helpers
 load ../../lib/composure
 load ../../plugins/available/go.plugin
 
-function local_setup {
-  export OLD_PATH="$PATH"
-  export PATH="/usr/bin:/bin:/usr/sbin"
-}
-
-function local_teardown {
-  export PATH="$OLD_PATH"
-  unset OLD_PATH
-}
 
 @test 'plugins go: single entry in GOPATH' {
   export GOROOT='/baz'
   export GOPATH='/foo'
   load ../../plugins/available/go.plugin
 
+  assert_equal $PATH 'foobar'
   assert_equal $(cut -d':' -f1,2 <<<$PATH | tr -d '\n') '/foo/bin:/baz/bin'
 }
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -8,7 +8,7 @@ load ../../lib/composure
   export GOPATH="/foo"
   load ../../plugins/available/go.plugin
 
-  [[ "$(cut -z -d':' -f1,2 <<<$PATH)" == '/foo/bin:/baz/bin' ]]
+  [[ "$(cut -d':' -f1,2 <<<$PATH)" == '/foo/bin:/baz/bin' ]]
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,6 +5,10 @@ load ../../lib/helpers
 load ../../lib/composure
 load ../../plugins/available/go.plugin
 
+@test 'ensure _go_pathmunge_wrap is defined' {
+  [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
+}
+
 @test 'debug where is go in travis' {
   assert_equal $(which go) 'dummy'
 }
@@ -17,8 +21,9 @@ load ../../plugins/available/go.plugin
   assert_equal $(go env GOROOT) 'dummy'
 }
 
-@test 'ensure _go_pathmunge_wrap is defined' {
-  [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
+@test 'debug goroot in travis, after load' {
+  load ../../plugins/available/go.plugin
+  assert_equal $(go env GOROOT) 'dummy'
 }
 
 @test 'plugins go: single entry in GOPATH' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -4,6 +4,10 @@
 # Travis notes:
 #   - `which go`
 #     - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin/go
+#   - `go env GOROOT` & `$GOROOT`
+#     - /home/travis/.gimme/versions/go1.7.4.linux.amd64
+#   - `go env GOPATH` & `GOPATH`
+#     - /home/travis/gopath
 #
 
 load ../test_helper
@@ -15,43 +19,27 @@ load ../../lib/composure
   [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
 }
 
-@test 'debug gopath in travis' {
-  assert_equal $(go env GOPATH) 'dummy'
+@test 'debug path in travis' {
+  assert_equal $PATH 'dummy'
 }
 
-@test 'debug gopath in travis 2' {
-  assert_equal $GOPATH 'dummy'
-}
+@test 'debug travis' {
+  export GOROOT='/foo'
+  export GOPATH='/bar'
+  local OLD_PATH=$PATH
 
-@test 'debug goroot in travis' {
-  assert_equal $(go env GOROOT) 'dummy'
-}
-
-@test 'debug goroot in travis 2' {
-  assert_equal $GOROOT 'dummy'
-}
-
-@test 'debug goroot in travis, after load' {
-  export GOROOT='/tmp'
   load ../../plugins/available/go.plugin
 
-  assert_equal $(go env GOROOT) 'dummy'
+  assert_equal $OLD_PATH $PATH
 }
 
-@test 'debug goroot in travis, after load 2' {
-  export GOROOT='/tmp'
-  load ../../plugins/available/go.plugin
-
-  assert_equal $GOROOT 'dummy'
-}
-
-@test 'plugins go: single entry in GOPATH' {
-  export GOROOT='/baz'
-  export GOPATH='/foo'
-  load ../../plugins/available/go.plugin
-  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
-}
-
+#@test 'plugins go: single entry in GOPATH' {
+#  export GOROOT='/baz'
+#  export GOPATH='/foo'
+#  load ../../plugins/available/go.plugin
+#  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
+#}
+#
 #@test 'plugins go: single entry in GOPATH, with space' {
 #  export GOROOT="/baz"
 #  export GOPATH="/foo bar"

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -47,7 +47,7 @@ load ../../lib/composure
 
 @test 'ensure _go_pathmunge_wrap is defined' {
   load ../../plugins/available/go.plugin
-  run type -t remove_gem
+  run type -t _go_pathmunge_wrap
   assert_line 'function'
 }
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -18,10 +18,11 @@ load ../../plugins/available/go.plugin
 }
 
 @test 'debug goroot in travis' {
-  assert_equal $(go env GOROOT) 'dummy'
+  assert_equal $GOROOT 'dummy'
 }
 
 @test 'debug goroot in travis, after load' {
+  export GOROOT='/baz'
   load ../../plugins/available/go.plugin
   assert_equal $(go env GOROOT) 'dummy'
 }

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -1,5 +1,11 @@
 #!/usr/bin/env bats
 
+##
+# Travis notes:
+#   - `which go`
+#     - /home/travis/.gimme/versions/go1.7.4.linux.amd64/bin/go
+#
+
 load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure
@@ -9,23 +15,34 @@ load ../../lib/composure
   [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
 }
 
-@test 'debug where is go in travis' {
-  assert_equal $(which go) 'dummy'
-}
-
 @test 'debug gopath in travis' {
   assert_equal $(go env GOPATH) 'dummy'
 }
 
+@test 'debug gopath in travis 2' {
+  assert_equal $GOPATH 'dummy'
+}
+
 @test 'debug goroot in travis' {
+  assert_equal $(go env GOROOT) 'dummy'
+}
+
+@test 'debug goroot in travis 2' {
   assert_equal $GOROOT 'dummy'
 }
 
 @test 'debug goroot in travis, after load' {
   export GOROOT='/tmp'
   load ../../plugins/available/go.plugin
-  assert_equal $GOROOT 'dummy'
+
   assert_equal $(go env GOROOT) 'dummy'
+}
+
+@test 'debug goroot in travis, after load 2' {
+  export GOROOT='/tmp'
+  load ../../plugins/available/go.plugin
+
+  assert_equal $GOROOT 'dummy'
 }
 
 @test 'plugins go: single entry in GOPATH' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -3,6 +3,7 @@
 load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure
+load ../../plugins/available/go.plugin
 
 function local_setup {
   export OLD_PATH="$PATH"

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,6 +5,10 @@ load ../../lib/helpers
 load ../../lib/composure
 load ../../plugins/available/go.plugin
 
+@test 'debug where is go in travis' {
+  assert_equal $(which go) 'dummy'
+}
+
 @test 'debug gopath in travis' {
   assert_equal $(go env GOPATH) 'dummy'
 }

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -57,7 +57,7 @@ load ../../lib/composure
 
   load ../../plugins/available/go.plugin
   run _go_pathmunge_wrap "${GOPATH}:${GOROOT}"
-  assert_equal $PATH 'dummy'
+  assert_line 'dummy'
 }
 
 #@test 'plugins go: single entry in GOPATH' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -54,11 +54,10 @@ load ../../lib/composure
 @test 'debug travis' {
   export GOROOT='/foo'
   export GOPATH='/bar'
-  local OLD_PATH=$PATH
 
   load ../../plugins/available/go.plugin
 
-  assert_equal $OLD_PATH $PATH
+  assert_line 'dummy'
 }
 
 #@test 'plugins go: single entry in GOPATH' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -56,7 +56,7 @@ load ../../lib/composure
   export GOPATH='/bar'
 
   load ../../plugins/available/go.plugin
-
+  run _go_pathmunge_wrap "${GOPATH}:${GOROOT}"
   assert_equal $PATH 'dummy'
 }
 

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -51,78 +51,44 @@ load ../../lib/composure
   assert_line 'function'
 }
 
-@test 'debug travis' {
-  export GOROOT='/foo'
-  export GOPATH='/bar'
-
+@test 'plugins go: single entry in GOPATH' {
+  export GOPATH="/foo"
+  export GOROOT="/baz"
   load ../../plugins/available/go.plugin
-  run _go_pathmunge_wrap "${GOPATH}:${GOROOT}"
-  assert_line 'dummy'
+  assert_equal "$(cut -d':' -f1,2 <<<$PATH)" "/foo/bin:/baz/bin"
 }
 
-#@test 'plugins go: single entry in GOPATH' {
-#  export GOROOT='/baz'
-#  export GOPATH='/foo'
-#  load ../../plugins/available/go.plugin
-#  assert_equal $(cut -d':' -f1,2 <<<$PATH) '/foo/bin:/baz/bin'
-#}
-#
-#@test 'plugins go: single entry in GOPATH, with space' {
-#  export GOROOT="/baz"
-#  export GOPATH="/foo bar"
-#  load ../../plugins/available/go.plugin
-#
-#  echo "$(echo $PATH | cut -d':' -f1)"
-#  [ "$(echo $PATH | cut -d':' -f1)" = "/foo bar/bin" ]
-#
-#  echo "$(echo $PATH | cut -d':' -f2)"
-#  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
-#}
-#
-#@test 'plugins go: single entry in GOPATH, with escaped space' {
-#  export GOROOT="/baz"
-#  export GOPATH="/foo\ bar"
-#  load ../../plugins/available/go.plugin
-#
-#  echo "$(echo $PATH | cut -d':' -f1)"
-#  [ "$(echo $PATH | cut -d':' -f1)" = "/foo\ bar/bin" ]
-#
-#  echo "$(echo $PATH | cut -d':' -f2)"
-#  [ "$(echo $PATH | cut -d':' -f2)" = "/baz/bin" ]
-#}
-#
-#@test 'plugins go: multiple entries in GOPATH' {
-#  export GOROOT="/baz"
-#  export GOPATH="/foo:/bar"
-#  load ../../plugins/available/go.plugin
-#
-#  echo "$(echo $PATH | cut -d':' -f1,2)"
-#  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/bar/bin" ]
-#
-#  echo "$(echo $PATH | cut -d':' -f3)"
-#  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
-#}
-#
-#@test 'plugins go: multiple entries in GOPATH, with space' {
-#  export GOROOT="/baz"
-#  export GOPATH="/foo:/foo bar"
-#  load ../../plugins/available/go.plugin
-#
-#  echo "$(echo $PATH | cut -d':' -f1,2)"
-#  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo bar/bin" ]
-#
-#  echo "$(echo $PATH | cut -d':' -f3)"
-#  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
-#}
-#
-#@test 'plugins go: multiple entries in GOPATH, with escaped space' {
-#  export GOROOT="/baz"
-#  export GOPATH="/foo:/foo\ bar"
-#  load ../../plugins/available/go.plugin
-#
-#  echo "$(echo $PATH | cut -d':' -f1,2)"
-#  [ "$(echo $PATH | cut -d':' -f1,2)" = "/foo/bin:/foo\ bar/bin" ]
-#
-#  echo "$(echo $PATH | cut -d':' -f3)"
-#  [ "$(echo $PATH | cut -d':' -f3)" = "/baz/bin" ]
-#}
+@test 'plugins go: single entry in GOPATH, with space' {
+  export GOPATH="/foo bar"
+  export GOROOT="/baz"
+  load ../../plugins/available/go.plugin
+  assert_equal "$(cut -d':' -f1,2 <<<$PATH)" "/foo bar/bin:/baz/bin"
+}
+
+@test 'plugins go: single entry in GOPATH, with escaped space' {
+  export GOPATH="/foo\ bar"
+  export GOROOT="/baz"
+  load ../../plugins/available/go.plugin
+  assert_equal "$(cut -d':' -f1,2 <<<$PATH)" "/foo\ bar/bin:/baz/bin"
+}
+
+@test 'plugins go: multiple entries in GOPATH' {
+  export GOPATH="/foo:/bar"
+  export GOROOT="/baz"
+  load ../../plugins/available/go.plugin
+  assert_equal "$(cut -d':' -f1,2,3 <<<$PATH)" "/foo/bin:/bar/bin:/baz/bin"
+}
+
+@test 'plugins go: multiple entries in GOPATH, with space' {
+  export GOPATH="/foo:/foo bar"
+  export GOROOT="/baz"
+  load ../../plugins/available/go.plugin
+  assert_equal "$(cut -d':' -f1,2,3 <<<$PATH)" "/foo/bin:/foo bar/bin:/baz/bin"
+}
+
+@test 'plugins go: multiple entries in GOPATH, with escaped space' {
+  export GOPATH="/foo:/foo\ bar"
+  export GOROOT="/baz"
+  load ../../plugins/available/go.plugin
+  assert_equal "$(cut -d':' -f1,2,3 <<<$PATH)" "/foo/bin:/foo\ bar/bin:/baz/bin"
+}

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -54,10 +54,11 @@ load ../../lib/composure
 @test 'debug travis' {
   export GOROOT='/foo'
   export GOPATH='/bar'
+  export PATH='/usr/bin:/bin:/usr/sbin'
 
   load ../../plugins/available/go.plugin
 
-  assert_line 'dummy'
+  assert_equal $PATH 'dummy'
 }
 
 #@test 'plugins go: single entry in GOPATH' {

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -4,6 +4,16 @@ load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure
 
+function local_setup {
+  export OLD_PATH="$PATH"
+  export PATH="/usr/bin:/bin:/usr/sbin"
+}
+
+function local_teardown {
+  export PATH="$OLD_PATH"
+  unset OLD_PATH
+}
+
 @test 'plugins go: single entry in GOPATH' {
   export GOROOT='/baz'
   export GOPATH='/foo'

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -3,9 +3,9 @@
 load ../test_helper
 load ../../lib/helpers
 load ../../lib/composure
-load ../../plugins/available/go.plugin
 
 @test 'ensure _go_pathmunge_wrap is defined' {
+  load ../../plugins/available/go.plugin
   [[ $(type -t _go_pathmunge_wrap) = 'function' ]]
 }
 


### PR DESCRIPTION
This PR seeks to simplify the wrapped pathmunge logic setup in #1267.
Tests have been updated to account for cases with spaces in $PATH.