### PR TITLE
ensure go and goenv play well together

### DIFF
--- a/completion/available/go.completion.bash
+++ b/completion/available/go.completion.bash
@@ -9,5 +9,5 @@
 # gocomplete -install
 
 if _command_exists gocomplete && _command_exists go ; then
-  complete -C "${GOBIN}"/gocomplete go
+  complete -C gocomplete go
 fi

--- a/completion/available/goenv.completion.bash
+++ b/completion/available/goenv.completion.bash
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+if _command_exists goenv && [[ -r "$GOENV_ROOT/completions/goenv.bash" ]] ; then
+  source "$GOENV_ROOT/completions/goenv.bash"
+fi

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -7,8 +7,7 @@ about-plugin 'go environment variables & path configuration'
 _command_exists go || return 0
 
 # If using goenv, make sure it can find go
-go version &>/dev/null
-[[ $? -eq 0 ]] || return 0
+go version &>/dev/null || return 0
 
 function _go_pathmunge_wrap() {
   IFS=':' local -a 'a=($1)'

--- a/plugins/available/go.plugin.bash
+++ b/plugins/available/go.plugin.bash
@@ -1,9 +1,14 @@
-#!/usr/bin/env bash
-
 cite about-plugin
 about-plugin 'go environment variables & path configuration'
 
-command -v go &>/dev/null || return
+# Load late to ensure goenv runs first, if enabled
+# BASH_IT_LOAD_PRIORITY: 275
+
+_command_exists go || return 0
+
+# If using goenv, make sure it can find go
+go version &>/dev/null
+[[ $? -eq 0 ]] || return 0
 
 function _go_pathmunge_wrap() {
   IFS=':' local -a 'a=($1)'

--- a/plugins/available/goenv.plugin.bash
+++ b/plugins/available/goenv.plugin.bash
@@ -8,13 +8,15 @@ about-plugin 'load goenv, if you are using it'
 _command_exists goenv ||
   [[ -n "$GOENV_ROOT" && -x "$GOENV_ROOT/bin/goenv" ]] ||
   [[ -x "$HOME/.goenv/bin/goenv" ]] ||
-  return
+  return 0
 
 # Set GOENV_ROOT, if not already set
 export GOENV_ROOT="${GOENV_ROOT:-$HOME/.goenv}"
 
 # Add GOENV_ROOT/bin to PATH, if that's where it's installed
-! _command_exists goenv && [[ -x "$GOENV_ROOT/bin/goenv" ]] && pathmunge "$GOENV_ROOT/bin"
+if ! _command_exists goenv && [[ -x "$GOENV_ROOT/bin/goenv" ]] ; then
+  pathmunge "$GOENV_ROOT/bin"
+fi
 
 # Initialize goenv
 eval "$(goenv init - bash)"

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -5,14 +5,14 @@ load ../../lib/helpers
 load ../../lib/composure
 
 @test 'ensure _go_pathmunge_wrap is defined' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   load ../../plugins/available/go.plugin
   run type -t _go_pathmunge_wrap
   assert_line 'function'
 }
 
 @test 'plugins go: single entry in GOPATH' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   export GOPATH="/foo"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -20,7 +20,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: single entry in GOPATH, with space' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   export GOPATH="/foo bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -28,7 +28,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: single entry in GOPATH, with escaped space' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   export GOPATH="/foo\ bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -36,7 +36,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: multiple entries in GOPATH' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   export GOPATH="/foo:/bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -44,7 +44,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: multiple entries in GOPATH, with space' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   export GOPATH="/foo:/foo bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin
@@ -52,7 +52,7 @@ load ../../lib/composure
 }
 
 @test 'plugins go: multiple entries in GOPATH, with escaped space' {
-  { [[ $CI ]] || _command_exists go; } || skip 'golang not found'
+  { _command_exists go && go version &>/dev/null ; } || skip 'golang not found'
   export GOPATH="/foo:/foo\ bar"
   export GOROOT="/baz"
   load ../../plugins/available/go.plugin


### PR DESCRIPTION
- don't assume `gocomplete`'s location
- add `goenv` completion
- cleanup `go` plugin and make sure it works well with `goenv`
- cleanup `goenv` plugin to follow safer conventions