### PR TITLE
bash_it.sh: Require interactive shell

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # Initialize Bash It
 
+# If not running interactively, don't do anything
+case $- in
+  *i*) ;;
+    *) return;;
+esac
+
 # Only set $BASH_IT if it's not already set
 if [ -z "$BASH_IT" ];
 then


### PR DESCRIPTION
Previously, a fix was added for bad behavior when `bash-it` printed text
to the console in conjunction with protocols like `SCP`, as commit
83c44fac "template/profile: Require interactive shell".

It did work for those users who replace their original `~/.bash_profile`
file with the one provided by `bash-it`, but not for those who merely
append a `bash-it` call to their existing `~/.bash_profile` file.

Fix the behavior for the latter case, too.

This serves as a preparation for #1501 