### PR TITLE
gitstatus: Add informative warning in case dir is not found

### DIFF
--- a/plugins/available/gitstatus.plugin.bash
+++ b/plugins/available/gitstatus.plugin.bash
@@ -21,4 +21,6 @@ if [[ -d ${SCM_GIT_GITSTATUS_DIR} ]]; then
   # Start the actual gitstatus binary
   gitstatus_stop && gitstatus_start -s -1 -u -1 -c -1 -d -1
   export SCM_GIT_USE_GITSTATUS=true
+else
+	_log_warning "Could not find gitstatus directory in ${SCM_GIT_GITSTATUS_DIR}. Please specify directory location using SCM_GIT_GITSTATUS_DIR."
 fi


### PR DESCRIPTION
I think we should gradually see (and encourage) more PR's like this, which in the long run will ensure there are many logs throughout `bash-it`