### PR TITLE
Make head commands BSD compatible

### DIFF
--- a/aliases/available/docker.aliases.bash
+++ b/aliases/available/docker.aliases.bash
@@ -19,7 +19,7 @@ case $OSTYPE in
     ;;
 esac
 
-if [ ! -z "$(command ls "${BASH_IT}/enabled/"{[0-9][0-9][0-9]${BASH_IT_LOAD_PRIORITY_SEPARATOR}docker,docker}.plugin.bash 2>/dev/null | head -1)" ]; then
+if [ ! -z "$(command ls "${BASH_IT}/enabled/"{[0-9][0-9][0-9]${BASH_IT_LOAD_PRIORITY_SEPARATOR}docker,docker}.plugin.bash 2>/dev/null | head -n 1)" ]; then
 # Function aliases from docker plugin:
     alias dkrmlc='docker-remove-most-recent-container'  # Delete most recent (i.e., last) Docker container
     alias dkrmall='docker-remove-stale-assets'  # Delete all untagged images and exited containers

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -16,8 +16,8 @@ _bash-it-comp-list-available-not-enabled()
     do
       file_entity=$(basename $f)
 
-      typeset enabled_component=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity,$file_entity} 2>/dev/null | head -1)
-      typeset enabled_component_global=$(command ls "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity 2>/dev/null | head -1)
+      typeset enabled_component=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity,$file_entity} 2>/dev/null | head -n 1)
+      typeset enabled_component_global=$(command ls "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity 2>/dev/null | head -n 1)
 
       if [ -z "$enabled_component" ] && [ -z "$enabled_component_global" ]
       then

--- a/completion/available/fabric.completion.bash
+++ b/completion/available/fabric.completion.bash
@@ -70,7 +70,7 @@ function __fab_fabfile_mtime() {
     else
         # Suppose that it's a fabfile dir
         find $f/*.py -exec ${__FAB_COMPLETION_MTIME_COMMAND} {} + \
-            | xargs -n 1 expr | sort -n -r | head -1
+            | xargs -n 1 expr | sort -n -r | head -n 1
     fi
 }
 

--- a/lib/composure.bash
+++ b/lib/composure.bash
@@ -190,10 +190,10 @@ draft ()
         if [ -n "$myopic" ]; then
             lines=2
         fi
-        cmd=$(fc -ln -$lines | head -1 | sed 's/^[[:blank:]]*//')
+        cmd=$(fc -ln -$lines | head -n 1 | sed 's/^[[:blank:]]*//')
     else
         # parse command from history line number
-        cmd=$(eval "history | grep '^[[:blank:]]*$num' | head -1" | sed 's/^[[:blank:][:digit:]]*//')
+        cmd=$(eval "history | grep '^[[:blank:]]*$num' | head -n 1" | sed 's/^[[:blank:][:digit:]]*//')
     fi
     eval "$func() { $cmd; }"
     typeset file=$(mktemp -t draft.XXXX)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -371,13 +371,13 @@ _disable-thing ()
           rm "$f"
         done
     else
-        typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.$suffix.bash 2>/dev/null | head -1)
+        typeset plugin_global=$(command ls $ "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.$suffix.bash 2>/dev/null | head -n 1)
         if [ -z "$plugin_global" ]; then
           # Use a glob to search for both possible patterns
           # 250---node.plugin.bash
           # node.plugin.bash
           # Either one will be matched by this glob
-          typeset plugin=$(command ls $ "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.$suffix.bash,$file_entity.$suffix.bash} 2>/dev/null | head -1)
+          typeset plugin=$(command ls $ "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity.$suffix.bash,$file_entity.$suffix.bash} 2>/dev/null | head -n 1)
           if [ -z "$plugin" ]; then
               printf '%s\n' "sorry, $file_entity does not appear to be an enabled $file_type."
               return
@@ -458,7 +458,7 @@ _enable-thing ()
             _enable-thing $subdirectory $file_type $to_enable $load_priority
         done
     else
-        typeset to_enable=$(command ls "${BASH_IT}/$subdirectory/available/"$file_entity.*bash 2>/dev/null | head -1)
+        typeset to_enable=$(command ls "${BASH_IT}/$subdirectory/available/"$file_entity.*bash 2>/dev/null | head -n 1)
         if [ -z "$to_enable" ]; then
             printf '%s\n' "sorry, $file_entity does not appear to be an available $file_type."
             return
@@ -466,13 +466,13 @@ _enable-thing ()
 
         to_enable=$(basename $to_enable)
         # Check for existence of the file using a wildcard, since we don't know which priority might have been used when enabling it.
-        typeset enabled_plugin=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable,$to_enable} 2>/dev/null | head -1)
+        typeset enabled_plugin=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable,$to_enable} 2>/dev/null | head -n 1)
         if [ ! -z "$enabled_plugin" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return
         fi
 
-        typeset enabled_plugin_global=$(command compgen -G "${BASH_IT}/enabled/[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable" 2>/dev/null | head -1)
+        typeset enabled_plugin_global=$(command compgen -G "${BASH_IT}/enabled/[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable" 2>/dev/null | head -n 1)
         if [ ! -z "$enabled_plugin_global" ] ; then
           printf '%s\n' "$file_entity is already enabled."
           return

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -57,19 +57,19 @@ battery_percentage(){
 
   if _command_exists upower;
   then
-    COMMAND_OUTPUT=$(upower --show-info $(upower --enumerate | grep -i BAT) | grep percentage | grep -o "[0-9]\+" | head -1)
+    COMMAND_OUTPUT=$(upower --show-info $(upower --enumerate | grep -i BAT) | grep percentage | grep -o "[0-9]\+" | head -n 1)
   elif _command_exists acpi;
   then
     COMMAND_OUTPUT=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}' )
   elif _command_exists pmset;
   then
-    COMMAND_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -1)
+    COMMAND_OUTPUT=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -n 1)
   elif _command_exists ioreg;
   then
