### PR TITLE
Fixes early exit if tmp cache is missing

### DIFF
--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -44,7 +44,9 @@ _bash-it-clean-component-cache() {
     done
   else
     cache="$(_bash-it-component-cache-file ${component})"
-    [[ -f "${cache}" ]] && rm -f "${cache}"
+    if [[ -f "${cache}" ]] ; then
+      rm -f "${cache}"
+    fi
   fi
 }
 


### PR DESCRIPTION
Found if this `${cache}` file doesn't exist, the single line conditional command would return false causing a `exit 1`.

This little change makes the conditional verbose and not cause a false return failing the function.

Happens to be related to #1273 