### PR TITLE
fix: uuid behavior for linux

### DIFF
--- a/aliases/available/kubectl.aliases.bash
+++ b/aliases/available/kubectl.aliases.bash
@@ -18,7 +18,7 @@ function _set_pkg_aliases()
     alias kcdn='kubectl describe node'
     alias kcgpan='kubectl get pods --all-namespaces'
     alias kcgdan='kubectl get deployments --all-namespaces'
-    alias kcnetshoot='kubectl run --generator=run-pod/v1 netshoot-$(uuidgen | tr A-Z a-z | sed 's/-//g') --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
+    alias kcnetshoot='kubectl run --generator=run-pod/v1 netshoot-$(date +%s) --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
 	fi
 }
 

--- a/aliases/available/kubectl.aliases.bash
+++ b/aliases/available/kubectl.aliases.bash
@@ -5,12 +5,11 @@
 cite 'about-alias'
 about-alias 'kubectl aliases'
 
-# set apt aliases
 function _set_pkg_aliases()
 {
-	if [ -x $(which kubectl) ]; then
-		alias kc='kubectl'
-		alias kcgp='kubectl get pods'
+  if _command_exists kubectl; then
+    alias kc='kubectl'
+    alias kcgp='kubectl get pods'
     alias kcgd='kubectl get deployments'
     alias kcgn='kubectl get nodes'
     alias kcdp='kubectl describe pod'
@@ -18,8 +17,9 @@ function _set_pkg_aliases()
     alias kcdn='kubectl describe node'
     alias kcgpan='kubectl get pods --all-namespaces'
     alias kcgdan='kubectl get deployments --all-namespaces'
+    # launches a disposable netshoot pod in the k8s cluster
     alias kcnetshoot='kubectl run --generator=run-pod/v1 netshoot-$(date +%s) --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
-	fi
+  fi
 }
 
 _set_pkg_aliases

--- a/aliases/available/uuidgen.aliases.bash
+++ b/aliases/available/uuidgen.aliases.bash
@@ -1,6 +1,11 @@
-cite 'uuid-alias'
-about-alias 'uuidgen aliases'
+# cite 'uuid-alias'
+# about-alias 'uuidgen aliases'
 
-alias uuidu="uuidgen"
-alias uuidl="uuidgen | tr '[:upper:]' '[:lower:]'"
-alias uuid=uuidl # because upper case is like YELLING
+if [ "$(uuid 2>/dev/null)" != "" ]; then # Linux
+  alias uuidu="uuid | tr '[:lower:]' '[:upper:]'"
+  alias uuidl=uuid
+elif [ "$(uuidgen 2>/dev/null)" != "" ]; then # macOS/BSD
+  alias uuidu="uuidgen"
+  alias uuid="uuidgen | tr '[:upper:]' '[:lower:]'" # because upper case is like YELLING
+  alias uuidl=uuid
+fi

--- a/aliases/available/uuidgen.aliases.bash
+++ b/aliases/available/uuidgen.aliases.bash
@@ -1,10 +1,10 @@
-# cite 'uuid-alias'
-# about-alias 'uuidgen aliases'
+cite 'uuid-alias'
+about-alias 'uuidgen aliases'
 
-if [ "$(uuid 2>/dev/null)" != "" ]; then # Linux
+if _command_exists uuid; then # Linux
   alias uuidu="uuid | tr '[:lower:]' '[:upper:]'"
   alias uuidl=uuid
-elif [ "$(uuidgen 2>/dev/null)" != "" ]; then # macOS/BSD
+elif _command_exists uuidgen; then # macOS/BSD
   alias uuidu="uuidgen"
   alias uuid="uuidgen | tr '[:upper:]' '[:lower:]'" # because upper case is like YELLING
   alias uuidl=uuid


### PR DESCRIPTION
My bad.  macOS uses `uuidgen` and produces upper case by default.  Linux uses `uuid` (if installed) and produces lower case by default.

This fixes it for `uuidgen.bash` & `kubectl.bash`.
