### PR TITLE
editorconfig: Add `.git*` section

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[.git*]
+indent_style = tab


### PR DESCRIPTION
Configuration files of `git` are managed by the tool and thus are
tab-indented. If a developer happens to edit such a file manually, the
indentation would become inconsistent.

Add an explicit section for such files and set the indentation to tabs.