### PR TITLE
Theme barbuk: Add ssh detection and user@host information in ssh session

### DIFF
--- a/themes/barbuk/README.md
+++ b/themes/barbuk/README.md
@@ -38,7 +38,19 @@ SCM_GIT_CHAR_GITHUB='•'
 source "$BASH_IT"/bash_it.sh
 ```
 
-## SSH prompt and sudoers
+## SSH prompt
+
+### Usage
+
+When using a ssh session, the theme will display `user@fqdn`.
+You can disable this information before sourcing bsah-it:
+
+```bash
+export BARBUK_SSH_INFO=false
+source "$BASH_IT"/bash_it.sh
+```
+
+### Keep theme with sudoer
 
 If you want the theme to persist using `sudo -s` in a ssh session, you need to configure sudo to keep the `HOME` and `SSH_CONNECTION` environment variables.
 

--- a/themes/barbuk/README.md
+++ b/themes/barbuk/README.md
@@ -43,16 +43,16 @@ source "$BASH_IT"/bash_it.sh
 ### Usage
 
 When using a ssh session, the theme will display `user@hostname`.
-You can disable this information with `BARBUK_SSH_INFO`.
+You can disable this information with `BASH_IT_THEME_BARBUK_SSH_INFO`.
 
 The hostname is displayed in the FQDN format by default. You
-can use the short hostname format with `BARBUK_HOST_INFO`.
+can use the short hostname format with `BASH_IT_THEME_BARBUK_HOST_INFO`.
 
 ```bash
 # short or long
-export BARBUK_HOST_INFO=short
+export BASH_IT_THEME_BARBUK_HOST_INFO=short
 # true or false
-export BARBUK_SSH_INFO=false
+export BASH_IT_THEME_BARBUK_SSH_INFO=false
 source "$BASH_IT"/bash_it.sh
 ```
 

--- a/themes/barbuk/README.md
+++ b/themes/barbuk/README.md
@@ -8,6 +8,7 @@ A minimal theme with a clean git prompt
 * Current path (red when user is root)
 * Current git info
 * Last command exit code (only shown when the exit code is greater than 0)
+* user@host for ssh connection
 
 ## Fonts and glyphs
 
@@ -37,6 +38,26 @@ SCM_GIT_CHAR_GITHUB='•'
 source "$BASH_IT"/bash_it.sh
 ```
 
