### PR TITLE
adding env var for bash-completion@2 compatibility

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -22,7 +22,7 @@ if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
 
  # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
   if [ "${BASH_VERSINFO}" -ge 4 ] && [ -f "$BREW_PREFIX"/share/bash-completion/bash_completion ]; then
-    export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
+    export BASH_COMPLETION_COMPAT_DIR="$BREW_PREFIX"/etc/bash_completion.d
     . "$BREW_PREFIX"/share/bash-completion/bash_completion
   fi
 fi

--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -22,6 +22,7 @@ if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
 
  # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
   if [ "${BASH_VERSINFO}" -ge 4 ] && [ -f "$BREW_PREFIX"/share/bash-completion/bash_completion ]; then
+    export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
     . "$BREW_PREFIX"/share/bash-completion/bash_completion
   fi
 fi


### PR DESCRIPTION
I noticed after switching to `bash-completion@2` that the ones installed by `brew` in `/usr/local/etc/bash_completion.d/` weren't getting loaded. Found [this](https://discourse.brew.sh/t/bash-completion-2-vs-brews-auto-installed-bash-completions/2391/2?u=danemacmillan) reference and updated `system.completion.bash` to set the necessary environment variable for backwards compatibility.