### PR TITLE
Update less-pretty-cat plugin to support pygment style selection

### DIFF
--- a/plugins/available/less-pretty-cat.plugin.bash
+++ b/plugins/available/less-pretty-cat.plugin.bash
@@ -13,9 +13,12 @@ if $(command -v pygmentize &> /dev/null) ; then
       about 'runs either pygmentize or cat on each file passed in'
       param '*: files to concatenate (as normally passed to cat)'
       example 'cat mysite/manage.py dir/text-file.txt'
+      if [ -z "$BASH_IT_CCAT_STYLE" ]; then
+          BASH_IT_CCAT_STYLE=default;
+      fi
       for var;
       do
-          pygmentize "$var" 2>/dev/null || "$CAT_BIN" "$var";
+          pygmentize -f 256 -O style="$BASH_IT_CCAT_STYLE" -g "$var" 2>/dev/null || "$CAT_BIN" "$var";
       done
   }
 
@@ -24,6 +27,9 @@ if $(command -v pygmentize &> /dev/null) ; then
       about 'it pigments the file passed in and passes it to less for pagination'
       param '$1: the file to paginate with less'
       example 'less mysite/manage.py'
-      pygmentize -g $* | "$LESS_BIN" -R
+      if [ -z "$BASH_IT_CLESS_STYLE" ]; then
+          BASH_IT_CLESS_STYLE=default;
+      fi
+      pygmentize -f 256 -O style="$BASH_IT_CLESS_STYLE" -g $* | "$LESS_BIN" -R
   }
 fi

--- a/plugins/available/less-pretty-cat.plugin.bash
+++ b/plugins/available/less-pretty-cat.plugin.bash
@@ -5,6 +5,8 @@ if $(command -v pygmentize &> /dev/null) ; then
   # get the full paths to binaries
   CAT_BIN=$(which cat)
   LESS_BIN=$(which less)
+  BASH_IT_CCAT_STYLE="${BASH_IT_CCAT_STYLE:=default}"
+  BASH_IT_CLESS_STYLE="${BASH_IT_CLESS_STYLE:=default}"
 
   # pigmentize cat and less outputs - call them ccat and cless to avoid that
   # especially cat'ed output in scripts gets mangled with pygemtized meta characters
@@ -13,9 +15,6 @@ if $(command -v pygmentize &> /dev/null) ; then
       about 'runs either pygmentize or cat on each file passed in'
       param '*: files to concatenate (as normally passed to cat)'
       example 'cat mysite/manage.py dir/text-file.txt'
-      if [ -z "$BASH_IT_CCAT_STYLE" ]; then
-          BASH_IT_CCAT_STYLE=default;
-      fi
       for var;
       do
           pygmentize -f 256 -O style="$BASH_IT_CCAT_STYLE" -g "$var" 2>/dev/null || "$CAT_BIN" "$var";
@@ -27,9 +26,6 @@ if $(command -v pygmentize &> /dev/null) ; then
       about 'it pigments the file passed in and passes it to less for pagination'
       param '$1: the file to paginate with less'
       example 'less mysite/manage.py'
-      if [ -z "$BASH_IT_CLESS_STYLE" ]; then
-          BASH_IT_CLESS_STYLE=default;
-      fi
       pygmentize -f 256 -O style="$BASH_IT_CLESS_STYLE" -g $* | "$LESS_BIN" -R
   }
 fi


### PR DESCRIPTION
Pygments offers great styles and in dark terminals the default is unsatisfactory.

Use two new env variables BASH_IT_CLESS_STYLE and BASH_IT_CCAT_STYLE to select pygment themes.
Availables styles can be listes using pygmentize -L styles