### PR TITLE
Remove echo when a dead SSH Agent PID is found

### DIFF
--- a/plugins/available/sshagent.plugin.bash
+++ b/plugins/available/sshagent.plugin.bash
@@ -94,7 +94,6 @@ function _ensure_valid_sshagent_env() {
     return
   fi
 
-  echo "There's a dead ssh-agent at the landing..."
   ssh-agent > "${SSH_AGENT_ENV}"
   return
 }
@@ -125,7 +124,7 @@ function sshagent() {
   about 'ensures ssh-agent is up and running'
   param '1: on|off '
   example '$ sshagent on'
-  group 'ssh'    
+  group 'ssh'
   [[ -z "${SSH_AGENT_ENV}" ]] \
   && export SSH_AGENT_ENV="${HOME}/.ssh/agent_env.${HOSTNAME}"
 


### PR DESCRIPTION
This case can be safely ignored, no need to print a message for that.

Fixes #1579