### PR TITLE
Use new line character instead semicolon in the preexec hook

### DIFF
--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -123,7 +123,7 @@ function preexec_install () {
 
     # Finally, install the actual traps.
     if [[ ! -z "${PROMPT_COMMAND// }" ]]; then
-      PROMPT_COMMAND="${PROMPT_COMMAND};preexec_invoke_cmd"
+      PROMPT_COMMAND="${PROMPT_COMMAND}"$'\n'"preexec_invoke_cmd"
     else
       PROMPT_COMMAND="preexec_invoke_cmd"
     fi


### PR DESCRIPTION
The semicolon cause some issues in some cases, mainly, when there're several apps modifiying the `PROMPT_COMMAND` variable.

This change is motivated by this [issue](https://github.com/starship/starship/issues/842) in the [Starship](https://github.com/starship/starship) project.