### PR TITLE
plugins/base: Detect HTTP errors in `myip()`

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -32,7 +32,7 @@ function myip ()
     list=("http://myip.dnsomatic.com/" "http://checkip.dyndns.com/" "http://checkip.dyndns.org/")
     for url in ${list[*]}
     do
-        res=$(curl -s "${url}")
+        res=$(curl -fs "${url}")
         if [ $? -eq 0 ];then
             break;
         fi


### PR DESCRIPTION
Out of the box, `curl` reports success (via exit code) even if the
server returns an error, e.g. _429 Too Many Requests_ which was
sometimes the case with `http://myip.dnsomatic.com`. So, errors went
undetected.

There is the `--fail` switch which enables us to use the exit code the
way we need:

> -f, --fail
>        (HTTP) Fail  silently  (no  output  at  all)  on  server
>        errors. This is mostly done to better enable scripts etc
>        to better deal with failed  attempts.  In  normal  cases
>        when  an  HTTP  server  fails  to deliver a document, it
>        returns an HTML document stating so  (which  often  also
>        describes  why  and  more).  This flag will prevent curl
>        from outputting that and return error 22.

Use it to make the `myip()` deliver results reliably.