### PR TITLE
template/profile: Require interactive shell

### DIFF
--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# If not running interactively, don't do anything
+case $- in
+  *i*) ;;
+    *) return;;
+esac
+
 # Path to the bash it configuration
 export BASH_IT="{{BASH_IT}}"
 


### PR DESCRIPTION
Bash is run either in interactive mode (e.g. in a terminal) or
non-interactive mode (e.g. on an SSH server handling an SCP request). In
the latter example, any output performed by bash-it's actions will be
interpreted as SCP reply on the client side, typically leading to failed
transfers. This is a well-known limitation of the SCP:
https://bugzilla.redhat.com/show_bug.cgi?id=20527.

In bash's own bashrc example, the first lines of code query for the mode
and return early if it's non-interactive:
http://git.savannah.gnu.org/cgit/bash.git/tree/examples/startup-files/bashrc?h=bash-5.0#n1.
This practice is adopted by Linux distributions (e.g. Ubuntu) and
probably other systems.

Current mode can be queried as described here:
https://www.gnu.org/software/bash/manual/html_node/Is-this-Shell-Interactive_003f.html.

Copy the according lines from Debian stretch's default .bashrc (as found
in https://packages.debian.org/stretch/bash under /etc/skel/.bashrc) to
the bash-it profile template to disable bash-it for non-interactive
shells.

As a side effect, this change makes SCP faster since the server doesn't
need to run any bash-it code in context of SCP handling.