### PR TITLE
Add goenv plugin

### DIFF
--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -6,20 +6,18 @@ about-plugin 'Init goenv, if installed. Plays nicely with package managers'
 # NOTE: We don't export it yet, since we might still bail
 GOENV_ROOT="${GOENV_ROOT:-${HOME}/.goenv}"
 
-# Look for goenv command
-if ! _command_exists goenv ; then
-	# Add it to the path if we find it, bail otherwise
-	if [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ] ; then
-		pathmunge "${GOENV_ROOT}/bin"
-	else
-		return
-	fi
+# Look for goenv command, adding to path if needbe
+if ! _command_exists goenv && [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ] ; then
+	pathmunge "${GOENV_ROOT}/bin"
 fi
 
-# Since we didn't bail, export the value
-export GOENV_ROOT
+# If we found the command, we're good to go
+if _command_exists goenv ; then
+	# Now its safe to export the value
+	export GOENV_ROOT
 
-# Initialize goenv
-# NOTE: In the off-chance that goenv has already been initialized,
-#       it should be safe to re-initialize
-eval "$(goenv init - bash)"
+	# Initialize goenv
+	# NOTE: In the off-chance that goenv has already been initialized,
+	#       it should be safe to re-initialize
+	eval "$(goenv init - bash)"
+fi

--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -1,21 +1,23 @@
 cite about-plugin
 about-plugin 'Init goenv, if installed. Plays nicely with package managers'
 
+# Use a reasonable default to ensure variable is always present
+# NOTE: This (currently) matches goenv's built-in default
+# NOTE: We don't export it yet, since we might still bail
+GOENV_ROOT="${GOENV_ROOT:-${HOME}/.goenv}"
+
 # Look for goenv command
 if ! _command_exists goenv ; then
 	# Add it to the path if we find it, bail otherwise
 	if [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ] ; then
 		pathmunge "${GOENV_ROOT}/bin"
-	elif [ -x "${HOME}/.goenv/bin/goenv" ]; then
-		pathmunge "${HOME}/.goenv/bin"
 	else
 		return
 	fi
 fi
 
-# Use a reasonable default to ensure variable is always present
-# NOTE: This (currently) matches goenv's built-in default
-export GOENV_ROOT="${GOENV_ROOT:-${HOME}/.goenv}"
+# Since we didn't bail, export the value
+export GOENV_ROOT
 
 # Initialize goenv
 # NOTE: In the off-chance that goenv has already been initialized,

--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -1,21 +1,29 @@
 cite about-plugin
 about-plugin 'Init goenv, if installed. Plays nicely with package managers'
 
-# Try to set GOENV_ROOT if not already set
-if [ -z "${GOENV_ROOT}" ]; then
-	# Bail if cannot be set
-	if [ ! -d "$HOME/.goenv" ]; then
-		return
-	fi
-	export GOENV_ROOT="$HOME/.goenv"
+# GOENV_ROOT does not need to be configured.
+# If it is configured, it should not be overridden.
+# However, let's try to handle the case where:
+# - goenv is not already on the path
+# - GOENV_ROOT is not configured
+# - User has installed goenv in ~/.goenv
+# In this case, we'll do the user a solid and configure
+# the goenv they've taken the time to install.
+if ! _command_exists goenv && [ -z "${GOENV_ROOT}" ] && [ -x "${HOME}/.goenv/bin/goenv" ]; then
+	export GOENV_ROOT="${HOME}/.goenv"
 fi
 
-# Add GOENV_ROOT/bin to path if goenv not already on path
-if ! _command_exists goenv && [ -x "${GOENV_ROOT}/bin/goenv" ]; then
-	pathmunge "$GOENV_ROOT/bin"
+# Add GOENV_ROOT/bin to path if:
+# - goenv not already on path
+# - GOENV_ROOT is configured
+# - User has installed goenv in GOENV_ROOT
+if ! _command_exists goenv && [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ]; then
+	pathmunge "${GOENV_ROOT}/bin"
 fi
 
-# Initialize goenv - Play nicely if goenv not on path
+# Initialize goenv - Play nicely if goenv never made it to the path
+# NOTE: In the off-chance that goenv has already been initialized,
+#       it should be safe to re-initialize
 if _command_exists goenv ; then
 	eval "$(goenv init - bash)"
 fi

