### PR TITLE
Make bobby and bobby-python themes more readable

### DIFF
--- a/themes/bobby-python/bobby-python.theme.bash
+++ b/themes/bobby-python/bobby-python.theme.bash
@@ -12,8 +12,13 @@ GIT_THEME_PROMPT_SUFFIX="${green}|"
 CONDAENV_THEME_PROMPT_SUFFIX="|"
 
 function prompt_command() {
-    #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(ruby_version_prompt) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
-    PS1="\n${yellow}$(python_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_char)${green}$(scm_prompt_info) ${green}→${reset_color} "
+    PS1="\n${yellow}$(python_version_prompt) "  # Name of virtual env followed by python version
+    PS1+="${purple}\h "
+    PS1+="${reset_color}in "
+    PS1+="${green}\w\n"
+    PS1+="${bold_cyan}$(scm_char)"
+    PS1+="${green}$(scm_prompt_info) "
+    PS1+="${green}→${reset_color} "
 }
 
 safe_append_prompt_command prompt_command

--- a/themes/bobby/bobby.theme.bash
+++ b/themes/bobby/bobby.theme.bash
@@ -22,8 +22,13 @@ __bobby_clock() {
 }
 
 function prompt_command() {
-    #PS1="${bold_cyan}$(scm_char)${green}$(scm_prompt_info)${purple}$(ruby_version_prompt) ${yellow}\h ${reset_color}in ${green}\w ${reset_color}\n${green}→${reset_color} "
-    PS1="\n$(battery_char) $(__bobby_clock)${yellow}$(ruby_version_prompt) ${purple}\h ${reset_color}in ${green}\w\n${bold_cyan}$(scm_prompt_char_info) ${green}→${reset_color} "
+    PS1="\n$(battery_char) $(__bobby_clock)"
+    PS1+="${yellow}$(ruby_version_prompt) "
+    PS1+="${purple}\h "
+    PS1+="${reset_color}in "
+    PS1+="${green}\w\n"
+    PS1+="${bold_cyan}$(scm_prompt_char_info) "
+    PS1+="${green}→${reset_color} "
 }
 
 THEME_SHOW_CLOCK_CHAR=${THEME_SHOW_CLOCK_CHAR:-"true"}


### PR DESCRIPTION
This PR attempts to make the `bobby` and `bobby-python` themes slightly more readable by breaking up PS1 into its individual components. I tested the proposed changes locally and can confirm they don't alter the appearance of the themes.

Edit: Just realized after opening the PR that I had forgotten to create a feature branch on my fork and used master directly. Happy to open a new PR with a feature branch instead. Just let me know.