### PR TITLE
Fix goenv plugin

### DIFF
--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -3,8 +3,10 @@ about-plugin 'load goenv, if you are using it'
 
 # Don't modify the environment if we can't find the tool:
 # - Check if in $PATH already
+# - Check if installed manually to $GOENV_ROOT
 # - Check if installed manually to $HOME
 _command_exists goenv ||
+  [[ -n "$GOENV_ROOT" && -x "$GOENV_ROOT/bin/goenv" ]] ||
   [[ -x "$HOME/.goenv/bin/goenv" ]] ||
   return
 
@@ -12,7 +14,7 @@ _command_exists goenv ||
 export GOENV_ROOT="${GOENV_ROOT:-$HOME/.goenv}"
 
 # Add GOENV_ROOT/bin to PATH, if that's where it's installed
-[[ -x "$HOME/.goenv/bin/goenv" ]] && pathmunge "$GOENV_ROOT/bin"
+! _command_exists goenv && [[ -x "$GOENV_ROOT/bin/goenv" ]] && pathmunge "$GOENV_ROOT/bin"
 
 # Initialize goenv
 eval "$(goenv init - bash)"


### PR DESCRIPTION
The original version suffers from a few bugs:

* If the user defined `$GOENV_ROOT`, **but** defined it outside of `$HOME/.goenv`, then the script would exit without finding it.
* For path-munging, the script checked for the tool in `$HOME/.goenv` instead of `$GOENV_ROOT` - This would cause the tool to **not** end up on the path if the `$GOENV_ROOT` was defined outside of `$HOME`
* The script would path-munge `$GOENV_ROOT/bin` even if the binary was already on the path (say by using homebrew), causing it now to appear on the path twice, with the `$GOENV_ROOT` version overriding the homebrew version.
