### PR TITLE
travis: Give jobs names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ language: shell
 
 jobs:
   - <<: *native_job
+    name: default Ubuntu
     os: linux
   - <<: *native_job
+    name: MacOS
     os: osx


### PR DESCRIPTION
It's easier to read a long job list when the jobs are named.

Reference:
https://docs.travis-ci.com/user/build-stages/#naming-your-jobs-within-build-stages