### PR TITLE
Add check for broken XCode SVN command

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -88,6 +88,15 @@ P4_EXE=$(which p4 2> /dev/null || true)
 HG_EXE=$(which hg  2> /dev/null || true)
 SVN_EXE=$(which svn  2> /dev/null || true)
 
+# Check for broken SVN exe that is caused by some versions of Xcode.
+# See https://github.com/Bash-it/bash-it/issues/1612 for more details.
+if [[ -x "$SVN_EXE" ]] ; then
+  if "$SVN_EXE" 2>&1 | grep -q "subversion command line tools are no longer provided" ; then
+    # Unset the SVN exe variable so that SVN commands are avoided.
+    SVN_EXE=""
+  fi
+fi
+
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE
   elif [[ -f .git/HEAD ]] && [[ -x "$GIT_EXE" ]]; then SCM=$SCM_GIT

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -83,10 +83,10 @@ RBENV_THEME_PROMPT_SUFFIX='|'
 RBFU_THEME_PROMPT_PREFIX=' |'
 RBFU_THEME_PROMPT_SUFFIX='|'
 
-GIT_EXE=`which git 2> /dev/null || true`
-P4_EXE=`which p4 2> /dev/null || true`
-HG_EXE=`which hg  2> /dev/null || true`
-SVN_EXE=`which svn  2> /dev/null || true`
+GIT_EXE=$(which git 2> /dev/null || true)
+P4_EXE=$(which p4 2> /dev/null || true)
+HG_EXE=$(which hg  2> /dev/null || true)
+SVN_EXE=$(which svn  2> /dev/null || true)
 
 function scm {
   if [[ "$SCM_CHECK" = false ]]; then SCM=$SCM_NONE

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -91,7 +91,7 @@ SVN_EXE=$(which svn  2> /dev/null || true)
 # Check for broken SVN exe that is caused by some versions of Xcode.
 # See https://github.com/Bash-it/bash-it/issues/1612 for more details.
 if [[ -x "$SVN_EXE" ]] ; then
-  if "$SVN_EXE" 2>&1 | grep -q "subversion command line tools are no longer provided" ; then
+  if ! "$SVN_EXE" --version > /dev/null 2>&1 ; then
     # Unset the SVN exe variable so that SVN commands are avoided.
     SVN_EXE=""
   fi


### PR DESCRIPTION
Fixes #1612 
Fixes #914 

Can you please validate that this fixes the slowness, @arturmartins?

This should detect the broken `svn` command when you open a new shell or run `bash-it reload`.