### PR TITLE
Bira theme

### DIFF
--- a/themes/bira/README.md
+++ b/themes/bira/README.md
@@ -1,0 +1,8 @@
+# Bira
+
+This is a port of Oh My Zsh's ['Bira'](https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/bira.zsh-theme) theme. It looks the same as the original, except for the following changes:
+
+- Exit code of last command is not shown
+- More informative git prompt (if you want to keep it minimal, please read: https://github.com/Bash-it/bash-it#git-prompt)
+- Position and colour of virtualenv prompt
+- No ruby version prompt

--- a/themes/bira/bira.theme.bash
+++ b/themes/bira/bira.theme.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+SCM_THEME_PROMPT_PREFIX=" ${yellow}‹"
+SCM_THEME_PROMPT_SUFFIX="›${reset_color}"
+
+VIRTUALENV_THEME_PROMPT_PREFIX=" ${cyan}‹"
+VIRTUALENV_THEME_PROMPT_SUFFIX="›${reset_color}"
+
+bold="\[\e[1m\]"
+
+if [ ${UID} -eq 0 ]; then
+  user_host="${bold_red}\u@\h${normal}${reset_color}"
+else
+  user_host="${bold_green}\u@\h${normal}${reset_color}"
+fi
+
+function prompt_command() {
+  local current_dir=" ${bold_blue}\w${normal}${reset_color}"
+  PS1="╭─${user_host}${current_dir}$(virtualenv_prompt)$(scm_prompt_info)\n╰─${bold}\\$ ${normal}"
+}
+
+safe_append_prompt_command prompt_command


### PR DESCRIPTION
This is a port of Oh My Zsh's [Bira](https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/bira.zsh-theme) theme. It looks the same as the original, except for the following changes:

- Exit code of last command is not shown
- More informative git prompt (if you want to keep it minimal, please read: https://github.com/Bash-it/bash-it#git-prompt)
- Position and colour of virtualenv prompt
- No ruby version prompt

![Bira-theme-bash-it](https://user-images.githubusercontent.com/60271007/73108322-4a75b780-3f00-11ea-8893-003bcc48bd89.png)