### PR TITLE
Ensure node plugin plays nice with nodenv

### DIFF
--- a/plugins/available/node.plugin.bash
+++ b/plugins/available/node.plugin.bash
@@ -1,7 +1,13 @@
 cite about-plugin
 about-plugin 'Node.js helper functions'
 
+# Ensure local modules are preferred in PATH
 pathmunge "./node_modules/.bin" "after"
 
-# Make sure the global npm prefix is on the path
-[[ `which npm 2>/dev/null` ]] && pathmunge "$(npm config get prefix)/bin" "after"
+# Check that we have npm
+out=$(command -v npm 2>&1) || return
+
+# If not using nodenv, ensure global modules are in PATH
+if [[ ! $out == *"nodenv/shims"* ]] ; then
+  pathmunge "$(npm config get prefix)/bin" "after"
+fi


### PR DESCRIPTION
`nodenv` manages executable location through "shims", and these can conflict with the normal way one would configure their workspace. This addresses that. Thanks!