### PR TITLE
Remove Deprecated Brew Command

### DIFF
--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -4,7 +4,6 @@ cite 'about-alias'
 about-alias 'homebrew abbreviations'
 
 alias bup='brew update && brew upgrade'
-alias bupc='brew update && brew upgrade --cleanup'
 alias bout='brew outdated'
 alias bin='brew install'
 alias brm='brew uninstall'


### PR DESCRIPTION
`brew upgrade --cleanup` command is deprecated now so it should be removed.
```
○ → brew upgrade --cleanup
Updating Homebrew...
Fast-forwarded master to origin/master.
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask-versions).
No changes to formulae.

Warning: Calling 'brew upgrade --cleanup' is deprecated! Use 'HOMEBREW_INSTALL_CLEANUP' instead.
```