### PR TITLE
use || to silence exit 1 properly and quote fasd init

### DIFF
--- a/plugins/available/fasd.plugin.bash
+++ b/plugins/available/fasd.plugin.bash
@@ -1,4 +1,6 @@
 cite about-plugin
 about-plugin 'load fasd, if you are using it'
 
-_command_exists fasd && eval $(fasd --init auto)
+_command_exists fasd || return
+
+eval "$(fasd --init auto)"


### PR DESCRIPTION
This PR fixes two mistakes I made in #1602:

1) when checking for a command `||` should be use to silence the non-0 exits
2) `fasd`s `--init` output needs to be wrapped in quotes, as is documented in their readme :man_facepalming:

My bad y'all!

Fixes #1605