### PR TITLE
Adds a new vi-mode theme called ramses

### DIFF
--- a/themes/ramses/ramses.theme.bash
+++ b/themes/ramses/ramses.theme.bash
@@ -1,0 +1,109 @@
+SCM_THEME_PROMPT_PREFIX=""
+SCM_THEME_PROMPT_SUFFIX=""
+
+SCM_THEME_PROMPT_DIRTY=" ${bold_red}✗${normal}"
+SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"
+SCM_GIT_CHAR="${bold_green}±${normal}"
+SCM_SVN_CHAR="${bold_cyan}⑆${normal}"
+SCM_HG_CHAR="${bold_red}☿${normal}"
+
+#Mysql Prompt
+export MYSQL_PS1="(\u@\h) [\d]> "
+
+case $TERM in
+        xterm*)
+        TITLEBAR="\[\033]0;\w\007\]"
+        ;;
+        *)
+        TITLEBAR=""
+        ;;
+esac
+
+PS3=">> "
+
+__my_rvm_ruby_version() {
+    local gemset=$(echo $GEM_HOME | awk -F'@' '{print $2}')
+  [ "$gemset" != "" ] && gemset="@$gemset"
+    local version=$(echo $MY_RUBY_HOME | awk -F'-' '{print $2}')
+    local full="$version$gemset"
+  [ "$full" != "" ] && echo "[$full]"
+}
+
+is_vim_shell() {
+        if [ ! -z "$VIMRUNTIME" ]
+        then
+                echo "[${cyan}vim shell${normal}]"
+        fi
+}
+
+modern_scm_prompt() {
+        CHAR=$(scm_char)
+        if [ $CHAR = $SCM_NONE_CHAR ]
+        then
+                return
+        else
+                echo "[$(scm_char)][$(scm_prompt_info)]"
+        fi
+}
+
+# show chroot if exist
+chroot(){
+    if [ -n "$debian_chroot" ]
+    then 
+        my_ps_chroot="${bold_cyan}$debian_chroot${normal}";
+        echo "($my_ps_chroot)";
+    fi
+    }
+
+# show virtualenvwrapper
+my_ve(){
+
+    if [ -n "$CONDA_DEFAULT_ENV" ]
+    then
+        my_ps_ve="${bold_purple}${CONDA_DEFAULT_ENV}${normal}";
+        echo "($my_ps_ve)";
+    elif [ -n "$VIRTUAL_ENV" ]
+    then 
+        my_ps_ve="${bold_purple}$ve${normal}";
+        echo "($my_ps_ve)";
+    fi
+    echo "";
+    }
+
+prompt() {
+
+    my_ps_host="${green}\h${normal}";
+    # yes, these are the the same for now ...
+    my_ps_host_root="${green}\h${normal}";
+ 
+    my_ps_user="${bold_green}\u${normal}"
+    my_ps_root="${bold_red}\u${normal}";
+
+    if [ -n "$VIRTUAL_ENV" ]
+    then
+        ve=`basename $VIRTUAL_ENV`;
+    fi
+
+    # nice prompt
+    case "`id -u`" in
+        0) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(modern_scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]
+▪ "
+        ;;
+        *) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(modern_scm_prompt)$(__my_rvm_ruby_version)
+|─[${bold_purple}\w${normal}]
+▪ "
+        ;;
+    esac
+}
+
+PS2="▪ "
+
+# vi mode
+set -o vi
+bind 'set vi-ins-mode-string "└+"'
+bind 'set vi-cmd-mode-string "└─"'
+bind 'set show-mode-in-prompt on'
+bind '"jj":vi-movement-mode'
+VIMRUNTIME='true'
+
+safe_append_prompt_command prompt


### PR DESCRIPTION
Based on the [zork](https://github.com/Bash-it/bash-it/blob/master/themes/zork/zork.theme.bash) theme, it separates user info and git status from the pwd and the prompt line.

It also activates vi-mode and tells you if you're in insert mode by showing a small *+* before your prompt, and a long dash otherwise.

Here in insert mode
![ramses_screenshot](https://user-images.githubusercontent.com/16966227/70330750-79e04000-183e-11ea-9ea3-2eff4d6d3f06.png)

Here in normal mode and inside a git repo
![ramses_screenshot2](https://user-images.githubusercontent.com/16966227/70330981-e4917b80-183e-11ea-8e3d-1f06f42dbd28.png)
