### PR TITLE
Enhance make completion to support multiple files and gnumake

### DIFF
--- a/completion/available/makefile.completion.bash
+++ b/completion/available/makefile.completion.bash
@@ -8,9 +8,9 @@ _makecomplete() {
 
   # https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html
   local files=()
-  while IFS='' read -r line; do
-    files+=("$line")
-  done < <(find . -maxdepth 1 -regextype posix-extended -regex '.*(GNU)?[Mm]akefile$' -printf '%f\n')
+  for f in 'GNUmakefile' 'makefile' 'Makefile' ; do
+    [ -f "$f" ] && files+=("$f")
+  done
 
   [ "${#files[@]}" -eq 0 ] && return 0
 

--- a/completion/available/makefile.completion.bash
+++ b/completion/available/makefile.completion.bash
@@ -4,11 +4,15 @@
 # Loosely adapted from http://stackoverflow.com/a/38415982/1472048
 
 _makecomplete() {
+  COMPREPLY=()
+
   # https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html
   local files=()
   while IFS='' read -r line; do
     files+=("$line")
   done < <(find . -maxdepth 1 -regextype posix-extended -regex '.*(GNU)?[Mm]akefile$' -printf '%f\n')
+
+  [ "${#files[@]}" -eq 0 ] && return 0
 
   # collect all targets
   local targets=()
@@ -18,11 +22,13 @@ _makecomplete() {
     done < <(grep -oE '^[a-zA-Z0-9_-]+:([^=]|$)' "$f" | cut -d':' -f1)
   done
 
-  # flatten the array for completion
-  COMPREPLY=()
+  [ "${#targets[@]}" -eq 0 ] && return 0
+
+  # use the targets for completion
   while IFS='' read -r line ; do
     COMPREPLY+=("$line")
   done < <(compgen -W "$(tr ' ' '\n' <<<"${targets[@]}" | sort -u)" -- "${COMP_WORDS[COMP_CWORD]}")
+
   return 0
 }
 

--- a/completion/available/makefile.completion.bash
+++ b/completion/available/makefile.completion.bash
@@ -1,3 +1,24 @@
-# Add completion for Makefile
-# see http://stackoverflow.com/a/38415982/1472048
-complete -W "\`grep -oE '^[a-zA-Z0-9_-]+:([^=]|$)' Makefile | sed 's/[^a-zA-Z0-9_-]*$//'\`" make
+#!/usr/bin/env bash
+# Bash completion for Makefile
+
+# Loosely adapted from http://stackoverflow.com/a/38415982/1472048
+
+_makecomplete() {
+  # https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html
+  local files=( $(find . -maxdepth 1 -regextype posix-extended -regex '.*(GNU)?[Mm]akefile$' -printf '%f ') )
+
+  # collect all targets
+  local targets=''
+  for f in ${files[@]} ; do
+    for t in $(grep -oE '^[a-zA-Z0-9_-]+:([^=]|$)' $f | cut -d':' -f1) ; do
+      targets+="$t\n"
+    done
+  done
+
+  # flatten the array for completion
+  COMPREPLY=($(compgen -W "$(echo -e "$targets" | head -c -1 | sort -u)" -- ${COMP_WORDS[COMP_CWORD]}))
+  return 0
+}
+
+complete -o nospace -F _makecomplete make
+complete -o nospace -F _makecomplete gnumake

--- a/completion/available/makefile.completion.bash
+++ b/completion/available/makefile.completion.bash
@@ -5,18 +5,24 @@
 
 _makecomplete() {
   # https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html
-  local files=( $(find . -maxdepth 1 -regextype posix-extended -regex '.*(GNU)?[Mm]akefile$' -printf '%f ') )
+  local files=()
+  while IFS='' read -r line; do
+    files+=("$line")
+  done < <(find . -maxdepth 1 -regextype posix-extended -regex '.*(GNU)?[Mm]akefile$' -printf '%f\n')
 
   # collect all targets
-  local targets=''
-  for f in ${files[@]} ; do
-    for t in $(grep -oE '^[a-zA-Z0-9_-]+:([^=]|$)' $f | cut -d':' -f1) ; do
-      targets+="$t\n"
-    done
+  local targets=()
+  for f in "${files[@]}" ; do
+    while IFS='' read -r line ; do
+      targets+=("$line")
+    done < <(grep -oE '^[a-zA-Z0-9_-]+:([^=]|$)' "$f" | cut -d':' -f1)
   done
 
   # flatten the array for completion
-  COMPREPLY=($(compgen -W "$(echo -e "$targets" | head -c -1 | sort -u)" -- ${COMP_WORDS[COMP_CWORD]}))
+  COMPREPLY=()
+  while IFS='' read -r line ; do
+    COMPREPLY+=("$line")
+  done < <(compgen -W "$(tr ' ' '\n' <<<"${targets[@]}" | sort -u)" -- "${COMP_WORDS[COMP_CWORD]}")
   return 0
 }
 

--- a/completion/available/makefile.completion.bash
+++ b/completion/available/makefile.completion.bash
@@ -1,6 +1,4 @@
-#!/usr/bin/env bash
 # Bash completion for Makefile
-
 # Loosely adapted from http://stackoverflow.com/a/38415982/1472048
 
 _makecomplete() {


### PR DESCRIPTION
This PR seeks to enhance the existing support for make completion by searching all 3 possible filenames, and supporting gnumake which is commonly found on macs.

Linted with shellcheck. Tested locally.

I'm on linux today, but will be able to test on Mac next week. If anyone beats me to it and tests on Mac sooner, feel free to post your results.

Thanks.