### PR TITLE
Optimize SCM checks

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -79,15 +79,20 @@ RBENV_THEME_PROMPT_SUFFIX='|'
 RBFU_THEME_PROMPT_PREFIX=' |'
 RBFU_THEME_PROMPT_SUFFIX='|'
 
+GIT_EXE=`which git 2> /dev/null || true`
+P4_EXE=`which p4 2> /dev/null || true`
+HG_EXE=`which hg  2> /dev/null || true`
+SVN_EXE=`which svn  2> /dev/null || true`
+
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE
-  elif [[ -f .git/HEAD ]] && which git &> /dev/null; then SCM=$SCM_GIT
-  elif which git &> /dev/null && [[ -n "$(git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
-  elif which p4 &> /dev/null && [[ -n "$(p4 set P4CLIENT 2> /dev/null)" ]]; then SCM=$SCM_P4
-  elif [[ -d .hg ]] && which hg &> /dev/null; then SCM=$SCM_HG
-  elif which hg &> /dev/null && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
-  elif [[ -d .svn ]] && which svn &> /dev/null; then SCM=$SCM_SVN
-  elif which svn &> /dev/null && [[ -n "$(svn info --show-item wc-root 2>/dev/null)" ]]; then SCM=$SCM_SVN
+  elif [[ -f .git/HEAD ]] && [[ -x "$GIT_EXE" ]]; then SCM=$SCM_GIT
+  elif [[ -x "$GIT_EXE" ]] && [[ -n "$(git rev-parse --is-inside-work-tree 2> /dev/null)" ]]; then SCM=$SCM_GIT
+  elif [[ -x "$P4_EXE" ]] && [[ -n "$(p4 set P4CLIENT 2> /dev/null)" ]]; then SCM=$SCM_P4
+  elif [[ -d .hg ]] && [[ -x "$HG_EXE" ]]; then SCM=$SCM_HG
+  elif [[ -x "$HG_EXE" ]] && [[ -n "$(hg root 2> /dev/null)" ]]; then SCM=$SCM_HG
+  elif [[ -d .svn ]] && [[ -x "$SVN_EXE" ]]; then SCM=$SCM_SVN
+  elif [[ -x "$SVN_EXE" ]] && [[ -n "$(svn info --show-item wc-root 2>/dev/null)" ]]; then SCM=$SCM_SVN
   else SCM=$SCM_NONE
   fi
 }


### PR DESCRIPTION
When SCM_CHECK is enabled every time you do a command in the terminal it will spawn many `which` processes to check the existence of the SCM executables, this increase the delay of commands on the terminal and CPU/battery usage. This PR make this check more lightweight by checking at startup. This behavior was found by monitoring terminal usage with `forkstat` tool:

```
Time     Event   PID Info   Duration Process
09:18:23 exec  10280                 which git
09:18:23 exit  10280      0   0.002s which git
09:18:23 fork  10279 parent          /bin/bash
09:18:23 fork  10281 child           /bin/bash
09:18:23 fork  10281 parent          /bin/bash
09:18:23 fork  10282 child           /bin/bash
09:18:23 exec  10282                 git rev-parse --is-inside-work-tree
09:18:23 exit  10282  32768   0.002s git rev-parse --is-inside-work-tree
09:18:23 exit  10281  32768   0.003s /bin/bash
09:18:23 fork  10279 parent          /bin/bash
09:18:23 fork  10283 child           /bin/bash
09:18:23 exec  10283                 which p4
09:18:23 exit  10283    256   0.001s which p4
09:18:23 fork  10279 parent          /bin/bash
09:18:23 fork  10284 child           /bin/bash
09:18:23 exec  10284                 which hg
09:18:23 exit  10284    256   0.001s which hg
09:18:23 fork  10279 parent          /bin/bash
09:18:23 fork  10285 child           /bin/bash
09:18:23 exec  10285                 which svn
09:18:23 exit  10285    256   0.001s which svn
09:18:23 exit  10279      0   0.012s /bin/bash
```

As you can see above the `which` sum up to 5ms delays. With this PR they are called once at startup.