### PR TITLE
Completely ignore enabled-dir in root to support symlinking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ bats
 *.sublime-workspace
 *.sublime-project
 enabled/*
+/enabled
 tmp/


### PR DESCRIPTION
### Context
In a dotfiles-setup it is handy to track everything in your dotfiles-repo that makes up your environment. In this context `BASH_IT_CUSTOM` is very handy to track every custom plugin/alias/... in your dotfiles-repo. This is not possible for your enabled-plugins/aliases/... in the enabled-dir. This means every environment has to manually enable the plugins/aliases/... you want. There is a way to fix this by making the enabled-dir a symlink to somewhere else.

### Issue
The enabled-symlink in the root is not ignored by the current .gitignore.

### Fix
Ignore `/enabled` which fixes the issue.

A better solution would be to have something like `BASH_IT_CUSTOM` but this seems like a fine solution for now.