### PR TITLE
Trivial fix for clean theme

### DIFF
--- a/themes/clean/clean.theme.bash
+++ b/themes/clean/clean.theme.bash
@@ -13,7 +13,7 @@ function prompt_command() {
 
     if [ "$(whoami)" = root ]; then no_color=$red; else no_color=$white; fi
 
-    PS1="${no_color}\u${reset_color}:${blue}\W/${reset_color} \[$(scm_prompt_info)\]${normal}$ "
+    PS1="${no_color}\u${reset_color}:${blue}\W/${reset_color} $(scm_prompt_info)${normal}$ "
 }
 
 safe_append_prompt_command prompt_command


### PR DESCRIPTION
https://github.com/Bash-it/bash-it/issues/1422

Removed `\[` and `\]` around `$(scm_prompt_info)`. This created an issue with ghost characters in combination with nvm.
