### PR TITLE
Check gh command exists before setting git gh alias

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -103,7 +103,11 @@ alias gsw="git switch"
 alias gswm="git switch master"
 alias gswc="git switch --create"
 alias gswt="git switch --track"
-alias gh='cd "$(git rev-parse --show-toplevel)"'
+# Git home
+alias ghm='cd "$(git rev-parse --show-toplevel)"'
+if ! _command_exists gh; then
+  alias gh='cd "$(git rev-parse --show-toplevel)"'
+fi
 # Show untracked files
 alias gu='git ls-files . --exclude-standard --others'
 

--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -106,7 +106,7 @@ alias gswt="git switch --track"
 # Git home
 alias ghm='cd "$(git rev-parse --show-toplevel)"'
 if ! _command_exists gh; then
-  alias gh='cd "$(git rev-parse --show-toplevel)"'
+  alias gh='ghm'
 fi
 # Show untracked files
 alias gu='git ls-files . --exclude-standard --others'


### PR DESCRIPTION
Fixes https://github.com/Bash-it/bash-it/issues/1498

`gh` was for `git home` so I am renaming it `ghm`