### PR TITLE
fix BASH_IT_LEGACY_PASS logic to be and instead of or

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -68,9 +68,9 @@ function passgen ()
     echo "Without (use this as the password): $(echo $pass | tr -d ' ')"
 }
 
-# Create alias pass to passgen when pass isn't installed or
+# Create alias pass to passgen when pass isn't installed and
 # BASH_IT_LEGACY_PASS is true.
-if ! command -v pass &>/dev/null || [ "$BASH_IT_LEGACY_PASS" = true ]
+if ! command -v pass &>/dev/null && [ "$BASH_IT_LEGACY_PASS" = true ]
 then
   alias pass=passgen
 fi


### PR DESCRIPTION
Noticed that the `pass` alias was being set giving me the impression I already had that tool installed but it wasn't behaving as expected.  I dug a bit into it and realized bash_it was setting this as an alias for some legacy behavior I wasn't aware of.

I am pretty sure the intended goal of setting `BASH_IT_LEGACY_PASS=true` was to allow users needing legacy behavior to be able to recreate that old `pass` command unless they actually had the pass command.  

Right now if you don't have pass command you get the pass alias regardless of the BASH_IT_LEGACY_PASS setting being false or true.  (OR logic) 

This PR switches that behavior to AND logic to only set the pass alias if the user doesn't have the pass command *and* they have explicitly asked for the legacy behavior. 