### PR TITLE
Separate bashit alias from general

### DIFF
--- a/aliases/available/bash_it.aliases.bash
+++ b/aliases/available/bash_it.aliases.bash
@@ -1,5 +1,5 @@
 cite about-alias
-about-alias 'bashit aliases'
+about-alias 'Bash-it aliases'
 
 # Common misspellings of bash-it
 alias shit='bash-it'

--- a/aliases/available/bashit.aliases.bash
+++ b/aliases/available/bashit.aliases.bash
@@ -1,0 +1,24 @@
+cite about-alias
+about-alias 'bashit aliases'
+
+# Common misspellings of bash-it
+alias shit='bash-it'
+alias batshit='bash-it'
+alias bashit='bash-it'
+alias batbsh='bash-it'
+alias babsh='bash-it'
+alias bash_it='bash-it'
+alias bash_ti='bash-it'
+
+# Additional bash-it aliases for help/show
+alias bshsa='bash-it show aliases'
+alias bshsc='bash-it show completions'
+alias bshsp='bash-it show plugins'
+alias bshha='bash-it help aliases'
+alias bshhc='bash-it help completions'
+alias bshhp='bash-it help plugins'
+alias bshsch="bash-it search"
+alias bshenp="bash-it enable plugin"
+alias bshena="bash-it enable alias"
+alias bshenc="bash-it enable completion"
+

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -75,27 +75,6 @@ fi
 alias md='mkdir -p'
 alias rd='rmdir'
 
-# Common misspellings of bash-it
-alias shit='bash-it'
-alias batshit='bash-it'
-alias bashit='bash-it'
-alias batbsh='bash-it'
-alias babsh='bash-it'
-alias bash_it='bash-it'
-alias bash_ti='bash-it'
-
-# Additional bash-it aliases for help/show
-alias bshsa='bash-it show aliases'
-alias bshsc='bash-it show completions'
-alias bshsp='bash-it show plugins'
-alias bshha='bash-it help aliases'
-alias bshhc='bash-it help completions'
-alias bshhp='bash-it help plugins'
-alias bshsch="bash-it search"
-alias bshenp="bash-it enable plugin"
-alias bshena="bash-it enable alias"
-alias bshenc="bash-it enable completion"
-
 # Shorten extract
 alias xt="extract"
 

--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -92,3 +92,5 @@ catt() {
     fi
   done
 }
+
+source "$BASH_IT/aliases/available/bash-it.aliases.bash"


### PR DESCRIPTION
I think that the **general** aliases are not the same for every user: if someone does not want some **general** alias, but still needs the _bash_it_ command, is then forced to remove it manually. With these changes bash_it aliases gets separated from the general ones, so that the user can choose what to use.