### PR TITLE
fix for issue #1418

### DIFF
--- a/plugins/available/aws.plugin.bash
+++ b/plugins/available/aws.plugin.bash
@@ -40,7 +40,8 @@ function __awskeys_help {
 function __awskeys_get {
     local ln=$(grep -n "\[ *$1 *\]" "${AWS_SHARED_CREDENTIALS_FILE}" | cut -d ":" -f 1)
     if [[ -n "${ln}" ]]; then
-        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | egrep -m 3 "aws_access_key_id|aws_secret_access_key|aws_session_token"
+        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | egrep -m 2 "aws_access_key_id|aws_secret_access_key"
+        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | egrep -m 1 "aws_session_token"
     fi
 }
 


### PR DESCRIPTION
Minor fix to address cases where there is no aws_session_token set. Checked the docs and only saw these three values are supported in the credentials file.