### PR TITLE
Make `bash-it reload` preserve working directory

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -256,7 +256,7 @@ _bash-it-reload() {
   _about 'reloads a profile file'
   _group 'lib'
 
-  cd "${BASH_IT}" || return
+  pushd "${BASH_IT}" &> /dev/null || return
 
   case $OSTYPE in
     darwin*)
@@ -267,7 +267,7 @@ _bash-it-reload() {
       ;;
   esac
 
-  cd - &> /dev/null || return
+  popd &> /dev/null || return
 }
 
 _bash-it-describe ()


### PR DESCRIPTION
In e5b6869 (part of #1283), a regression was introduced, which caused `bash-it reload` to return with the working directory set to `.bash_it` and the original working directory discarded.

The root cause is the function wrapper in `helpers.bash`, which has always relied on the working directory not to change during execution of the wrapped code. This assumption no longer holds with the [changes introduced in #1283](https://github.com/Bash-it/bash-it/commit/e5b68695c0e77403e9ceda6e2707c1be326da81b#diff-9ec933b9deff7a50e810f0211b467399R2).

This PR fixes the regression by using `pushd`/`popd` in `bash-it reload`.
