### PR TITLE
Remove escape characters in SCM_BRANCH variable

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -99,7 +99,7 @@ function __powerline_scm_prompt {
     elif [[ "${SCM_HG_CHAR}" == "${SCM_CHAR}" ]]; then
       scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
     fi
-    echo "${scm_prompt}${scm}|${color}"
+    echo "$(eval "echo ${scm_prompt}")${scm}|${color}"
   fi
 }
 


### PR DESCRIPTION
Fixes an issue with the SCM widget in `powerline-multiline` when the SCM widget is on the right hand side, shown below.

The issue was that the function `_git-friendly-ref` was escaped inside `${SCM_BRANCH}`, and thus the character count kept to work out how much to move the cursor left to print the right hand prompt was incorrect. This explains why when the branch is `master` below, the offset is worse than when it is `detatched:upstream-master`.

## Before Fix:

![image](https://user-images.githubusercontent.com/7091722/53986371-f14d3b80-4115-11e9-94ab-6a07e593f944.png)

## After Fix:

![image](https://user-images.githubusercontent.com/7091722/53986609-910ac980-4116-11e9-9e41-5152b3d6a782.png)
