### PR TITLE
test: Make `rsync` optional

### DIFF
--- a/test/bash_it/bash_it.bats
+++ b/test/bash_it/bash_it.bats
@@ -7,7 +7,14 @@ function local_setup {
   setup_test_fixture
 
   # Copy the test fixture to the Bash-it folder
-  rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
+  if command -v rsync &> /dev/null
+  then
+    rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
+  else
+    find "$BASH_IT/test/fixtures/bash_it" \
+      -mindepth 1 -maxdepth 1 \
+      -exec cp -r {} "$BASH_IT/" \;
+  fi
 }
 
 @test "bash-it: verify that the test fixture is available" {

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -31,9 +31,21 @@ local_teardown() {
 setup_test_fixture() {
   mkdir -p "$BASH_IT"
   lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  # Use rsync to copy Bash-it to the temp folder
-  # rsync is faster than cp, since we can exclude the large ".git" folder
-  rsync -qavrKL -d --delete-excluded --exclude=.git --exclude=enabled $lib_directory/../../../.. "$BASH_IT"
+  local src_topdir="$lib_directory/../../../.."
+
+  if command -v rsync &> /dev/null
+  then
+    # Use rsync to copy Bash-it to the temp folder
+    rsync -qavrKL -d --delete-excluded --exclude=.git --exclude=enabled "$src_topdir" "$BASH_IT"
+  else
+    rm -rf "$BASH_IT"
+    mkdir -p "$BASH_IT"
+
+    find "$src_topdir" \
+      -mindepth 1 -maxdepth 1 \
+      -not -name .git \
+      -exec cp -r {} "$BASH_IT" \;
+  fi
 
   rm -rf "$BASH_IT"/enabled
   rm -rf "$BASH_IT"/aliases/enabled


### PR DESCRIPTION
For bulk copying, `rsync` is used in test code, which is rather fast and
capable of saving needless write operations. The downside is that tests
fail when the tool is missing, which is the case with most minimal Linux
setups (e.g. containers or even Gnome installations of Debian).

Provide an alternative way for sufficiently fast copying by means of
`find -exec cp`. Measured total test time penalty is less than 0.5%.
Downside of needless write operations remains in case of fallback.