### PR TITLE
Fixed test of whether or not current session is interactive

### DIFF
--- a/plugins/available/history.plugin.bash
+++ b/plugins/available/history.plugin.bash
@@ -2,7 +2,7 @@ cite about-plugin
 about-plugin 'history manipulation'
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history
-if [ -t 1 ]
+if [[ ${SHELLOPTS} =~ (vi|emacs) ]]
 then
     bind '"[A":history-search-backward'
     bind '"[B":history-search-forward'


### PR DESCRIPTION
Exisitence of a tty is not sufficient condition to determine whether a bash session is interactive or not.  Checking if shopts have emacs or vi turned on is a better test.