### PR TITLE
nwinkler_random_colors: Allow to provide a customized color file

### DIFF
--- a/themes/nwinkler_random_colors/nwinkler_random_colors.theme.bash
+++ b/themes/nwinkler_random_colors/nwinkler_random_colors.theme.bash
@@ -15,7 +15,7 @@
 # The exit code functionality currently doesn't work if you are using the 'fasd' plugin,
 # since 'fasd' is messing with the $PROMPT_COMMAND
 
-RANDOM_COLOR_FILE=$HOME/.nwinkler_random_colors
+RANDOM_COLOR_FILE=${NWLINKLER_RANDOM_COLOR_FILE:-$HOME/.nwinkler_random_colors}
 
 function randomize_nwinkler {
   declare -a AVAILABLE_COLORS


### PR DESCRIPTION
When running bash inside a container where we share the home with the
host, or when whe share the same dotfiles betwee different machines, it
may be useful to be able to customize the random-colors files.

So allow to override it via $NWLINKLER_RANDOM_COLOR_FILE env variable