### PR TITLE
implement gitstatusd support

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -121,5 +121,12 @@ if ! command -v reload &>/dev/null && [ -n "$BASH_IT_RELOAD_LEGACY" ]; then
   esac
 fi
 
+# If gitstatusd is requested for the current shell, launch it if the shell is interactive
+if [[ "${SCM_GIT_USE_GITSTATUSD}" == "true" ]] && [[ "$SCM_CHECK" == "true" ]] && [[ $- == *i* ]]; then
+  test -z "${SCM_GIT_GITSTATUSD_LOC}" || SCM_GIT_GITSTATUSD_LOC="$HOME/gitstatus/gitstatus.plugin.sh"
+  source "${SCM_GIT_GITSTATUSD_LOC}"
+  gitstatus_stop && gitstatus_start -s -1 -u -1 -c -1 -d -1
+fi
+
 # Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
 set +T

--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -32,6 +32,12 @@ export TODO="t"
 
 # Set this to false to turn off version control status checking within the prompt for all themes
 export SCM_CHECK=true
+# when using Git, consider installing https://github.com/romkatv/gitstatus for faster status prompt
+# enable it here if you wish, change the LOC variable if you did not choose the standard location in your home
+#export SCM_GIT_USE_GITSTATUSD=true
+#export SCM_GIT_GITSTATUSD_LOC="$HOME/gitstatus/gitstatus.plugin.sh"
+# per default gitstatusd uses 2 times as many threads as CPU cores, you can change this here if you must
+#export GITSTATUS_NUM_THREADS=8
 
 # Set Xterm/screen/Tmux title with only a short hostname.
 # Uncomment this (or set SHORT_HOSTNAME to something else),

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -36,6 +36,7 @@ SCM_GIT_SHOW_STASH_INFO=${SCM_GIT_SHOW_STASH_INFO:=true}
 SCM_GIT_SHOW_COMMIT_COUNT=${SCM_GIT_SHOW_COMMIT_COUNT:=true}
 SCM_GIT_USE_GITSTATUSD=${SCM_GIT_USE_GITSTATUSD:=false}
 SCM_GIT_GITSTATUSD_LOC=${SCM_GIT_GITSTATUSD_LOC:="$HOME/gitstatus/gitstatus.plugin.sh"}
+SCM_GIT_GITSTATUSD_RAN=${SCM_GIT_GITSTATUSD_RAN:=false}
 
 SCM_GIT='git'
 SCM_GIT_CHAR='±'
