### PR TITLE
SSH completion : corrects the inclusion file list by properly interpreting the paths s…

### DIFF
--- a/completion/available/ssh.completion.bash
+++ b/completion/available/ssh.completion.bash
@@ -15,7 +15,7 @@ _sshcomplete() {
     for fl in "$HOME/.ssh/config" \
         $(grep "^\s*Include" "$HOME/.ssh/config" | 
             awk '{for (i=2; i<=NF; i++) print $i}' | 
-            sed "s|^~/|$HOME/|")
+            sed -re "s|^([^/~])|$HOME/.ssh/\1|" -e "s|^~/|$HOME/|")
     do
         if [ -r "$fl" ]; then
             COMPREPLY=( ${COMPREPLY[@]} $(compgen -W "$(grep -i ^Host "$fl" |grep -v '[*!]' | awk '{for (i=2; i<=NF; i++) print $i}' )" ${OPTIONS}) )


### PR DESCRIPTION
…pecified in the Include directive of the ssh_config, aka paths relative to the ~/.ssh folder.