### PR TITLE
Fix #1625 : escape quotes in alias completion.

### DIFF
--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -71,7 +71,7 @@ function alias_completion {
                         # with the last word in the unaliased form, i.e.,
                         # alias_cmd + ' ' + alias_args.
                         if [[ \$COMP_LINE == \"\$prec_word \$compl_word\" ]]; then
-                            prec_word=\"$alias_cmd $alias_args\"
+                            prec_word=\"$alias_cmd ${alias_args//\"/\\\"}\"
                             prec_word=\${prec_word#* }
                         fi
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))


### PR DESCRIPTION
I've tried to escape double quotes in $alias_args. 

One test case failed:

>  ✗ plugins base: myip()
>   (in test file test/plugins/base.plugin.bats, line 22)
>     `[[ $mask_ip == 'Your public IP is: ?.?.?.?' ]]' failed

But I don't think it caused by my change.