### PR TITLE
Simplified-sudo-check

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -18,9 +18,7 @@ function __powerline_user_info_prompt {
   local color=${USER_INFO_THEME_PROMPT_COLOR}
 
   if [[ "${THEME_CHECK_SUDO}" = true ]]; then
-    if sudo -n uptime 2>&1 | grep -q "load"; then
-      color=${USER_INFO_THEME_PROMPT_COLOR_SUDO}
-    fi
+    sudo -vn 1>/dev/null 2>&1 && color=${USER_INFO_THEME_PROMPT_COLOR_SUDO}
   fi
 
   case "${POWERLINE_PROMPT_USER_INFO_MODE}" in


### PR DESCRIPTION
Small change to the powerline theme.

Instead of calling uptime utilize the buildt-in sudo validate. This is just a small change but it should speed up the checks, especially when you have a valid sudo session.

If this is not something you guys would like just close the pull request.

Regards

```
$ time for _ in {1..1000}; do sudo uptime | grep "load" >/dev/null; done
real	0m8.246s
user	0m5.691s
sys	0m4.682s

$ time for _ in {1..1000}; do sudo -vn; done
real	0m4.083s
user	0m2.574s
sys	0m1.579s

$ sudo -k
$ time for _ in {1..1000}; do sudo -vn 2>/dev/null; done
real	0m4.138s
user	0m2.407s
sys	0m1.806s

$ time for _ in {1..1000}; do sudo -n uptime 2>/dev/null | grep "load" >/dev/null; done
real	0m5.855s
user	0m4.617s
sys	0m3.271s
```


```
$ bash --version
GNU bash, version 5.0.16(1)-release (x86_64-pc-linux-gnu)

$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu Focal Fossa (development branch)
Release:	20.04
Codename:	focal
```