### PR TITLE
test/plugins/go: Skip tests in absence of `go`

### DIFF
--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,12 +5,14 @@ load ../../lib/helpers
 load ../../lib/composure
 
 @test 'ensure _go_pathmunge_wrap is defined' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   load ../../plugins/available/go.plugin
   run type -t _go_pathmunge_wrap
   assert_line 'function'
 }
 
 @test 'plugins go: single entry in GOPATH' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   export GOPATH="/foo"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -18,6 +20,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   export GOPATH="/foo bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -25,6 +28,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: single entry in GOPATH, with escaped space' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   export GOPATH="/foo\ bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -32,6 +36,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: multiple entries in GOPATH' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   export GOPATH="/foo:/bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -39,6 +44,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: multiple entries in GOPATH, with space' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   export GOPATH="/foo:/foo bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -46,6 +52,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: multiple entries in GOPATH, with escaped space' {
+  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
   export GOPATH="/foo:/foo\ bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin


### PR DESCRIPTION
In case `go` is not installed, tests of the according plugin fail. It's
better to just skip them since `golang` isn't commonly installed on
`bash-it` developers' machines.

In CI environment, no tests should be skipped, so run them anyway.