### PR TITLE
added tar extract-directory creation and usage

### DIFF
--- a/plugins/available/extract.plugin.bash
+++ b/plugins/available/extract.plugin.bash
@@ -5,7 +5,7 @@ about-plugin 'one command to extract them all...'
 extract() {
     local opt
     local OPTIND=1
-    while getopts "hv" opt; do
+    while getopts "hdv" opt; do
         case "$opt" in
             h)
                 cat <<End-Of-Usage
@@ -29,12 +29,28 @@ End-Of-Usage
 
     [ $# -eq 0 ] && extract -h && return 1
     while [ $# -gt 0 ]; do
-	    if [ -f "$1" ]; then
-		    case "$1" in
-                *.tar.bz2|*.tbz|*.tbz2) tar "x${verbose}jf" "$1" ;;
-                *.tar.gz|*.tgz) tar "x${verbose}zf" "$1" ;;
-                *.tar.xz) xz --decompress "$1"; set -- "$@" "${1:0:-3}" ;;
-                *.tar.Z) uncompress "$1"; set -- "$@" "${1:0:-2}" ;;
+        if [[ ! -f "$1" ]]; then
+            echo "extract: '$1' is not a valid file" >&2
+            shift
+            continue
+        fi
+
+        local -r filename=$(basename -- $1)
+        local -r filedirname=$(dirname -- $1)
+        local targetdirname=$(sed 's/\(\.tar\.bz2$\|\.tbz$\|\.tbz2$\|\.tar\.gz$\|\.tgz$\|\.tar$\|\.tar\.xz$\|\.txz$\|\.tar\.Z$\|\.7z$\)//g' <<< $filename)
+        if [ "$filename" = "$targetdirname" ]; then
+            # archive type either not supported or it doesn't need dir creation
+            targetdirname=""
+        else
+            mkdir -v "$filedirname/$targetdirname"
+        fi
+
+        if [ -f "$1" ]; then
+            case "$1" in
+                *.tar.bz2|*.tbz|*.tbz2) tar "x${verbose}jf" "$1" -C "$filedirname/$targetdirname" ;;
+                *.tar.gz|*.tgz) tar "x${verbose}zf" "$1" -C "$filedirname/$targetdirname" ;;
+                *.tar.xz|*.txz) tar "x${verbose}Jf" "$1" -C "$filedirname/$targetdirname" ;;
+                *.tar.Z) tar "x${verbose}Zf" "$1" -C "$filedirname/$targetdirname" ;;
                 *.bz2) bunzip2 "$1" ;;
                 *.deb) dpkg-deb -x${verbose} "$1" "${1:0:-4}" ;;
                 *.pax.gz) gunzip "$1"; set -- "$@" "${1:0:-3}" ;;
@@ -43,17 +59,15 @@ End-Of-Usage
                 *.pkg) pkgutil --expand "$1" "${1:0:-4}" ;;
                 *.rar) unrar x "$1" ;;
                 *.rpm) rpm2cpio "$1" | cpio -idm${verbose} ;;
-                *.tar) tar "x${verbose}f" "$1" ;;
-                *.txz) mv "$1" "${1:0:-4}.tar.xz"; set -- "$@" "${1:0:-4}.tar.xz" ;;
+                *.tar) tar "x${verbose}f" "$1" -C "$filedirname/$targetdirname" ;;
                 *.xz) xz --decompress "$1" ;;
                 *.zip|*.war|*.jar) unzip "$1" ;;
                 *.Z) uncompress "$1" ;;
                 *.7z) 7za x "$1" ;;
                 *) echo "'$1' cannot be extracted via extract" >&2;;
-		    esac
-        else
-		    echo "extract: '$1' is not a valid file" >&2
-	    fi
+            esac
+        fi
+
         shift
     done
 }

--- a/plugins/available/extract.plugin.bash
+++ b/plugins/available/extract.plugin.bash
@@ -5,7 +5,7 @@ about-plugin 'one command to extract them all...'
 extract() {
     local opt
     local OPTIND=1
-    while getopts "hdv" opt; do
+    while getopts "hv" opt; do
         case "$opt" in
             h)
                 cat <<End-Of-Usage


### PR DESCRIPTION
added tar extract-directory creation and usage
(also removal of unnecessary recursion where appropriate)

positive side-effect:
- no lingering *.tar file when exracting a *.tgz/*.tar.xz/... or similar
- it now behaves like uncompressing *.zip or *.7z: the archive file remains as-is and is extracted in a new directory with the name of the archive (without suffix) in the same directory as the archive