### PR TITLE
add an env var that themes can save history immediately

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -497,3 +497,8 @@ function safe_append_prompt_command {
         fi
     fi
 }
+
+function _save-and-reload-history() {
+  local autosave=${1:-0}
+  [[ $autosave -eq 1 ]] && history -a && history -c && history -r
+}

--- a/themes/powerline-plain/powerline-plain.base.bash
+++ b/themes/powerline-plain/powerline-plain.base.bash
@@ -14,7 +14,7 @@ function __powerline_prompt_command {
 
   LEFT_PROMPT=""
 
-  [[ $HISTORY_AUTOSAVE -eq 1 ]] && history -a && history -c && history -r
+  _save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 
   ## left prompt ##
   for segment in $POWERLINE_PROMPT; do

--- a/themes/powerline-plain/powerline-plain.base.bash
+++ b/themes/powerline-plain/powerline-plain.base.bash
@@ -14,6 +14,8 @@ function __powerline_prompt_command {
 
   LEFT_PROMPT=""
 
+  [[ $HISTORY_AUTOSAVE -eq 1 ]] && history -a && history -c && history -r
+
   ## left prompt ##
   for segment in $POWERLINE_PROMPT; do
     local info="$(__powerline_${segment}_prompt)"

--- a/themes/powerline-plain/powerline-plain.theme.bash
+++ b/themes/powerline-plain/powerline-plain.theme.bash
@@ -55,6 +55,3 @@ HOST_THEME_PROMPT_COLOR=0
 POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
 safe_append_prompt_command __powerline_prompt_command
-
-
-HISTORY_AUTOSAVE=${HISTORY_AUTOSAVE:-0}

--- a/themes/powerline-plain/powerline-plain.theme.bash
+++ b/themes/powerline-plain/powerline-plain.theme.bash
@@ -56,3 +56,5 @@ POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
 safe_append_prompt_command __powerline_prompt_command
 
+
+HISTORY_AUTOSAVE=${HISTORY_AUTOSAVE:-0}

--- a/themes/powerline/powerline.theme.bash
+++ b/themes/powerline/powerline.theme.bash
@@ -57,4 +57,6 @@ HOST_THEME_PROMPT_COLOR=0
 
 POWERLINE_PROMPT=${POWERLINE_PROMPT:="user_info scm python_venv ruby cwd"}
 
+HISTORY_AUTOSAVE=${HISTORY_AUTOSAVE:-0}
+
 safe_append_prompt_command __powerline_prompt_command


### PR DESCRIPTION
I might be missing something but I couldn't see any function/feature for this, so I've created.

Also, I haven't wanted to use a theme specific var. I thought other themes might want to use this as well. 