### PR TITLE
Fix search plugin tests

### DIFF
--- a/test/lib/search.bats
+++ b/test/lib/search.bats
@@ -5,6 +5,9 @@ load ../../lib/composure
 load ../../lib/helpers
 load ../../lib/utilities
 load ../../lib/search
+
+cite _about _param _example _group _author _version
+
 load ../../plugins/available/base.plugin
 load ../../aliases/available/git.aliases
 load ../../plugins/available/ruby.plugin
@@ -12,8 +15,6 @@ load ../../plugins/available/rails.plugin
 load ../../completion/available/bundler.completion
 load ../../completion/available/gem.completion
 load ../../completion/available/rake.completion
-
-cite _about _param _example _group _author _version
 
 load ../../lib/helpers
 


### PR DESCRIPTION
Had to move the `cite` definition up a couple of lines, since `_about`
is used in some of the tested plugins

Fixes #1582