### PR TITLE
Add helper function to add all ssh private keys to agent

### DIFF
--- a/plugins/available/ssh.plugin.bash
+++ b/plugins/available/ssh.plugin.bash
@@ -17,3 +17,10 @@ function sshlist() {
 
   awk '$1 ~ /Host$/ {for (i=2; i<=NF; i++) print $i}' ~/.ssh/config
 }
+
+function ssh-add-all() {
+  about 'add all ssh private keys to agent'
+  group 'ssh'
+
+  grep -slR "PRIVATE" ~/.ssh | xargs ssh-add
+}


### PR DESCRIPTION
This PR adds a helper function called `ssh-add-all` to add all private identities under `~/.ssh` to ssh authentication agent. Its an extension of `ssh-add` command.