### PR TITLE
editorconfig: Respect user rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,5 @@
 # EditorConfig is awesome: http://EditorConfig.org
 
-root = true
-
 [*]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
Editorconfig provides the concept of cascading rules, refer to
https://editorconfig.org/#file-location. For instance, I use a rule
which limits line length in git commit messages which enables `vim` to
re-flow the text by a simple command. Setting `root=true` in LT's own
`.editorconfig` file prevents any such user-defined rules from being
propagated.

Remove `root=true` to enable user-defined rules.