### PR TITLE
Aliases/git/git switch

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -87,6 +87,11 @@ alias gstb="git stash branch"
 alias gstd="git stash drop"
 alias gstl="git stash list"
 alias gstp="git stash pop"
+# Switch aliases - Requires git v2.23+
+alias gsw="git switch"
+alias gswm="git switch master"
+alias gswc="git switch -c"
+alias gswt="git switch -t"
 alias gh='cd "$(git rev-parse --show-toplevel)"'
 # Show untracked files
 alias gu='git ls-files . --exclude-standard --others'

--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -90,8 +90,8 @@ alias gstp="git stash pop"
 # Switch aliases - Requires git v2.23+
 alias gsw="git switch"
 alias gswm="git switch master"
-alias gswc="git switch -c"
-alias gswt="git switch -t"
+alias gswc="git switch --create"
+alias gswt="git switch --track"
 alias gh='cd "$(git rev-parse --show-toplevel)"'
 # Show untracked files
 alias gu='git ls-files . --exclude-standard --others'


### PR DESCRIPTION
Adds the following aliases for `git switch`:
```
alias gsw="git switch"
alias gswm="git switch master"
alias gswc="git switch --create"
alias gswt="git switch --track"
```

You can review the [Online Manual Page](https://git-scm.com/docs/git-switch) for more details.

I tried to get parity with existing aliases on the related `git checkout` and `git branch` commands:

_related git checkout aliases_
```
alias gco='git checkout'
alias gcom='git checkout master'
alias gcb='git checkout -b'
alias gcob='git checkout -b'
alias gct='git checkout --track'
```

_related git branch aliases_
```
alias gb='git branch'
alias gbt='git branch --track'
```

The remaining branch aliases don't have switch equivalents, specifically:

_unrelated git branch aliases_
```
alias gba='git branch -a'
alias gbm='git branch -m'
alias gbd='git branch -d'
alias gbD='git branch -D'
```

## No Completion Support

I noticed in my local that `git switch` in general doesn't appear to currently be supported by the bash-it git completions.

I have looked at it yet, and not sure if we want to consider a block for this issue/pr or perhaps just create a new issue to track it?

-DF

Fixes #1525 

---

cc: @finn-matti 

[edit] Add comment re: completions