### PR TITLE
Ignore unset and empty Kubernetes context

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -337,7 +337,7 @@ function ruby_version_prompt {
 }
 
 function k8s_context_prompt {
-  echo -e "$(kubectl config current-context)"
+  echo -e "$(kubectl config current-context 2> /dev/null)"
 }
 
 function virtualenv_prompt {


### PR DESCRIPTION
When current-context does not exist or is unset in $KUBECONFIG, kubectl
is throwing a message to stderr "error: current-context is not set".

Ignore it.