### PR TITLE
Add modern-time theme

### DIFF
--- a/themes/modern-time/modern-time.theme.bash
+++ b/themes/modern-time/modern-time.theme.bash
@@ -1,0 +1,63 @@
+# Modified version of the original modern theme in bash-it
+# Removes the battery charge and adds the current time
+
+SCM_THEME_PROMPT_PREFIX=""
+SCM_THEME_PROMPT_SUFFIX=""
+
+SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
+SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"
+SCM_GIT_CHAR="${bold_green}±${normal}"
+SCM_SVN_CHAR="${bold_cyan}⑆${normal}"
+SCM_HG_CHAR="${bold_red}☿${normal}"
+
+case $TERM in
+	xterm*)
+	TITLEBAR="\[\033]0;\w\007\]"
+	;;
+	*)
+	TITLEBAR=""
+	;;
+esac
+
+PS3=">> "
+
+is_vim_shell() {
+	if [ ! -z "$VIMRUNTIME" ]
+	then
+		echo "[${cyan}vim shell${normal}]"
+	fi
+}
+
+modern_scm_prompt() {
+	CHAR=$(scm_char)
+	if [ $CHAR = $SCM_NONE_CHAR ]
+	then
+		return
+	else
+		echo "[$(scm_char)][$(scm_prompt_info)]"
+	fi
+}
+
+modern_current_time_prompt() {
+	echo "[$(date '+%l:%M%p')]"
+}
+
+prompt() {
+	if [ $? -ne 0 ]
+	then
+		# Yes, the indenting on these is weird, but it has to be like
+		# this otherwise it won't display properly.
+
+		PS1="${TITLEBAR}${bold_red}┌─${reset_color}$(modern_scm_prompt)$(modern_current_time_prompt)[${cyan}\W${normal}]$(is_vim_shell)
+${bold_red}└─▪${normal} "
+	else
+		PS1="${TITLEBAR}┌─$(modern_scm_prompt)$(modern_current_time_prompt)[${cyan}\W${normal}]$(is_vim_shell)
+└─▪ "
+	fi
+}
+
+PS2="└─▪ "
+
+
+
+safe_append_prompt_command prompt


### PR DESCRIPTION
It's the modern theme with the battery charge indicator replaced with the current time

```bash
┌─[11:44pm][~]
└─▪
┌─[11:44pm][~]
└─▪ cd workspace/
┌─[11:44pm][workspace]
└─▪ cd bash-it/
┌─[±][modern-time-theme ✓][11:44pm][bash-it]
└─▪ git status
On branch modern-time-theme
Your branch is up to date with 'origin/modern-time-theme'.

nothing to commit, working tree clean
┌─[±][modern-time-theme ✓][11:45pm][bash-it]
└─▪
```
<img width="777" alt="Screen Shot 2019-04-21 at 11 45 30 PM" src="https://user-images.githubusercontent.com/4583837/56481959-a43be380-648f-11e9-9ad5-43c66dac761e.png">
