### PR TITLE
Projects logging

### DIFF
--- a/completion/available/projects.completion.bash
+++ b/completion/available/projects.completion.bash
@@ -1,5 +1,13 @@
+# Ensure that we log to doctor so the user can address these issues
+_is_function _init_completion ||
+  _log_error '_init_completion not found. Ensure bash-completion 2.0 or newer is installed and configured properly.'
+_is_function _rl_enabled ||
+  _log_error '_rl_enabled not found. Ensure bash-completion 2.0 or newer is installed and configured properly.'
+
 _pj() {
-  [ -z "$PROJECT_PATHS" ] && return
+  _is_function _init_completion || return
+  _is_function _rl_enabled || return
+  [ -n "$PROJECT_PATHS" ] || return
   shift
   [ "$1" == "open" ] && shift
 

--- a/plugins/available/projects.plugin.bash
+++ b/plugins/available/projects.plugin.bash
@@ -1,5 +1,5 @@
 cite about-plugin
-about-plugin 'add "export PROJECT_PATHS=~/projects:~/intertrode/projects" to navigate quickly to your project directories with `pj` and `pjo`'
+about-plugin 'quickly navigate configured paths with `pj` and `pjo`. example: "export PROJECT_PATHS=~/projects:~/work/projects"'
 
 function pj {
 about 'navigate quickly to your various project directories'


### PR DESCRIPTION
For systems without bash-completion >= 2, `projects` were erroring out. This now uses the doctor command to at least tell the user what they can do.