### PR TITLE
Add bash-it restart command

### DIFF
--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -65,7 +65,7 @@ _bash-it-comp()
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   chose_opt="${COMP_WORDS[1]}"
   file_type="${COMP_WORDS[2]}"
-  opts="disable enable help migrate reload doctor search show update version"
+  opts="disable enable help migrate reload restart doctor search show update version"
   case "${chose_opt}" in
     show)
       local show_args="aliases completions plugins"

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -45,7 +45,7 @@ alias reload_plugins="$(_make_reload_alias plugin plugins)"
 bash-it ()
 {
     about 'Bash-it help and maintenance'
-    param '1: verb [one of: help | show | enable | disable | migrate | update | search | version | reload | doctor ] '
+    param '1: verb [one of: help | show | enable | disable | migrate | update | search | version | reload | restart | doctor ] '
     param '2: component type [one of: alias(es) | completion(s) | plugin(s) ] or search term(s)'
     param '3: specific component [optional]'
     example '$ bash-it show plugins'
@@ -57,6 +57,7 @@ bash-it ()
     example '$ bash-it search [-|@]term1 [-|@]term2 ... [ -e/--enable ] [ -d/--disable ] [ -r/--refresh ] [ -c/--no-color ]'
     example '$ bash-it version'
     example '$ bash-it reload'
+    example '$ bash-it restart'
     example '$ bash-it doctor errors|warnings|all'
     typeset verb=${1:-}
     shift
@@ -84,6 +85,8 @@ bash-it ()
         func=_bash-it-migrate;;
       version)
         func=_bash-it-version;;
+      restart)
+        func=_bash-it-restart;;
       reload)
         func=_bash-it-reload;;
       *)
@@ -312,6 +315,23 @@ _bash-it-doctor-() {
   _group 'lib'
 
   _bash-it-doctor-all
+}
+
+_bash-it-restart() {
+  _about 'restarts the shell in order to fully reload it'
+  _group 'lib'
+
+  saved_pwd=$(pwd)
+
+  case $OSTYPE in
+    darwin*)
+      init_file=.bash_profile
+      ;;
+    *)
+      init_file=.bashrc
+      ;;
+  esac
+  exec "${0/-/}" --rcfile <(echo "source \"$HOME/$init_file\"; cd \"$saved_pwd\"")
 }
 
 _bash-it-reload() {

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -75,32 +75,32 @@ function __check_completion () {
 
 @test "completion bash-it: show options" {
   run __check_completion 'bash-it '
-  assert_line -n 0 "disable enable help migrate reload doctor search show update version"
+  assert_line -n 0 "disable enable help migrate reload restart doctor search show update version"
 }
 
 @test "completion bash-it: bash-ti - show options" {
   run __check_completion 'bash-ti '
-  assert_line -n 0 "disable enable help migrate reload doctor search show update version"
+  assert_line -n 0 "disable enable help migrate reload restart doctor search show update version"
 }
 
 @test "completion bash-it: shit - show options" {
   run __check_completion 'shit '
-  assert_line -n 0 "disable enable help migrate reload doctor search show update version"
+  assert_line -n 0 "disable enable help migrate reload restart doctor search show update version"
 }
 
 @test "completion bash-it: bashit - show options" {
   run __check_completion 'bashit '
-  assert_line -n 0 "disable enable help migrate reload doctor search show update version"
+  assert_line -n 0 "disable enable help migrate reload restart doctor search show update version"
 }
 
 @test "completion bash-it: batshit - show options" {
   run __check_completion 'batshit '
-  assert_line -n 0 "disable enable help migrate reload doctor search show update version"
+  assert_line -n 0 "disable enable help migrate reload restart doctor search show update version"
 }
 
 @test "completion bash-it: bash_it - show options" {
   run __check_completion 'bash_it '
-  assert_line -n 0 "disable enable help migrate reload doctor search show update version"
+  assert_line -n 0 "disable enable help migrate reload restart doctor search show update version"
 }
 
 @test "completion bash-it: show - show options" {


### PR DESCRIPTION
This command will re exec the shell, yet `cd` to the prev `pwd`
I briefly floated the idea in https://github.com/Bash-it/bash-it/issues/1665#issuecomment-706459916
I still did not test this on Mac, and also I could not enable the `--login` option, as I wanted to run command after shell initialization. @ahmadassaf could you please test this and tell me if this works on Mac? 