### PR TITLE
Fix the completion for pip/pip3

### DIFF
--- a/completion/available/pip.completion.bash
+++ b/completion/available/pip.completion.bash
@@ -1,2 +1,10 @@
 # https://pip.pypa.io/en/stable/user_guide/#command-completion
-eval "$(pip completion --bash)"
+# Of course, you should first install the pip, say on Debian:
+# sudo apt-get install python-pip
+# sudo apt-get install python3-pip
+# If the pip package is installed within virtual environments, say, python managed by pyenv,
+# you should first initilization the corresponding environment.
+# So that the pip/pip3 is in system's path.
+if command -v pip >/dev/null; then
+  eval "$(pip completion --bash)"
+fi

--- a/completion/available/pip.completion.bash
+++ b/completion/available/pip.completion.bash
@@ -1,11 +1,2 @@
-
-# pip bash completion start
-_pip_completion()
-{
-    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   PIP_AUTO_COMPLETE=1 $1 ) )
-}
-complete -o default -F _pip_completion pip
-# pip bash completion end
-
+# https://pip.pypa.io/en/stable/user_guide/#command-completion
+eval "$(pip completion --bash)"

--- a/completion/available/pip3.completion.bash
+++ b/completion/available/pip3.completion.bash
@@ -1,11 +1,2 @@
-
-# pip bash completion start
-_pip_completion()
-{
-    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \
-                   COMP_CWORD=$COMP_CWORD \
-                   PIP_AUTO_COMPLETE=1 $1 ) )
-}
-complete -o default -F _pip_completion pip3
-# pip bash completion end
-
+# https://pip.pypa.io/en/stable/user_guide/#command-completion
+eval "$(pip3 completion --bash)"

--- a/completion/available/pip3.completion.bash
+++ b/completion/available/pip3.completion.bash
@@ -1,2 +1,11 @@
 # https://pip.pypa.io/en/stable/user_guide/#command-completion
-eval "$(pip3 completion --bash)"
+# Of course, you should first install the pip, say on Debian:
+# sudo apt-get install python-pip
+# sudo apt-get install python3-pip
+# If the pip package is installed within virtual environments, say, python managed by pyenv,
+# you should first initilization the corresponding environment.
+# So that the pip/pip3 is in system's path.
+if command -v pip3 >/dev/null; then
+  eval "$(pip3 completion --bash)"
+fi
+


### PR DESCRIPTION
Use the official suggested method for  pip/pip3 completion described here :
https://pip.pypa.io/en/stable/user_guide/#command-completion

```

Command Completion

pip comes with support for command line completion in bash, zsh and fish.

To setup for bash:

$ pip completion --bash >> ~/.profile

To setup for zsh:

$ pip completion --zsh >> ~/.zprofile

To setup for fish:

$ pip completion --fish > ~/.config/fish/completions/pip.fish

Alternatively, you can use the result of the completion command directly with the eval function of your shell, e.g. by adding the following to your startup file:

eval "`pip completion --bash`"
```