-    COMMAND_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}' | grep -o "[0-9]\+" | head -1)
+    COMMAND_OUTPUT=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}' | grep -o "[0-9]\+" | head -n 1)
   elif _command_exists WMIC;
   then
-    COMMAND_OUTPUT=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -1)
+    COMMAND_OUTPUT=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -n 1)
   else
     COMMAND_OUTPUT="no"
   fi

--- a/plugins/available/docker.plugin.bash
+++ b/plugins/available/docker.plugin.bash
@@ -10,7 +10,7 @@ function docker-remove-most-recent-container() {
 function docker-remove-most-recent-image() {
   about 'attempt to remove the most recent image from docker images'
   group 'docker'
-  docker images -q | head -1 | xargs docker rmi
+  docker images -q | head -n 1 | xargs docker rmi
 }
 
 function docker-remove-stale-assets() {

--- a/plugins/available/gif.plugin.bash
+++ b/plugins/available/gif.plugin.bash
@@ -152,8 +152,8 @@ function v2gif {
     else
       fps=$defaultfps
       if [[ -x $mediainfo ]] ; then
-        fps=$($mediainfo "$file" | grep "Frame rate   " |sed 's/.*: \([0-9.]\+\) .*/\1/' | head -1)
-        [[ -z "$fps" ]] && fps=$($mediainfo "$file" | grep "Minimum frame rate" |sed 's/.*: \([0-9.]\+\) .*/\1/' | head -1)
+        fps=$($mediainfo "$file" | grep "Frame rate   " |sed 's/.*: \([0-9.]\+\) .*/\1/' | head -n 1)
+        [[ -z "$fps" ]] && fps=$($mediainfo "$file" | grep "Minimum frame rate" |sed 's/.*: \([0-9.]\+\) .*/\1/' | head -n 1)
       fi
     fi
 


### PR DESCRIPTION
Shortcut `head -1` is not BSD compatible. Replace it with `head -n 1`.