### PR TITLE
hg SCM_CHANGE: prevent hexdump squeezing

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -344,7 +344,7 @@ function hg_prompt_vars {
 
     if [ -f "$HG_ROOT/dirstate" ]; then
         # Mercurial holds various information about the working directory in .hg/dirstate file. More on http://mercurial.selenic.com/wiki/DirState
-        SCM_CHANGE=$(hexdump -n 10 -e '1/1 "%02x"' "$HG_ROOT/dirstate" | cut -c-12)
+        SCM_CHANGE=$(hexdump -vn 10 -e '1/1 "%02x"' "$HG_ROOT/dirstate" | cut -c-12)
     else
         SCM_CHANGE=$(hg summary 2> /dev/null | grep parent: | awk '{print $2}')
     fi


### PR DESCRIPTION
hexdump by default will replace any repeated groups with an asterisk and
a newline, which breaks prompts. This can be disabled with the `-v`
flag. For example:

```
printf 'aac' | hexdump -e '1/1 "%02x"'
61*
63
printf 'abc' | hexdump -e '1/1 "%02x"'
616263
printf 'aac' | hexdump -ve '1/1 "%02x"'
616163
```