### PR TITLE
Update Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,20 @@ os: linux
 
 dist: xenial
 
-# This is the default xcode version. The Xcode version defines what
-osx_image: xcode9.4
-
 jobs:
   - <<: *native_job
-    name: default Ubuntu
-    os: linux
+    name: Ubuntu 16.04
+  
   - <<: *native_job
-    name: MacOS
+    name: Ubuntu 18.04
+    dist: bionic
+    
+  - <<: *native_job
+    name: MacOS xcode9.4
     os: osx
- 
+    osx_image: xcode9.4 # Default xcode on Travis.
+    
+  - <<: *native_job
+    name: MacOS xcode11.5
+    os: osx
+    osx_image: xcode11.5 # Latest xcode on Travis.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ _native_job: &native_job
 
 language: shell
 
+os: linux
+
+dist: xenial
+
+# This is the default xcode version. The Xcode version defines what
+osx_image: xcode9.4
+
 jobs:
   - <<: *native_job
     name: default Ubuntu
@@ -15,3 +22,4 @@ jobs:
   - <<: *native_job
     name: MacOS
     os: osx
+ 


### PR DESCRIPTION
### Update Travis configuration to make used versions more explicit

In this PR I've add the following changes:

- Added explicit default OS and DIST

- Added explicit default OSX_IMAGE declaration:

-  Added Ubuntu 18.04 to the list of builds

- Added new OSX_IMAGE to the list of builds

OBS: Could explain why you use a native job? 