### PR TITLE
Fix the _command_exists function exists test use case

### DIFF
--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -20,7 +20,7 @@ function local_setup {
 # TODO Create global __get_enabled_name function
 
 @test "helpers: _command_exists function exists" {
-  type -a _command_exists &> /dev/null
+  run type -a _command_exists &> /dev/null
   assert_success
 }
 


### PR DESCRIPTION
On trying to run the tests locally, the `@test "helpers: _command_exists function exists"` failed with the following:

```bash
✗ helpers: _command_exists function exists
   (from function `_command_exists' in file test/lib/../../lib/helpers.bash, line 26,
    in test file test/lib/helpers.bats, line 24)
     `_command_exists &> /dev/null' failed
   ..../bats-assert/src/assert_success.bash: line 33: output: parameter not set
```

Upon examining the `test/lib/helpers.bats` file I found that the bats `run` was missing.

> Bats includes a run helper that invokes its arguments as a command, saves the exit status and output into special global variables, and then returns with a 0 status code so you can continue to make assertions in your test case.