--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -1,0 +1,21 @@
+cite about-plugin
+about-plugin 'Init goenv, if installed. Plays nicely with package managers'
+
+# Try to set GOENV_ROOT if not already set
+if [ -z "${GOENV_ROOT}" ]; then
+	# Bail if cannot be set
+	if [ ! -d "$HOME/.goenv" ]; then
+		return
+	fi
+	export GOENV_ROOT="$HOME/.goenv"
+fi
+
+# Add GOENV_ROOT/bin to path if goenv not already on path
+if ! _command_exists goenv && [ -x "${GOENV_ROOT}/bin/goenv" ]; then
+	pathmunge "$GOENV_ROOT/bin"
+fi
+
+# Initialize goenv - Play nicely if goenv not on path
+if _command_exists goenv ; then
+	eval "$(goenv init - bash)"
+fi

--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -6,12 +6,12 @@ about-plugin 'Init goenv, if installed. Plays nicely with package managers'
 # NOTE: We don't export it yet, since we might still bail
 GOENV_ROOT="${GOENV_ROOT:-${HOME}/.goenv}"
 
-# Look for goenv command, adding to path if needbe
-if ! _command_exists goenv && [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ] ; then
+# If goenv not on path, but in GOENV_ROOT, then add to path
+if ! _command_exists goenv && [ -x "${GOENV_ROOT}/bin/goenv" ] ; then
 	pathmunge "${GOENV_ROOT}/bin"
 fi
 
-# If we found the command, we're good to go
+# If goenv on path, we're good to go
 if _command_exists goenv ; then
 	# Now its safe to export the value
 	export GOENV_ROOT

--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -1,29 +1,23 @@
 cite about-plugin
 about-plugin 'Init goenv, if installed. Plays nicely with package managers'
 
-# GOENV_ROOT does not need to be configured.
-# If it is configured, it should not be overridden.
-# However, let's try to handle the case where:
-# - goenv is not already on the path
-# - GOENV_ROOT is not configured
-# - User has installed goenv in ~/.goenv
-# In this case, we'll do the user a solid and configure
-# the goenv they've taken the time to install.
-if ! _command_exists goenv && [ -z "${GOENV_ROOT}" ] && [ -x "${HOME}/.goenv/bin/goenv" ]; then
-	export GOENV_ROOT="${HOME}/.goenv"
+# Look for goenv command
+if ! _command_exists goenv ; then
+	# Add it to the path if we find it, bail otherwise
+	if [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ] ; then
+		pathmunge "${GOENV_ROOT}/bin"
+	elif [ -x "${HOME}/.goenv/bin/goenv" ]; then
+		pathmunge "${HOME}/.goenv/bin"
+	else
+		return
+	fi
 fi
 
-# Add GOENV_ROOT/bin to path if:
-# - goenv not already on path
-# - GOENV_ROOT is configured
-# - User has installed goenv in GOENV_ROOT
-if ! _command_exists goenv && [ -n "${GOENV_ROOT}" ] && [ -x "${GOENV_ROOT}/bin/goenv" ]; then
-	pathmunge "${GOENV_ROOT}/bin"
-fi
+# Use a reasonable default to ensure variable is always present
+# NOTE: This (currently) matches goenv's built-in default
+export GOENV_ROOT="${GOENV_ROOT:-${HOME}/.goenv}"
 
-# Initialize goenv - Play nicely if goenv never made it to the path
+# Initialize goenv
 # NOTE: In the off-chance that goenv has already been initialized,
 #       it should be safe to re-initialize
-if _command_exists goenv ; then
-	eval "$(goenv init - bash)"
-fi
+eval "$(goenv init - bash)"


### PR DESCRIPTION
This PR is a continuation of #1510, which was closed.

In reviewing the goenv project page as part of testing this, I realized that there are several other projects that implement a `goenv` feature.  

I was thinking we might want to qualify this plugin name with the author's name (i.e. goenv-syndbg) but looking into it further it appears that the implementations I googled have been unmaintained for a while now and this one appears to be actively maintained.  Additionally, this is the one that has the [`goenv` Brew package](https://formulae.brew.sh/formula/goenv).  

So I'm okay leaving the plugin name unqualified for now, but happy to rename if it we think that's useful.

Additionally, we may want to mention something in the plugin description about exactly which goenv implementation we're supporting.  Open to ideas of what that might look like.

Tested locally

-DF

---

cc: @nwinkler, @cornfeedhobo, @syndbg 
