### PR TITLE
Add fasd plugin

### DIFF
--- a/plugins/available/fasd.plugin.bash
+++ b/plugins/available/fasd.plugin.bash
@@ -1,0 +1,4 @@
+cite about-plugin
+about-plugin 'load fasd, if you are using it'
+
+_command_exists fasd && eval $(fasd --init auto)


### PR DESCRIPTION
This PR seeks to add support for [`fasd`](https://github.com/clvv/fasd).

In case anyone is wondering why I chose `auto`, it's because I think `fasd` does a fine job of detecting bash, and I don't want to maintain any parity changes if they change defaults upstream. For posterity, here is a copy of the current output from `init`

```
$ fasd --init auto
{ if [ "$ZSH_VERSION" ] && compctl; then # zsh
    eval "$(fasd --init posix-alias zsh-hook zsh-ccomp zsh-ccomp-install \
      zsh-wcomp zsh-wcomp-install)"
  elif [ "$BASH_VERSION" ] && complete; then # bash
    eval "$(fasd --init posix-alias bash-hook bash-ccomp bash-ccomp-install)"
  else # posix shell
    eval "$(fasd --init posix-alias posix-hook)"
  fi
} >> "/dev/null" 2>&1
```