### PR TITLE
Fix _short-dirname

### DIFF
--- a/plugins/available/xterm.plugin.bash
+++ b/plugins/available/xterm.plugin.bash
@@ -3,7 +3,7 @@ about-plugin 'automatically set your xterm title with host and location info'
 
 
 _short-dirname () {
-  local dir_name=`dirs -0`
+  local dir_name=`dirs +0`
   [ "$SHORT_TERM_LINE" = true ] && [ ${#dir_name} -gt 8 ] && echo ${dir_name##*/} || echo $dir_name
 }
 


### PR DESCRIPTION
Fix issue: when using pushd/popd, the terminal title remains at the original location because, from `man bash`:

       dirs [-clpv] [+n] [-n]
             ...
              +n     Displays the nth entry counting from the left of the list shown by dirs ...
              -n     Displays the nth entry counting from the right of the list shown by dirs ...
