### PR TITLE
_command_exists - custom log message

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -19,9 +19,11 @@ function _command_exists ()
 {
   _about 'checks for existence of a command'
   _param '1: command to check'
+  _param '2: (optional) log message to include when command not found'
   _example '$ _command_exists ls && echo exists'
   _group 'lib'
-  type "$1" &> /dev/null || (_log_warning "Command $1 does not exist!" && return 1) ;
+  local msg="${2:-Command '$1' does not exist!}"
+  type "$1" &> /dev/null || (_log_warning "$msg" && return 1) ;
 }
 
 function _make_reload_alias() {


### PR DESCRIPTION
This PR allows the caller to pass a custom log message when the command is not found.

I considered a few other approaches, so I'm open to opinions, but this seems easy enough.

Example use case:

```bash
# Load pyenv virtualenv if the plugin is installed
! _command_exists \
  "pyenv virtualenv --help" \
  "pyenv plugin 'virtualenv' is not installed - skipping" ||
    eval "$(pyenv virtualenv-init - bash)"
```

```bash
$ bash-it doctor
...
 WARN: plugin: pyenv: pyenv plugin 'virtualenv' is not installed - skipping
...
```