+## SSH prompt and sudoers
+
+If you want the theme to persist using `sudo -s` in a ssh session, you need to configure sudo to keep the `HOME` and `SSH_CONNECTION` environment variables.
+
+`HOME` contains the path to the home directory of the current user. Keeping it will allow to use your user dotfiles when elevating privileges.
+
+Keeping `SSH_CONNECTION` env is necessary for ssh detection in the theme.
+
+Please refer to the following documentation for more information:
+ -  [sudo manual](https://www.sudo.ws/man/1.8.13/sudoers.man.html) for `env_keep` configuration
+ -  [openssh manual](https://linux.die.net/man/1/ssh) for information about `SSH_CONNECTION` environment
+
+```bash
+cat << EOF > /etc/sudoers.d/keepenv
+Defaults env_keep += HOME
+Defaults env_keep += SSH_CONNECTION
+EOF
+chmod 400 /etc/sudoers.d/keepenv
+```
+
 ## Examples
 
 ### Clean
@@ -49,5 +70,10 @@ source "$BASH_IT"/bash_it.sh
 
 ```bash
    ~/.dotfiles on  master ⤏  origin ↑2 •7 ✗ ❯
- ```
+```
 
+### Ssh
+
+```bash
+user@fqdn in  ~/bash-it on  master ✓ ❯
+```

--- a/themes/barbuk/README.md
+++ b/themes/barbuk/README.md
@@ -45,7 +45,7 @@ source "$BASH_IT"/bash_it.sh
 When using a ssh session, the theme will display `user@hostname`.
 You can disable this information with `BARBUK_SSH_INFO`.
 
-The hostname is display in the FQDN format by default. You
+The hostname is displayed in the FQDN format by default. You
 can use the short hostname format with `BARBUK_HOST_INFO`.
 
 ```bash

--- a/themes/barbuk/README.md
+++ b/themes/barbuk/README.md
@@ -42,10 +42,16 @@ source "$BASH_IT"/bash_it.sh
 
 ### Usage
 
-When using a ssh session, the theme will display `user@fqdn`.
-You can disable this information before sourcing bsah-it:
+When using a ssh session, the theme will display `user@hostname`.
+You can disable this information with `BARBUK_SSH_INFO`.
+
+The hostname is display in the FQDN format by default. You
+can use the short hostname format with `BARBUK_HOST_INFO`.
 
 ```bash
+# short or long
+export BARBUK_HOST_INFO=short
+# true or false
 export BARBUK_SSH_INFO=false
 source "$BASH_IT"/bash_it.sh
 ```
@@ -87,5 +93,5 @@ chmod 400 /etc/sudoers.d/keepenv
 ### Ssh
 
 ```bash
-user@fqdn in  ~/bash-it on  master ✓ ❯
+user@hostname in  ~/bash-it on  master ✓ ❯
 ```

--- a/themes/barbuk/README.md
+++ b/themes/barbuk/README.md
@@ -8,7 +8,7 @@ A minimal theme with a clean git prompt
 * Current path (red when user is root)
 * Current git info
 * Last command exit code (only shown when the exit code is greater than 0)
-* user@host for ssh connection
+* user@hostname for ssh connection
 
 ## Fonts and glyphs
 

--- a/themes/barbuk/barbuk.theme.bash
+++ b/themes/barbuk/barbuk.theme.bash
@@ -31,7 +31,7 @@ SCM_THEME_CURRENT_USER_PREFFIX='  '
 SCM_GIT_SHOW_CURRENT_USER=false
 
 function _git-uptream-remote-logo {
-    [[ "$(_git-upstream)" == "" ]] && return
+    [[ "$(_git-upstream)" == "" ]] && SCM_GIT_CHAR="$SCM_GIT_CHAR_DEFAULT"
 
     local remote remote_domain
     remote=$(_git-upstream-remote)
@@ -62,7 +62,7 @@ function _exit-code {
 }
 
 function _prompt {
-    local exit_code="$?" wrap_char=' ' dir_color=$green
+    local exit_code="$?" wrap_char=' ' dir_color=$green ssh_info=''
 
     _exit-code exit_code
     _git-uptream-remote-logo
@@ -74,7 +74,12 @@ function _prompt {
         dir_color=$red
     fi
 
-    PS1="\\n ${purple}$(scm_char)${dir_color}\\w${normal}$(scm_prompt_info)${exit_code}"
+    # Detect ssh
+    if [[ -n "${SSH_CLIENT}" ]] || [[ -n "${SSH_CONNECTION}" ]]; then
+        ssh_info="${bold_blue}\u${bold_orange}@${cyan}\H ${bold_orange}in"
+    fi
+
+    PS1="\\n${ssh_info} ${purple}$(scm_char)${dir_color}\\w${normal}$(scm_prompt_info)${exit_code}"
 
     [[ ${#PS1} -gt $((COLUMNS*3)) ]] && wrap_char="\\n"
     PS1="${PS1}${wrap_char}❯${normal} "

--- a/themes/barbuk/barbuk.theme.bash
+++ b/themes/barbuk/barbuk.theme.bash
@@ -9,6 +9,9 @@ SCM_GIT_CHAR_DEFAULT=${SCM_GIT_CHAR_DEFAULT:='  '}
 SCM_GIT_CHAR_ICON_BRANCH=${SCM_GIT_CHAR_ICON_BRANCH:=''}
 EXIT_CODE_ICON=${EXIT_CODE_ICON:=' '}
 
+# Ssh user and fqdn display
+SSH_INFO=${BARBUK_SSH_INFO:=true}
+
 # Bash-it default glyphs customization
 SCM_HG_CHAR='☿ '
 SCM_SVN_CHAR='⑆ '
@@ -75,7 +78,7 @@ function _prompt {
     fi
 
     # Detect ssh
-    if [[ -n "${SSH_CLIENT}" ]] || [[ -n "${SSH_CONNECTION}" ]]; then
+    if [[ -n "${SSH_CONNECTION}" ]] && [ "$SSH_INFO" = true ]; then
         ssh_info="${bold_blue}\u${bold_orange}@${cyan}\H ${bold_orange}in"
     fi
 

--- a/themes/barbuk/barbuk.theme.bash
+++ b/themes/barbuk/barbuk.theme.bash
@@ -10,8 +10,8 @@ SCM_GIT_CHAR_ICON_BRANCH=${SCM_GIT_CHAR_ICON_BRANCH:=''}
 EXIT_CODE_ICON=${EXIT_CODE_ICON:=' '}
 
 # Ssh user and hostname display
-SSH_INFO=${BARBUK_SSH_INFO:=true}
-HOST_INFO=${BARBUK_HOST_INFO:=long}
+SSH_INFO=${BASH_IT_THEME_BARBUK_SSH_INFO:=true}
+HOST_INFO=${BASH_IT_THEME_BARBUK_HOST_INFO:=long}
 
 # Bash-it default glyphs customization
 SCM_HG_CHAR='☿ '

--- a/themes/barbuk/barbuk.theme.bash
+++ b/themes/barbuk/barbuk.theme.bash
@@ -9,7 +9,7 @@ SCM_GIT_CHAR_DEFAULT=${SCM_GIT_CHAR_DEFAULT:='  '}
 SCM_GIT_CHAR_ICON_BRANCH=${SCM_GIT_CHAR_ICON_BRANCH:=''}
 EXIT_CODE_ICON=${EXIT_CODE_ICON:=' '}
 
-# Ssh user and fqdn display
+# Ssh user and hostname display
 SSH_INFO=${BARBUK_SSH_INFO:=true}
 HOST_INFO=${BARBUK_HOST_INFO:=long}
 

--- a/themes/barbuk/barbuk.theme.bash
+++ b/themes/barbuk/barbuk.theme.bash
@@ -11,6 +11,7 @@ EXIT_CODE_ICON=${EXIT_CODE_ICON:=' '}
 
 # Ssh user and fqdn display
 SSH_INFO=${BARBUK_SSH_INFO:=true}
+HOST_INFO=${BARBUK_HOST_INFO:=long}
 
 # Bash-it default glyphs customization
 SCM_HG_CHAR='☿ '
@@ -65,7 +66,7 @@ function _exit-code {
 }
 
 function _prompt {
-    local exit_code="$?" wrap_char=' ' dir_color=$green ssh_info=''
+    local exit_code="$?" wrap_char=' ' dir_color=$green ssh_info='' host
 
     _exit-code exit_code
     _git-uptream-remote-logo
@@ -79,7 +80,12 @@ function _prompt {
 
     # Detect ssh
     if [[ -n "${SSH_CONNECTION}" ]] && [ "$SSH_INFO" = true ]; then
-        ssh_info="${bold_blue}\u${bold_orange}@${cyan}\H ${bold_orange}in"
+        if [ "$HOST_INFO" = long ]; then
+            host="\H"
+        else
+            host="\h"
+        fi
+        ssh_info="${bold_blue}\u${bold_orange}@${cyan}$host ${bold_orange}in"
     fi
 
     PS1="\\n${ssh_info} ${purple}$(scm_char)${dir_color}\\w${normal}$(scm_prompt_info)${exit_code}"


### PR DESCRIPTION
Using an ssh session, this theme will now detect and display the user and fqdn to provide clear information about the remote host.

The theme keep the same format but prefix the prompt with `user@hostname`.

Documentation has been updated:
 - configuration usage to enable / disable ssh info
 - configuration usage to use short or long hostname
 - how to configure sudoer to keep the theme when using `sudo -s`.

A script like https://github.com/BarbUk/dotfiles#ssh-connect can be used to synchronise user dotfiles on remote host.

![image](https://user-images.githubusercontent.com/64371/78009888-bdf9d200-7352-11ea-8160-7a4529966d82.png)
