### PR TITLE
Fixes prompt bg color on powerline naked theme

### DIFF
--- a/themes/powerline-naked/powerline-naked.base.bash
+++ b/themes/powerline-naked/powerline-naked.base.bash
@@ -11,5 +11,6 @@ function __powerline_left_segment {
     separator="${separator_char}"
   fi
   LEFT_PROMPT+="${separator}$(set_color ${params[1]} -) ${params[0]} ${normal}"
+  LAST_SEGMENT_COLOR=${params[1]}
   (( SEGMENTS_AT_LEFT += 1 ))
 }


### PR DESCRIPTION
This PR brings in the `LAST_SEGMENT_COLOR` tracking logic from the default theme, resulting in the prompt having the normal background color and the last segment's foreground color.

*before*
<img width="555" alt="before" src="https://user-images.githubusercontent.com/45741407/68345770-03b5b580-00a7-11ea-9afb-44739e87ae3e.png">

*after*
<img width="555" alt="after" src="https://user-images.githubusercontent.com/45741407/68345769-03b5b580-00a7-11ea-9166-4b24f09c157f.png">

I'm not sure if the "before" result was intended or not, but it felt like an oversight to me, as the stark change in bg color feels like it breaks the `naked` theme's goals for simplicity.

-DF
