### PR TITLE
Fixes #1309 _bash-it-clean-component-cache: command not found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,7 @@ fi
 
 # Load dependencies for enabling components
 source "$BASH_IT/lib/composure.bash"
+source "$BASH_IT/lib/utilities.bash"
 cite _about _param _example _group _author _version
 source "$BASH_IT/lib/helpers.bash"
 


### PR DESCRIPTION
Silence errors when installing

```
Would you like to enable the ag aliases? [y/N] y
~/.bash_it/lib/helpers.bash: line 488: _bash-it-clean-component-cache: command not found
ag enabled with priority 150.
```