### PR TITLE
Added basic teaching mode

### DIFF
--- a/plugins/available/teachingmode.plugin.bash
+++ b/plugins/available/teachingmode.plugin.bash
@@ -1,0 +1,34 @@
+# requested by greenrd on a issue https://github.com/Bash-it/bash-it/issues/674
+
+function yes() {
+    if [ "$1" = "-ok" ]; then
+        shift
+        $(which yes) $*
+    else
+        echo "bash-it: this command will spam your terminal (use arg -ok to skip warning)"
+        exit 1
+    fi
+}
+function ls() {
+    if [[ -f ${*: -1:1} ]]; then
+        echo "bash-it: ${*: -1:1} is a file not a folder"
+        exit 1
+    else
+        $(which ls) $*
+    fi
+}
+function cat() {
+    if [[ -d ${*: -1:1} ]]; then
+        echo "bash-it: ${*: -1:1} is a folder not a file"
+        exit 1
+    else
+        $(which cat) $*
+    fi
+}
+function rm() {
+    if [[ -d ${*: -1:1} ]]; then
+        $(which rm) -r $*
+    else
+        $(which rm) $*
+    fi
+}


### PR DESCRIPTION
From @greenrd's idea (https://github.com/Bash-it/bash-it/issues/674), I made a basic teaching mode plugin.

I don't know how to do greenrd's example but I tried to do something with his idea : 
- anti-yes (skippabke using arg -ok)
- check if the thing you want to ls is a folder
- check if the thing you want to cat is a file
- add arg -r if you want to rm a folder