@@ -173,13 +174,10 @@ function git_prompt_minimal_info {
 }
 
 function git_prompt_vars {
-  if ${SCM_GIT_USE_GITSTATUSD}; then # use faster gitstatusd
-    gitstatus_query # call gitstatusd
-    if [[ -z ${VCS_STATUS_WORKDIR} ]] ; then # this var is guaranteed to exist if query was successful
-      SCM_GIT_GITSTATUSD_RAN=false
-    else
-      SCM_GIT_GITSTATUSD_RAN=true # use this in githelpers and below to choose gitstatusd output
-    fi
+  if ${SCM_GIT_USE_GITSTATUSD} && gitstatus_query && [[ "${VCS_STATUS_RESULT}" == "ok-sync" ]]; then # use faster gitstatusd
+    SCM_GIT_GITSTATUSD_RAN=true # use this in githelpers and below to choose gitstatusd output
+  else
+    SCM_GIT_GITSTATUSD_RAN=false
   fi
 
   if _git-branch &> /dev/null; then

--- a/themes/githelpers.theme.bash
+++ b/themes/githelpers.theme.bash
@@ -127,7 +127,7 @@ function _git-remote-info {
       if [[ "${same_branch_name}" != "true" ]]; then
         remote_info="\${VCS_STATUS_REMOTE_NAME}"
       else
-        remote_info="${VCS_STATUS_REMOTE_NAME}/${VCS_STATUS_REMOTE_BRANCH}"
+        remote_info="\${VCS_STATUS_REMOTE_NAME}/\${VCS_STATUS_REMOTE_BRANCH}"
       fi
     elif [[ ${same_branch_name} != "true" ]]; then
       remote_info="\${VCS_STATUS_REMOTE_BRANCH}"

--- a/themes/githelpers.theme.bash
+++ b/themes/githelpers.theme.bash
@@ -9,11 +9,19 @@ function _git-symbolic-ref {
 # same commit. _git-branch is used to explicitly choose the checked-out
 # branch.
 function _git-branch {
- git symbolic-ref -q --short HEAD 2> /dev/null || return 1
+  if [[ "${SCM_GIT_GITSTATUSD_RAN}" == "true" ]]; then
+    test -n "${VCS_STATUS_LOCAL_BRANCH}" && echo "${VCS_STATUS_LOCAL_BRANCH}" || return 1
+  else 
+    git symbolic-ref -q --short HEAD 2> /dev/null || return 1
+  fi
 }
 
 function _git-tag {
-  git describe --tags --exact-match 2> /dev/null
+  if [[ "${SCM_GIT_GITSTATUSD_RAN}" == "true" ]]; then
+    test -n "${VCS_STATUS_TAG}" && echo "${VCS_STATUS_TAG}"
+  else 
+    git describe --tags --exact-match 2> /dev/null
+  fi
 }
 
 function _git-commit-description {
@@ -21,12 +29,20 @@ function _git-commit-description {
 }
 
 function _git-short-sha {
-  git rev-parse --short HEAD
+  if [[ "${SCM_GIT_GITSTATUSD_RAN}" == "true" ]]; then
+    echo ${VCS_STATUS_COMMIT:0:7}
+  else
+    git rev-parse --short HEAD
+  fi
 }
 
 # Try the checked-out branch first to avoid collision with branches pointing to the same ref.
 function _git-friendly-ref {
+  if [[ "${SCM_GIT_GITSTATUSD_RAN}" == "true" ]]; then
+    _git-branch || _git-tag || _git-short-sha # there is no tag based describe output in gitstatusd
+  else 
     _git-branch || _git-tag || _git-commit-description || _git-short-sha
+  fi
 }
 
 function _git-num-remotes {
@@ -101,29 +117,51 @@ function _git-status-counts {
 }
 
 function _git-remote-info {
-  [[ "$(_git-upstream)" == "" ]] && return || true
 
-  [[ "$(_git-branch)" == "$(_git-upstream-branch)" ]] && local same_branch_name=true || true
-  local same_branch_name=
-  [[ "$(_git-branch)" == "$(_git-upstream-branch)" ]] && same_branch_name=true
-  if ([[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "auto" ]] && [[ "$(_git-num-remotes)" -ge 2 ]]) ||
-      [[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "true" ]]; then
-    if [[ "${same_branch_name}" != "true" ]]; then
-      remote_info="\$(_git-upstream)"
-    else
-      remote_info="$(_git-upstream-remote)"
+  if [[ "${SCM_GIT_GITSTATUSD_RAN}" == "true" ]]; then # prompt handling only, reimplement because patching the routine below gets ugly
+    [[ "${VCS_STATUS_REMOTE_NAME}" == "" ]] && return || true
+    [[ "${VCS_STATUS_LOCAL_BRANCH}" == "${VCS_STATUS_REMOTE_BRANCH}" ]] && local same_branch_name=true || true
+    local same_branch_name=
+    [[ "${VCS_STATUS_LOCAL_BRANCH}" == "${VCS_STATUS_REMOTE_BRANCH}" ]] && same_branch_name=true
+    if [[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "true" ]] || [[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "auto" ]]; then # no multiple remote support in gitstatusd
+      if [[ "${same_branch_name}" != "true" ]]; then
+        remote_info="\${VCS_STATUS_REMOTE_NAME}"
+      else
+        remote_info="${VCS_STATUS_REMOTE_NAME}/${VCS_STATUS_REMOTE_BRANCH}"
+      fi
+    elif [[ ${same_branch_name} != "true" ]]; then
+      remote_info="\${VCS_STATUS_REMOTE_BRANCH}"
     fi
-  elif [[ ${same_branch_name} != "true" ]]; then
-    remote_info="\$(_git-upstream-branch)"
-  fi
-  if [[ -n "${remote_info}" ]];then
-    local branch_prefix
-    if _git-upstream-branch-gone; then
-      branch_prefix="${SCM_THEME_BRANCH_GONE_PREFIX}"
-    else
-      branch_prefix="${SCM_THEME_BRANCH_TRACK_PREFIX}"
+    if [[ -n "${remote_info}" ]];then
+      local branch_prefix 
+      branch_prefix="${SCM_THEME_BRANCH_TRACK_PREFIX}" # no support for gone remote branches in gitstatusd
+      echo "${branch_prefix}${remote_info}"
     fi
-    echo "${branch_prefix}${remote_info}"
+  else 
+    [[ "$(_git-upstream)" == "" ]] && return || true
+
+    [[ "$(_git-branch)" == "$(_git-upstream-branch)" ]] && local same_branch_name=true || true
+    local same_branch_name=
+    [[ "$(_git-branch)" == "$(_git-upstream-branch)" ]] && same_branch_name=true
+    if ([[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "auto" ]] && [[ "$(_git-num-remotes)" -ge 2 ]]) ||
+        [[ "${SCM_GIT_SHOW_REMOTE_INFO}" = "true" ]]; then
+      if [[ "${same_branch_name}" != "true" ]]; then
+        remote_info="\$(_git-upstream)"
+      else
+        remote_info="$(_git-upstream-remote)"
+      fi
+    elif [[ ${same_branch_name} != "true" ]]; then
+      remote_info="\$(_git-upstream-branch)"
+    fi
+    if [[ -n "${remote_info}" ]];then
+      local branch_prefix
+      if _git-upstream-branch-gone; then
+        branch_prefix="${SCM_THEME_BRANCH_GONE_PREFIX}"
+      else
+        branch_prefix="${SCM_THEME_BRANCH_TRACK_PREFIX}"
+      fi
+      echo "${branch_prefix}${remote_info}"
+    fi
   fi
 }
 


### PR DESCRIPTION
This implements gitstatusd support for bash-it as requested in #1378 
Please review, the branch is based off of latest master. For me it works well using the powerline multiline theme.

I tried to preserve legacy 100%, meaning it's off by default and I'm switching between the legacy git calls and gitstatusd variables depending if gitstatusd ran or not. This means it should also failover correctly and if people used functions from the githelpers file it should not interfere with what they are getting when not using gitstatusd.

I put the launch into the bash_it.sh because it shall only happen once on opening the shell, and really only once. Also I check for an interactive shell so we do not waste resources for non-interactive shells where there is no prompt.