### PR TITLE
Run `myip` test

### DIFF
--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -16,10 +16,6 @@ load ../../plugins/available/base.plugin
 }
 
 @test 'plugins base: myip()' {
-  if [[ ! $SLOW_TESTS ]]; then
-    skip 'myip is slow - run only with SLOW_TESTS=true'
-  fi
-
   run myip
   assert_success
   declare -r mask_ip=$(echo $output | tr -s '[0-9]' '?')


### PR DESCRIPTION
Test of `myip` was skipped, allegedly for it being slow. It's fast for
me (60 ms), so enable it unconditionally.