### PR TITLE
Fixed OS comparison for macOS

### DIFF
--- a/completion/available/git.completion.bash
+++ b/completion/available/git.completion.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Only operate on MacOS since there are no linux paths
-if [[ "$(uname -s)" == 'Darwin' ]] ; then
+if [[ "$(uname -s)" != 'Darwin' ]] ; then
   _log_warning "unsupported operating system - only 'Darwin' is supported"
   return 0
 fi


### PR DESCRIPTION
This was always failing on macOS instead of working there...

See #1635 for the original commit that introduced this issue. We somehow missed this, @cornfeedhobo...