### PR TITLE
Remove errors if plugin executable not available

### DIFF
--- a/plugins/available/node.plugin.bash
+++ b/plugins/available/node.plugin.bash
@@ -4,4 +4,4 @@ about-plugin 'Node.js helper functions'
 pathmunge ./node_modules/.bin
 
 # Make sure the global npm prefix is on the path
-[[ `which npm` ]] && pathmunge $(npm config get prefix)/bin
+[[ `which npm 2>/dev/null` ]] && pathmunge $(npm config get prefix)/bin

--- a/plugins/available/pyenv.plugin.bash
+++ b/plugins/available/pyenv.plugin.bash
@@ -4,7 +4,7 @@ about-plugin 'load pyenv, if you are using it'
 export PYENV_ROOT="$HOME/.pyenv"
 pathmunge "$PYENV_ROOT/bin"
 
-[[ `which pyenv` ]] && eval "$(pyenv init - bash)"
+[[ `which pyenv 2>/dev/null` ]] && eval "$(pyenv init - bash)"
 
 #Load pyenv virtualenv if the virtualenv plugin is installed.
 if pyenv virtualenv-init - &> /dev/null; then

--- a/plugins/available/rbenv.plugin.bash
+++ b/plugins/available/rbenv.plugin.bash
@@ -4,4 +4,4 @@ about-plugin 'load rbenv, if you are using it'
 export RBENV_ROOT="$HOME/.rbenv"
 pathmunge "$RBENV_ROOT/bin"
 
-[[ `which rbenv` ]] && eval "$(rbenv init - bash)"
+[[ `which rbenv 2>/dev/null` ]] && eval "$(rbenv init - bash)"


### PR DESCRIPTION
Remove error output if plugin is enabled for npm, pyenv, rbenv but the executable is not available.
Useful for keeping the same configs synced across machines that may not have them installed.