### PR TITLE
Added proxy exceptions (noproxy) for npm

### DIFF
--- a/plugins/available/proxy.plugin.bash
+++ b/plugins/available/proxy.plugin.bash
@@ -121,6 +121,7 @@ npm-show-proxy ()
 		echo "==="
 		echo "npm HTTP  proxy: " `npm config get proxy`
 		echo "npm HTTPS proxy: " `npm config get https-proxy`
+		echo "npm proxy exceptions: " `npm config get noproxy`
 	fi
 }
 
@@ -132,6 +133,7 @@ npm-disable-proxy ()
 	if $(command -v npm &> /dev/null) ; then
 		npm config delete proxy
 		npm config delete https-proxy
+		npm config delete noproxy
 		echo "Disabled npm proxy settings"
 	fi
 }
@@ -143,10 +145,12 @@ npm-enable-proxy ()
 
 	local my_http_proxy=${1:-$BASH_IT_HTTP_PROXY}
 	local my_https_proxy=${2:-$BASH_IT_HTTPS_PROXY}
+	local my_no_proxy=${3:-$BASH_IT_NO_PROXY}
 
 	if $(command -v npm &> /dev/null) ; then
 		npm config set proxy $my_http_proxy
 		npm config set https-proxy $my_https_proxy
+		npm config set noproxy $my_no_proxy
 		echo "Enabled npm proxy settings"
 	fi
 }


### PR DESCRIPTION
NPM has to support proxy exceptions/exclusions. Now proxy command can add/remove/show exclusions for npm too.