### PR TITLE
Add cht.sh plugin

### DIFF
--- a/plugins/available/cht-sh.plugin.bash
+++ b/plugins/available/cht-sh.plugin.bash
@@ -4,6 +4,17 @@ about-plugin 'Simplify `curl cht.sh/<query>` to `cht.sh <query>`'
 # Play nicely if user already installed cht.sh cli tool
 if ! _command_exists cht.sh ; then
 	function cht.sh () {
-		curl "cht.sh/$1"
+		about 'Executes a cht.sh curl query using the provided arguments'
+		param ' [ ( topic [sub-topic] ) | ~keyword ] [ :list | :help | :learn ]'
+		example '$ cht.sh :help'
+		example '$ cht.sh :list'
+		example '$ cht.sh tar'
+		example '$ cht.sh js "parse json"'
+		example '$ cht.sh python :learn'
+		example '$ cht.sh rust :list'
+		group 'cht-sh'
+
+		local query=$(IFS=/ ; echo "$*")
+		curl "cht.sh/${query}"
 	}
 fi

--- a/plugins/available/cht-sh.plugin.bash
+++ b/plugins/available/cht-sh.plugin.bash
@@ -1,0 +1,9 @@
+cite about-plugin
+about-plugin 'Simplify `curl cht.sh/<query>` to `cht.sh <query>`'
+
+# Play nicely if user already installed cht.sh cli tool
+if ! _command_exists cht.sh ; then
+	function cht.sh () {
+		curl "cht.sh/$1"
+	}
+fi

--- a/plugins/available/cht-sh.plugin.bash
+++ b/plugins/available/cht-sh.plugin.bash
@@ -14,6 +14,7 @@ if ! _command_exists cht.sh ; then
 		example '$ cht.sh rust :list'
 		group 'cht-sh'
 
+		# Separate arguments with '/', preserving spaces within them
 		local query=$(IFS=/ ; echo "$*")
 		curl "cht.sh/${query}"
 	}


### PR DESCRIPTION
This PR is a continuation of #1484 which tried to add support as an alias, which wasn't the right fit.

Instead, we add support as a function, `cht.sh`.

We purposely name the function to match the project's [supported cli tool](https://github.com/chubin/cheat.sh#command-line-client-chtsh).

The plugin does nothing if the user has already installed the cli tool.

Tested locally (`GNU bash, version 5.0.2(1)-release (x86_64-apple-darwin18.2.0)`)

-DF
PS: TIL that both alias and function names can have dots in them !

---

cc: @nwinkler , @jrjang, @chubin 