### PR TITLE
System completion nitpick

### DIFF
--- a/completion/available/brew.completion.bash
+++ b/completion/available/brew.completion.bash
@@ -1,13 +1,27 @@
-if which brew >/dev/null 2>&1; then
-  BREW_PREFIX=$(brew --prefix)
-  if [ -f "$BREW_PREFIX"/etc/bash_completion.d/brew ]; then
-    . "$BREW_PREFIX"/etc/bash_completion.d/brew
-  elif [ -f "$BREW_PREFIX"/Library/Contributions/brew_bash_completion.sh ]; then
-    . "$BREW_PREFIX"/Library/Contributions/brew_bash_completion.sh
-  elif [ -f "$BREW_PREFIX"/completions/bash/brew ]; then
-    # For the git-clone based installation, see here for more info:
-    # https://github.com/Bash-it/bash-it/issues/1458
-    # https://docs.brew.sh/Shell-Completion   
-    . "$BREW_PREFIX"/completions/bash/brew
-  fi
+#!/usr/bin/env bash
+
+# Load late to make sure `system` completion loads first
+# BASH_IT_LOAD_PRIORITY: 375
+
+if [[ "$(uname -s)" != 'Darwin' ]] ; then
+  _log_warning "unsupported operating system - only 'Darwin' is supported"
+  return 0
+fi
+
+# Make sure brew is installed
+_command_exists brew || return 0
+
+BREW_PREFIX=${BREW_PREFIX:-$(brew --prefix)}
+
+if [[ -r "$BREW_PREFIX"/etc/bash_completion.d/brew ]] ; then
+  source "$BREW_PREFIX"/etc/bash_completion.d/brew
+
+elif [[ -r "$BREW_PREFIX"/Library/Contributions/brew_bash_completion.sh ]] ; then
+  source "$BREW_PREFIX"/Library/Contributions/brew_bash_completion.sh
+
+elif [[ -f "$BREW_PREFIX"/completions/bash/brew ]] ; then
+  # For the git-clone based installation, see here for more info:
+  # https://github.com/Bash-it/bash-it/issues/1458
+  # https://docs.brew.sh/Shell-Completion
+  source "$BREW_PREFIX"/completions/bash/brew
 fi

--- a/completion/available/crystal.completion.bash
+++ b/completion/available/crystal.completion.bash
@@ -1,11 +1,1 @@
-if which crystal >/dev/null 2>&1; then
-
-  if which brew >/dev/null 2>&1; then
-    BREW_PREFIX=$(brew --prefix)
-
-    if [ -f "$BREW_PREFIX"/etc/bash_completion.d/crystal ]; then
-      . "$BREW_PREFIX"/etc/bash_completion.d/crystal
-    fi
-  fi
-
-fi
+_log_warning 'Bash completion for "crystal" is now covered by "system". This completion can be disabled.'

--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -1,28 +1,25 @@
 #!/usr/bin/env bash
 
 # Loads the system's Bash completion modules.
-# If Homebrew is installed (OS X), its Bash completion modules are loaded.
+# If Homebrew is installed (OS X), it's Bash completion modules are loaded.
 
-if [ -f /etc/bash_completion ]; then
-  . /etc/bash_completion
-fi
+if [[ -r /etc/bash_completion ]] ; then
+  # shellcheck disable=SC1091
+  source /etc/bash_completion
 
 # Some distribution makes use of a profile.d script to import completion.
-if [ -f /etc/profile.d/bash_completion.sh ]; then
-  . /etc/profile.d/bash_completion.sh
+elif [[ -r /etc/profile.d/bash_completion.sh ]] ; then
+  # shellcheck disable=SC1091
+  source /etc/profile.d/bash_completion.sh
+
 fi
 
+if [[ "$(uname -s)" == 'Darwin' ]] && _command_exists brew ; then
+  BREW_PREFIX=${BREW_PREFIX:-$(brew --prefix)}
 
-if [ $(uname) = "Darwin" ] && command -v brew &>/dev/null ; then
-  BREW_PREFIX=$(brew --prefix)
-
-  if [ -f "$BREW_PREFIX"/etc/bash_completion ]; then
-    . "$BREW_PREFIX"/etc/bash_completion
-  fi
-
- # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
-  if [ "${BASH_VERSINFO}" -ge 4 ] && [ -f "$BREW_PREFIX"/share/bash-completion/bash_completion ]; then
-    export BASH_COMPLETION_COMPAT_DIR="$BREW_PREFIX"/etc/bash_completion.d
-    . "$BREW_PREFIX"/share/bash-completion/bash_completion
+  # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
+  if [[ -r "$BREW_PREFIX"/etc/profile.d/bash_completion.sh ]] ; then
+    # shellcheck disable=SC1090
+    source "$BREW_PREFIX"/etc/profile.d/bash_completion.sh
   fi
 fi

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -128,8 +128,8 @@ function local_setup {
 
 @test "helpers: enable the brew completion" {
   run _enable-completion "brew"
-  assert_line -n 0 'brew enabled with priority 350.'
-  assert_link_exist "$BASH_IT/enabled/350---brew.completion.bash"
+  assert_line -n 0 'brew enabled with priority 375.'
+  assert_link_exist "$BASH_IT/enabled/375---brew.completion.bash"
 }
 
 @test "helpers: enable the node plugin" {


### PR DESCRIPTION
This was inspired from the conversation over at #1635

- Prefer the brew/bash provided wrapper (`/usr/local/etc/profile.d/bash-completion.sh`) when loading `bash-completion@2`
- Remove completions that should be utilizing `system` and notify the user through `doctor`