### PR TITLE
Fix git Command Completion Not Working After 2.18.0

### DIFF
--- a/completion/available/git.completion.bash
+++ b/completion/available/git.completion.bash
@@ -624,7 +624,13 @@ __git_commands () {
 	then
 		printf "%s" "${GIT_TESTING_COMMAND_COMPLETION}"
 	else
-		git help -a|egrep '^  [a-zA-Z0-9]'
+		git_cmd_list=$(git help -a|egrep '^  [a-zA-Z0-9]')
+		if [ ! -z "$git_cmd_list" ]
+		then
+			"$git_cmd_list"
+		else
+			git --list-cmds=main,others,alias,nohelpers
+		fi
 	fi
 }
 


### PR DESCRIPTION
- "git help -a|egrep '^ [a-zA-Z0-9]'" returns empty in "__git_commands" function
 - Used git --list-cmds introduced in git v2.18.0 as a fallback