### PR TITLE
add gprom and gpunch to git aliases

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -77,6 +77,9 @@ alias gpatch="git format-patch -1"
 alias gnew="git log HEAD@{1}..HEAD@{0}"
 # Add uncommitted and unstaged changes to the last commit
 alias gcaa="git commit -a --amend -C HEAD"
+# Rebase with latest remote master
+alias gprom="git fetch origin master && git rebase origin/master && git update-ref refs/heads/master origin/master"
+alias gpunch="git push --force-with-lease"
 alias ggui="git gui"
 alias gcsam="git commit -S -am"
 alias gst="git stash"


### PR DESCRIPTION
Add `gprom` and `gpunch` git aliases which are useful for working on large projects where you have to rebase with latest master before creating a PR -- note: would like some thoughts on adding gprom (it might not be a good alias to add since it specifically assumes/references origin as remote and master as the main branch)    