### PR TITLE
support multiple paths in pathmunge

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -680,12 +680,18 @@ then
     example 'pathmunge /path/to/dir is equivalent to PATH=/path/to/dir:$PATH'
     example 'pathmunge /path/to/dir after is equivalent to PATH=$PATH:/path/to/dir'
 
-    if ! [[ $PATH =~ (^|:)$1($|:) ]] ; then
-      if [ "$2" = "after" ] ; then
-        export PATH=$PATH:$1
-      else
-        export PATH=$1:$PATH
+    IFS=':' local -a 'a=($1)'
+    local i=${#a[@]}
+    while [[ $i -gt 0 ]] ; do
+      i=$(( i - 1 ))
+      p=${a[i]}
+      if ! [[ $PATH =~ (^|:)$p($|:) ]] ; then
+        if [[ "$2" = "after" ]] ; then
+          export PATH=$PATH:$p
+        else
+          export PATH=$p:$PATH
+        fi
       fi
-    fi
+    done
   }
 fi

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -39,6 +39,39 @@ function local_setup {
   assert_failure
 }
 
+@test 'helpers: pathmunge: ensure function is defined' {
+  run type -t pathmunge
+  assert_line 'function'
+}
+
+@test 'helpers: pathmunge: single path' {
+  new_paths='/tmp/fake-pathmunge-path'
+  old_path="${PATH}"
+  pathmunge "${new_paths}"
+  assert_equal "${new_paths}:${old_path}" "${PATH}"
+}
+
+@test 'helpers: pathmunge: single path, with space' {
+  new_paths='/tmp/fake pathmunge path'
+  old_path="${PATH}"
+  pathmunge "${new_paths}"
+  assert_equal "${new_paths}:${old_path}" "${PATH}"
+}
+
+@test 'helpers: pathmunge: multiple paths' {
+  new_paths='/tmp/fake-pathmunge-path1:/tmp/fake-pathmunge-path2'
+  old_path="${PATH}"
+  pathmunge "${new_paths}"
+  assert_equal "${new_paths}:${old_path}" "${PATH}"
+}
+
+@test 'helpers: pathmunge: multiple paths, with space' {
+  new_paths='/tmp/fake pathmunge path1:/tmp/fake pathmunge path2'
+  old_path="${PATH}"
+  pathmunge "${new_paths}"
+  assert_equal "${new_paths}:${old_path}" "${PATH}"
+}
+
 @test "helpers: bash-it help aliases ag" {
   run bash-it help aliases "ag"
   assert_line -n 0 "ag='ag --smart-case --pager=\"less -MIRFX'"

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -72,6 +72,14 @@ function local_setup {
   assert_equal "${new_paths}:${old_path}" "${PATH}"
 }
 
+@test 'helpers: pathmunge: multiple paths, with duplicate' {
+  new_paths='/tmp/fake-pathmunge-path1:/tmp/fake pathmunge path2:/tmp/fake-pathmunge-path1:/tmp/fake-pathmunge-path3'
+  want_paths='/tmp/fake pathmunge path2:/tmp/fake-pathmunge-path1:/tmp/fake-pathmunge-path3'
+  old_path="${PATH}"
+  pathmunge "${new_paths}"
+  assert_equal "${want_paths}:${old_path}" "${PATH}"
+}
+
 @test "helpers: bash-it help aliases ag" {
   run bash-it help aliases "ag"
   assert_line -n 0 "ag='ag --smart-case --pager=\"less -MIRFX'"


### PR DESCRIPTION
This PR seeks to add support for colon deliminated list to be passed to `pathmunge` ~and removes the specialized wrapper that was in the go plugin~. Tests have been ~updated~ added accordingly.

I'd like to adjust the pathmunge function description, but the words escape me - taking all suggestions.