### PR TITLE
clean up jenv to follow the newer pattern

### DIFF
--- a/plugins/available/jenv.plugin.bash
+++ b/plugins/available/jenv.plugin.bash
@@ -1,7 +1,22 @@
 cite about-plugin
 about-plugin 'load jenv, if you are using it'
 
-export JENV_ROOT="$HOME/.jenv"
-pathmunge "$JENV_ROOT/bin"
+# Don't modify the environment if we can't find the tool:
+# - Check if in $PATH already
+# - Check if installed manually to $JENV_ROOT
+# - Check if installed manually to $HOME
+_command_exists jenv ||
+  [[ -n "$JENV_ROOT" && -x "$JENV_ROOT/bin/jenv" ]] ||
+  [[ -x "$HOME/.jenv/bin/jenv" ]] ||
+  return
 
-if which jenv > /dev/null; then eval "$(jenv init - bash)"; fi
+# Set JENV_ROOT, if not already set
+export JENV_ROOT="${JENV_ROOT:-$HOME/.jenv}"
+
+# Add JENV_ROOT/bin to PATH, if that's where it's installed
+! _command_exists jenv &&
+  [[ -x "$JENV_ROOT/bin/jenv" ]] &&
+  pathmunge "$JENV_ROOT/bin"
+
+# Initialize jenv
+eval "$(jenv init - bash)"


### PR DESCRIPTION
This translates the pattern set in `go.plugin.bash` to `jenv`.