### PR TITLE
Fixes #1203 convert alias to aliases

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -452,6 +452,9 @@ _enable-thing ()
         for f in "${BASH_IT}/$subdirectory/available/"*.bash
         do
             to_enable=$(basename $f .$file_type.bash)
+            if [ "$file_type" = "alias" ]; then
+              to_enable=$(basename $f ".aliases.bash")
+            fi
             _enable-thing $subdirectory $file_type $to_enable $load_priority
         done
     else


### PR DESCRIPTION
An ungraceful patch but fixes this one case where the command is singular `alias` while the file is plural with `aliases.

you can now 
```bash
bash-it enable alias all
```
again