### PR TITLE
test/plugins/base: Adjust `myip` expected output

### DIFF
--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -23,7 +23,7 @@ load ../../plugins/available/base.plugin
   run myip
   assert_success
   declare -r mask_ip=$(echo $output | tr -s '[0-9]' '?')
-  [[ $mask_ip == 'Your public IP is: ?.?.?.?' ]]
+  [[ "$mask_ip" == "Your public IP is: ${bold_green}?.?.?.?${normal}" ]]
 }
 
 @test 'plugins base: pickfrom()' {


### PR DESCRIPTION
The `myip()` function outputs colored text while the test doesn't expect
this and fails when run.

Also, strings with blanks were compared while quotes around one of them
was missing, so the test was bogus anyway. Fix this, too.

The test wasn't run in CI builds until now, apparently.