### PR TITLE
Basic ReadTheDocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+version: 2
+
+sphinx:
+  builder: htmldir
+  configuration: docs/conf.py
+
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,15 @@ cache:
 
 jobs:
   include:
+  - language: python
+    python: 3.8
+    name: docs
+    dist: bionic
+    install:
+      pip3 install -r docs/requirements.txt;
+    script:
+      sphinx-build -W -b html docs docs/_build/html;
+
   - language: go
     go: "1.14"
     name: pre-commit lint

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/commands/doctor.rst
+++ b/docs/commands/doctor.rst
@@ -1,0 +1,20 @@
+.. _doctor:
+
+Bash-it doctor
+^^^^^^^^^^^^^^
+
+If you encounter problems with any part of Bash-it, run the following command:
+
+.. code-block:: bash
+
+   bash-it doctor
+
+This will reload your bash profile and print out logs of various parts in Bash-it.
+Note that this command at default will print all logs, including debug logs.
+You can call it like this:
+
+.. code-block:: bash
+
+   bash-it doctor [errors/warnings/all]
+
+In order to get wanted verbosity.

--- a/docs/commands/index.rst
+++ b/docs/commands/index.rst
@@ -1,0 +1,15 @@
+.. _commands:
+
+Bash-it Commands
+================
+
+**Bash-it** boasts a wide range of available commands.
+You should be familiar with them in order to fully utilize Bash-it.
+
+.. toctree::
+   :maxdepth: 1
+
+   update
+   search
+   reload
+   doctor

--- a/docs/commands/reload.rst
+++ b/docs/commands/reload.rst
@@ -1,0 +1,10 @@
+.. _reload:
+
+Bash-it reload
+^^^^^^^^^^^^^^
+
+Bash-it creates a ``reload`` alias that makes it convenient to reload
+your Bash profile when you make changes.
+
+Additionally, if you export ``BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE`` as a non-null value,
+Bash-it will automatically reload itself after activating or deactivating plugins, aliases, or completions.

--- a/docs/commands/search.rst
+++ b/docs/commands/search.rst
@@ -1,0 +1,59 @@
+.. _searching:
+
+Bash-it search
+--------------
+
+If you need to quickly find out which of the plugins, aliases or completions are available for a specific framework, programming language, or an environment, you can *search* for multiple terms related to the commands you use frequently.
+Search will find and print out modules with the name or description matching the terms provided.
+
+Syntax
+^^^^^^
+
+.. code-block:: bash
+
+     bash-it search term1 [[-]term2] [[-]term3]....
+
+As an example, a ruby developer might want to enable everything related to the commands such as ``ruby``\ , ``rake``\ , ``gem``\ , ``bundler``\ , and ``rails``.
+Search command helps you find related modules so that you can decide which of them you'd like to use:
+
+.. code-block:: bash
+
+   ❯ bash-it search ruby rake gem bundle irb rails
+         aliases:  bundler rails
+         plugins:  chruby chruby-auto ruby
+     completions:  bundler gem rake
+
+Currently enabled modules will be shown in green.
+
+Searching with Negations
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can prefix a search term with a "-" to exclude it from the results.
+In the above example, if we wanted to hide ``chruby`` and ``chruby-auto``\ ,
+we could change the command as follows:
+
+.. code-block:: bash
+
+   ❯ bash-it search ruby rake gem bundle irb rails -chruby
+         aliases:  bundler rails
+         plugins:  ruby
+     completions:  bundler gem rake
+
+Using Search to Enable or Disable Components
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By adding a ``--enable`` or ``--disable`` to the search command, you can automatically enable all modules that come up as a result of a search query.
+This could be quite handy if you like to enable a bunch of components related to the same topic.
+
+Disabling ASCII Color
+^^^^^^^^^^^^^^^^^^^^^
+
+To remove non-printing non-ASCII characters responsible for the coloring of the search output, you can set environment variable ``NO_COLOR``.
+Enabled components will then be shown with a checkmark:
+
+.. code-block:: bash
+
+   ❯ NO_COLOR=1 bash-it search ruby rake gem bundle irb rails -chruby
+         aliases  =>   ✓bundler ✓rails
+         plugins  =>   ✓ruby
+     completions  =>   bundler gem rake

--- a/docs/commands/update.rst
+++ b/docs/commands/update.rst
@@ -1,0 +1,38 @@
+.. _update:
+
+Bash-it update
+^^^^^^^^^^^^^^
+
+To update Bash-it to the latest stable version, simply run:
+
+.. code-block:: bash
+
+   bash-it update stable
+
+If you want to update to the latest dev version (directly from master), run:
+
+.. code-block:: bash
+
+   bash-it update dev
+
+If you want to update automatically and unattended, you can add the optional
+``-s/--silent`` flag, for example:
+
+.. code-block:: bash
+
+   bash-it update dev --silent
+
+.. _migrate:
+
+Bash-it migrate
+^^^^^^^^^^^^^^^
+
+If you are using an older version of Bash-it, it's possible that some functionality has changed, or that the internal structure of how Bash-it organizes its functionality has been updated.
+For these cases, we provide a ``migrate`` command:
+
+.. code-block:: bash
+
+   bash-it migrate
+
+This command will automatically migrate the Bash-it structure to the latest version.
+The ``migrate`` command is run automatically if you run the ``update``\ , ``enable`` or ``disable`` commands.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Bash-it'
+copyright = '2020, Bash-it Team'
+author = 'Bash-it Team'
+
+# The full version, including alpha/beta/rc tags
+release = ''
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -47,7 +48,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,108 @@
+.. _contributing:
+
+Contribution Guidelines
+=======================
+
+When contributing a new feature, a bug fix, a new theme, or any other change to Bash-it, please consider the following guidelines.
+Most of this is common sense, but please try to stick to the conventions listed here.
+
+Issues
+------
+
+
+* When opening a new issue in the issue tracker, please include information about which *Operating System* you're using, and which version of *Bash*.
+* In many cases, it also makes sense to show which Bash-it plugins you are using.
+  This information can be obtained using ``bash-it show plugins``.
+* If the issue happens while loading Bash-it, please also include your ``~/.bash_profile`` or ``~/.bashrc`` file,
+  as well as the install location of Bash-it (default should be ``~/.bash_it``\ ).
+* When reporting a bug or requesting a new feature, consider providing a Pull Request that fixes the issue or can be used as a starting point for the new feature.
+  Don't be afraid, most things aren't that complex...
+
+Pull Requests
+-------------
+
+
+* Fork the Bash-it repo, create a new feature branch from *master* and apply your changes there.
+  Create a *Pull Request* from your feature branch against Bash-it's *master* branch.
+* Limit each Pull Request to one feature.
+  Don't bundle multiple features/changes (e.g. a new *Theme* and a fix to an existing plugin) into a single Pull Request - create one PR for the theme, and a separate PR for the fix.
+* For complex changes, try to *squash* your changes into a single commit before
+  pushing code. Once you've pushed your code and opened a PR, please refrain
+  from force-pushing changes to the PR branch – remember, Bash-it is a
+  distributed project and your branch may be in use already.
+* When in doubt, open a PR with too many commits. Bash-it is a learning project
+  for everyone involved. Showing your work provides a great history for folks
+  to learn what works and what didn't.
+
+Code Style
+----------
+
+
+* Try to stick to the existing code style. Please don't reformat or change the syntax of existing code simply because you don't like that style.
+* Indentation is using spaces, not tabs. Most of the code is indented with 2 spaces, some with 4 spaces. Please try to stick to 2 spaces.
+  If you're using an editor that supports `EditorConfig <http://EditorConfig.org>`_\ , the editor should automatically use the settings defined in Bash-it's `.editorconfig file <.editorconfig>`_.
+* When creating new functions, please use a dash ("-") to separate the words of the function's name, e.g. ``my-new-function``.
+  Don't use underscores, e.g. ``my_new_function``.
+* Internal functions that aren't to be used by the end user should start with an underscore, e.g. ``_my-new-internal-function``.
+* Use the provided meta functions to document your code, e.g. ``about-plugin``\ , ``about``\ , ``group``\ , ``param``\ , ``example``.
+  This will make it easier for other people to use your new functionality.
+  Take a look at the existing code for an example (e.g. `the base plugin <plugins/available/base.plugin.bash>`_\ ).
+* When adding files, please use the existing file naming conventions, e.g. plugin files need to end in ``.plugin.bash``.
+  This is important for the installation functionality.
+* When using the ``$BASH_IT`` variable, please always enclose it in double quotes to ensure that the code also works when Bash-it is installed in a directory that contains spaces in its name: ``for f in "${BASH_IT}/plugins/available"/*.bash ; do echo "$f" ; done``
+* Bash-it supports Bash 3.2 and higher. Please don't use features only available in Bash 4, such as associative arrays.
+
+Unit Tests
+----------
+
+When adding features or making changes/fixes, please run our growing unit test suite to ensure that you did not break existing functionality.
+The test suite does not cover all aspects of Bash-it, but please run it anyway to verify that you did not introduce any regression issues.
+
+Any code pushed to GitHub as part of a Pull Request will automatically trigger a continuous integration build on `Travis CI <https://travis-ci.org/Bash-it/bash-it>`_\ , where the test suite is run on both Linux and macOS.
+The Pull Request will then show the result of the Travis build, indicating whether all tests ran fine, or whether there were issues.
+Please pay attention to this, Pull Requests with build issues will not be merged.
+
+Adding new functionality or changing existing functionality is a good opportunity to increase Bash-it's test coverage.
+When you're changing the Bash-it codebase, please consider adding some unit tests that cover the new or changed functionality.
+Ideally, when fixing a bug, a matching unit test that verifies that the bug is no longer present, is added at the same time.
+
+To run the test suite, simply execute the following in the directory where you cloned Bash-it:
+
+.. code-block:: bash
+
+   test/run
+
+This command will ensure that the `Bats Test Framework <https://github.com/bats-core/bats-core>`_ is available in the local ``test_lib`` directory (Bats is included as a Git submodule) and then run the test suite found in the `test <test>`_ folder.
+The test script will execute each test in turn, and will print a status for each test case.
+
+When adding new test cases, please take a look at the existing test cases for examples.
+
+The following libraries are used to help with the tests:
+
+
+* Test Framework: https://github.com/bats-core/bats-core
+* Support library for Bats-Assert: https://github.com/ztombol/bats-support
+* General ``assert`` functions: https://github.com/ztombol/bats-assert
+* File ``assert`` functions: https://github.com/ztombol/bats-file
+
+When verifying test results, please try to use the ``assert`` functions found in these libraries.
+
+Features
+--------
+
+
+* When adding new completions or plugins, please don't simply copy existing tools into the Bash-it codebase, try to load/integrate the tools instead.
+  An example is using ``nvm``\ : Instead of copying the existing ``nvm`` script into Bash-it, the ``nvm.plugin.bash`` file tries to load an existing installation of ``nvm``.
+  This means an additional step for the user (installing ``nvm`` from its own repo, or through a package manager),
+  but it will also ensure that ``nvm`` can be upgraded in an easy way.
+
+.. _contributing_theme:
+
+Themes
+------
+
+
+* When adding a new theme, please include a screenshot and a short description about what makes this theme unique in the Pull Request's description field.
+  Please do not add theme screenshots to the repo itself, as they will add unnecessary bloat to the repo.
+  The project's Wiki has a *Themes* page where you can add a screenshot if you want.
+* Ideally, each theme's folder should contain a ``README.md`` file describing the theme and its configuration options.

--- a/docs/custom.rst
+++ b/docs/custom.rst
@@ -1,0 +1,18 @@
+.. _custom:
+
+Custom Content
+--------------
+
+For custom scripts, and aliases, just create the following files (they'll be ignored by the git repo):
+
+
+* ``aliases/custom.aliases.bash``
+* ``completion/custom.completion.bash``
+* ``lib/custom.bash``
+* ``plugins/custom.plugins.bash``
+* ``custom/themes/<custom theme name>/<custom theme name>.theme.bash``
+
+Anything in the custom directory will be ignored, with the exception of ``custom/example.bash``.
+
+Alternately, if you would like to keep your custom scripts under version control, you can set ``BASH_IT_CUSTOM`` in your ``~/.bashrc`` to another location outside of the ``$BASH_IT`` folder.
+In this case, any ``*.bash`` file under every directory below ``BASH_IT_CUSTOM`` folder will be used.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,94 @@
+.. _development:
+
+Bash-it Development
+===================
+
+This page summarizes a couple of rules to keep in mind when developing features or making changes in Bash-it.
+
+Testing
+-------
+
+Make sure to read the :ref:`testing docs<test>`.
+
+Debugging and Logging
+---------------------
+
+General Logging
+^^^^^^^^^^^^^^^
+
+While developing feature or making changes in general, you can log error/warning/debug
+using ``_log_error`` ``_log_warning`` and ``_log_debug``. This will help you solve problems quicker
+and also propagate important notes to other users of Bash-it.
+You can see the logs by using ``bash-it doctor`` command to reload and see the logs.
+Alternatively, you can set ``BASH_IT_LOG_LEVEL`` to ``BASH_IT_LOG_LEVEL_ERROR``\ , ``BASH_IT_LOG_LEVEL_WARNING`` or ``BASH_IT_LOG_LEVEL_ALL``.
+
+Log Prefix/Context
+^^^^^^^^^^^^^^^^^^
+
+You can define ``BASH_IT_LOG_PREFIX`` in your files in order to a have a constant prefix before your logs.
+Note that we prefer to uses "tags" based logging, i.e ``plugins: git: DEBUG: Loading git plugin``.
+
+Load Order
+----------
+
+General Load Order
+^^^^^^^^^^^^^^^^^^
+
+The main ``bash_it.sh`` script loads the frameworks individual components in the following order:
+
+
+* ``lib/composure.bash``
+* Files in ``lib`` with the exception of ``appearance.bash`` - this means that ``composure.bash`` is loaded again here (possible improvement?)
+* Enabled ``aliases``
+* Enabled ``plugins``
+* Enabled ``completions``
+* ``themes/colors.theme.bash``
+* ``themes/base.theme.bash``
+* ``lib/appearance.bash``\ , which loads the selected theme
+* Custom ``aliases``
+* Custom ``plugins``
+* Custom ``completions``
+* Additional custom files from either ``$BASH_IT/custom`` or ``$BASH_IT_CUSTOM``
+
+This order is subject to change.
+
+Individual Component Load Order
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For ``aliases``\ , ``plugins`` and ``completions``\ , the following rules are applied that influence the load order:
+
+
+* There is a global ``enabled`` directory, which the enabled components are linked into. Enabled plugins are symlinked from ``$BASH_IT/plugins/available`` to ``$BASH_IT/enabled`` for example. All component types are linked into the same common ``$BASH_IT/enabled`` directory.
+* Within the common ``enabled`` directories, the files are loaded in alphabetical order, which is based on the item's load priority (see next item).
+* When enabling a component, a *load priority* is assigned to the file. The following default priorities are used:
+
+  * Aliases: 150
+  * Plugins: 250
+  * Completions: 350
+
+* When symlinking a component into the ``enabled`` directory, the load priority is used as a prefix for the linked name, separated with three dashes from the name of the component. The ``node.plugin.bash`` would be symlinked to ``250---node.plugin.bash`` for example.
+*
+  Each file can override the default load priority by specifying a new value. To do this, the file needs to include a comment in the following form. This example would cause the ``node.plugin.bash`` (if included in that file) to be linked to ``225---node.plugin.bash``\ :
+
+  .. code-block:: bash
+
+     # BASH_IT_LOAD_PRIORITY: 225
+
+Having the order based on a numeric priority in a common directory allows for more flexibility. While in general, aliases are loaded first (since their default priority is 150), it's possible to load some aliases after the plugins, or some plugins after completions by setting the items' load priority. This is more flexible than a fixed type-based order or a strict alphabetical order based on name.
+
+These items are subject to change. When making changes to the internal functionality, this page needs to be updated as well.
+
+Plugin Disable Callbacks
+------------------------
+
+Plugins can define a function that will be called when the plugin is being disabled.
+The callback name should be ``{PLUGIN_NAME}_on_disable``\ , you can see ``gitstatus`` for usage example.
+
+Using the pre-commit hook
+-------------------------
+
+Note the file .pre-commit-config.yaml at the top of the repo.
+This file configures the behavior of the a pre-commit hook based on `the Pre-Commit framework <https://pre-commit.com/>`_. Please see the site about
+installing it (with pip, brew or other tools) then run ``pre-commit install`` in the repo's root to activate the hook.
+For the full use of the tool, you may need to install also other third-party tools, such as
+`shellcheck <https://github.com/koalaman/shellcheck/>`_ and `shfmt <https://github.com/mvdan/sh>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,14 +1,42 @@
+
 Welcome to Bash-it's documentation!
 ===================================
 
+**Bash-it** is a collection of community Bash commands and scripts for Bash 3.2+.
+(And a shameless ripoff of `oh-my-zsh <https://github.com/robbyrussell/oh-my-zsh>`_)
+
+Includes autocompletion, themes, aliases, custom functions, a few stolen pieces from Steve Losh, and more.
+
+Bash-it provides a solid framework for using, developing and maintaining shell scripts and custom commands for your daily work.
+If you're using the *Bourne Again Shell* (Bash) regularly and have been looking for an easy way on how to keep all of these nice little scripts and aliases under control, then Bash-it is for you!
+Stop polluting your ``~/bin`` directory and your ``.bashrc`` file, fork/clone Bash-it and start hacking away.
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
+   :maxdepth: 1
+
+   contributing
+   development
+   test
+   installation
+   commands/index
+   custom
+   themes
+   vcs_user
+   misc
+   uninstalling
 
 
+Help out
+--------
 
-Indices and tables
-==================
+We think everyone has their own custom scripts accumulated over time.
+And so, following in the footsteps of oh-my-zsh, Bash-it is a framework for easily customizing your Bash shell.
+Everyone's got a custom toolbox, so let's start making them even better, **as a community!**
 
-* :ref:`genindex`
-* :ref:`search`
+Send us a pull request and we'll merge it as long as it looks good.
+If you change an existing command, please give an explanation why.
+That will help a lot when we merge your changes in.
+
+Please take a look at the :ref:`Contribution Guidelines <contributing>` before reporting a bug or providing a new feature.
+
+Thanks, and happing bashing!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,14 @@
+Welcome to Bash-it's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,57 @@
+.. _installation:
+
+Installation
+------------
+
+
+#. Check out a clone of this repo to a location of your choice, such as
+   ``git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it``
+#. Run ``~/.bash_it/install.sh`` (it automatically backs up your ``~/.bash_profile`` or ``~/.bashrc``\ , depending on your OS)
+#. Edit your modified config (\ ``~/.bash_profile`` or ``~/.bashrc``\ ) file in order to customize Bash-it.
+#. Check out available aliases, completions, and plugins and enable the ones you want to use (see the next section for more details).
+
+Install Options
+^^^^^^^^^^^^^^^
+
+The install script can take the following options:
+
+
+* ``--interactive``\ : Asks the user which aliases, completions and plugins to enable.
+* ``--silent``\ : Ask nothing and install using default settings.
+* ``--no-modify-config``\ : Do not modify the existing config file (\ ``~/.bash_profile`` or ``~/.bashrc``\ ).
+
+When run without the ``--interactive`` switch, Bash-it only enables a sane default set of functionality to keep your shell clean and to avoid issues with missing dependencies.
+Feel free to enable the tools you want to use after the installation.
+
+When you run without the ``--no-modify-config`` switch, the Bash-it installer automatically modifies/replaces your existing config file.
+Use the ``--no-modify-config`` switch to avoid unwanted modifications, e.g. if your Bash config file already contains the code that loads Bash-it.
+
+**NOTE**\ : Keep in mind how Bash loads its configuration files,
+``.bash_profile`` for login shells (and in macOS in terminal emulators like `Terminal.app <http://www.apple.com/osx/apps/>`_ or
+`iTerm2 <https://www.iterm2.com/>`_\ ) and ``.bashrc`` for interactive shells (default mode in most of the GNU/Linux terminal emulators),
+to ensure that Bash-it is loaded correctly.
+A good "practice" is sourcing ``.bashrc`` into ``.bash_profile`` to keep things working in all the scenarios.
+To achieve this, you can add this snippet in your ``.bash_profile``\ :
+
+.. code-block::
+
+   if [ -f ~/.bashrc ]; then
+     . ~/.bashrc
+   fi
+
+Refer to the official `Bash documentation <https://www.gnu.org/software/bash/manual/bashref.html#Bash-Startup-Files>`_ to get more info.
+
+Install using Docker
+^^^^^^^^^^^^^^^^^^^^
+
+You can try Bash-it in an isolated environment without changing any local files via a `Docker <https://www.docker.com/>`_ Container.
+(Bash Shell v4.4 with Bash-it, `bats <https://github.com/sstephenson/bats>`_\ ,and bash-completion based on `Alpine Linux <https://alpinelinux.org/>`_\ ).
+
+``docker pull ellerbrock/bash-it``
+
+Have a look at our `bash-it-docker repository <https://github.com/Bash-it/bash-it-docker>`_ for further information.
+
+Updating
+^^^^^^^^
+
+See :ref:`update command <update>`.

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/misc.rst
+++ b/docs/misc.rst
@@ -1,0 +1,76 @@
+.. _misc:
+
+Misc
+----
+
+Help Screens
+^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   bash-it show aliases        # shows installed and available aliases
+   bash-it show completions    # shows installed and available completions
+   bash-it show plugins        # shows installed and available plugins
+   bash-it help aliases        # shows help for installed aliases
+   bash-it help completions    # shows help for installed completions
+   bash-it help plugins        # shows help for installed plugins
+
+Pass function renamed to passgen
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Bash-it ``pass`` function has been renamed to ``passgen`` in order to avoid a naming conflict with the `pass password manager <https://www.passwordstore.org/>`_.
+In order to minimize the impact on users of the legacy Bash-it ``pass`` function, Bash-it will create the alias ``pass`` that calls the new ``passgen`` function if the ``pass`` password manager command is not found on the ``PATH`` (default behavior).
+
+This behavior can be overridden with the ``BASH_IT_LEGACY_PASS`` flag as follows:
+
+Set ``BASH_IT_LEGACY_PASS`` to 'true' to force Bash-it to always **create** the ``pass`` alias to ``passgen``\ :
+
+
+* ``export BASH_IT_LEGACY_PASS=true``
+
+Unset ``BASH_IT_LEGACY_PASS`` to have Bash-it **return to default behavior**\ :
+
+
+* ``unset BASH_IT_LEGACY_PASS``
+
+Proxy Support
+^^^^^^^^^^^^^
+
+If you are working in a corporate environment where you have to go through a proxy server for internet access,
+then you know how painful it is to configure the OS proxy variables in the shell,
+especially if you are switching between environments, e.g. office (with proxy) and home (without proxy).
+
+The Bash shell (and many shell tools) use the following variables to define the proxy to use:
+
+
+* ``HTTP_PROXY`` (and ``http_proxy``\ ): Defines the proxy server for HTTP requests
+* ``HTTPS_PROXY`` (and ``https_proxy``\ ): Defines the proxy server for HTTPS requests
+* ``ALL_PROXY`` (and ``all_proxy``\ ): Used by some tools for the same purpose as above
+* ``NO_PROXY`` (and ``no_proxy``\ ): Comma-separated list of hostnames that don't have to go through the proxy
+
+Bash-it's ``proxy`` plugin allows to enable and disable these variables with a simple command.
+To start using the ``proxy`` plugin, run the following:
+
+.. code-block:: bash
+
+   bash-it enable plugin proxy
+
+Bash-it also provides support for enabling/disabling proxy settings for various shell tools.
+The following backends are currently supported (in addition to the shell's environment variables): Git, SVN, npm, ssh.
+The ``proxy`` plugin changes the configuration files of these tools to enable or disable the proxy settings.
+
+Bash-it uses the following variables to set the shell's proxy settings when you call ``enable-proxy``.
+These variables are best defined in a custom script in Bash-it's custom script folder (\ ``$BASH_IT/custom``\ ), e.g. ``$BASH_IT/custom/proxy.env.bash``
+
+
+* ``BASH_IT_HTTP_PROXY`` and `BASH_IT_HTTPS_PROXY`: Define the proxy URL to be used, e.g. 'http://localhost:1234'
+* ``BASH_IT_NO_PROXY``\ : A comma-separated list of proxy exclusions, e.g. ``127.0.0.1,localhost``
+
+Once you have defined these variables (and have run ``reload`` to load the changes), you can use the following commands to enable or disable the proxy settings in your current shell:
+
+
+* ``enable-proxy``\ : This sets the shell's proxy environment variables and configures proxy support in your SVN, npm, and SSH configuration files.
+* ``disable-proxy``\ : This unsets the shell's proxy environment variables and disables proxy support in your SVN, npm, and SSH configuration files.
+
+There are many more proxy commands, e.g. for changing the local Git project's proxy settings.
+Run ``glossary proxy`` to show the available proxy functions with a short description.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx == 3.2.1
+sphinx-rtd-theme==0.5.0

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -1,0 +1,46 @@
+.. _test:
+
+Testing Bash-it
+===============
+
+Overview
+--------
+
+The Bash-it unit tests leverage the `Bats unit test framework for Bash <https://github.com/bats-core/bats-core>`_.
+There is no need to install Bats explicitly, the test run script will automatically download and install Bats and its dependencies.
+
+When making changes to Bash-it, the tests are automatically executed in a test build environment on `Travis CI <https://travis-ci.com>`_.
+
+Test Execution
+--------------
+
+To execute the unit tests, please run the ``run`` script:
+
+.. code-block:: bash
+
+   # If you are in the `test` directory:
+   ./run
+
+   # If you are in the root `.bash_it` directory:
+   test/run
+
+The ``run`` script will automatically install if it is not already present, and will then run all tests found under the ``test`` directory, including subdirectories.
+
+To run only a subset of the tests, you can provide the name of the test subdirectory that you want to run, e.g. like this for the tests in the ``test/themes`` directory:
+
+.. code-block:: bash
+
+   # If you are in the root `.bash_it` directory:
+   test/run test/themes
+
+By default, the tests run in single-threaded mode.
+If you want to speed up the test execution, you can install the `GNU ``parallel`` tool <https://www.gnu.org/software/parallel/>`_\ , which is supported by Bats.
+When using ``parallel``\ , the ``test/run`` script will use a number of threads in parallel, depending on the available CPU cores of your system.
+This can speed up test execution significantly.
+
+Writing Tests
+-------------
+
+When adding or modifying tests, please stick to the format and conventions of the existing test cases.
+The ``test_helper.bash`` script provides a couple of reusable helper functions that you should use when writing a test case,
+for example for setting up an isolated test environment.

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -1,0 +1,35 @@
+.. _themes:
+
+Themes
+------
+
+There are over 50+ Bash-it themes to pick from in ``$BASH_IT/themes``.
+The default theme is ``bobby``.
+Set ``BASH_IT_THEME`` to the theme name you want, or if you've developed your own custom theme outside of ``$BASH_IT/themes``\ ,
+point the ``BASH_IT_THEME`` variable directly to the theme file.
+To disable theming completely, leave the variable empty.
+
+Examples:
+
+.. code-block:: bash
+
+   # Use the "powerline-multiline" theme
+   export BASH_IT_THEME="powerline-multiline"
+
+   # Use a theme outside of the Bash-it folder
+   export BASH_IT_THEME="/home/foo/my_theme/my_theme.theme.bash"
+
+   # Disable theming
+   export BASH_IT_THEME=""
+
+You can easily preview the themes in your own shell using ``BASH_PREVIEW=true bash-it reload``.
+
+If you've created your own custom prompts, we'd love it if you shared them with everyone else! Just submit a Pull Request.
+You can see theme screenshots on `wiki/Themes <https://github.com/Bash-it/bash-it/wiki/Themes>`_.
+
+**NOTE**\ : Bash-it and some themes use UTF-8 characters, so to avoid strange behavior in your terminal, set your locale to ``LC_ALL=en_US.UTF-8`` or the equivalent to your language if it isn't American English.
+
+Contributing a new theme
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+See the :ref:`instructions <contributing_theme>`.

--- a/docs/uninstalling.rst
+++ b/docs/uninstalling.rst
@@ -1,0 +1,14 @@
+.. _uninstalling:
+
+Uninstalling
+------------
+
+To uninstall Bash-it, run the ``uninstall.sh`` script found in the ``$BASH_IT`` directory:
+
+.. code-block::
+
+   cd $BASH_IT
+   ./uninstall.sh
+
+This will restore your previous Bash profile.
+After the uninstall script finishes, remove the Bash-it directory from your machine (\ ``rm -rf $BASH_IT``\ ) and start a new shell.

--- a/docs/vcs_user.rst
+++ b/docs/vcs_user.rst
@@ -28,6 +28,8 @@ It is possible for themes to ignore the ``SCM_CHECK`` flag and query specific ve
 For example, themes that use functions like ``git_prompt_vars`` skip the ``SCM_CHECK`` flag to retrieve and display git prompt information.
 If you turned version control checking off and you still see version control information within your prompt, then functions like ``git_prompt_vars`` are most likely the reason why.
 
+.. _git_prompt:
+
 Git prompt
 ^^^^^^^^^^
 

--- a/docs/vcs_user.rst
+++ b/docs/vcs_user.rst
@@ -1,0 +1,198 @@
+.. _vcs_user:
+
+Prompt Version Control Information
+==================================
+
+Bash-it provides prompt :ref:`themes` with the ability to check and display version control information for the current directory.
+The information is retrieved for each directory and can slow down the navigation of projects with a large number of files and folders.
+Turn version control checking off to prevent slow directory navigation within large projects.
+
+Controlling Flags
+^^^^^^^^^^^^^^^^^
+
+Bash-it provides a flag (\ ``SCM_CHECK``\ ) within the ``~/.bash_profile`` file that turns off/on version control information checking and display within all themes.
+Version control checking is on by default unless explicitly turned off.
+
+Set ``SCM_CHECK`` to 'false' to **turn off** version control checks for all themes:
+
+
+* ``export SCM_CHECK=false``
+
+Set ``SCM_CHECK`` to 'true' (the default value) to **turn on** version control checks for all themes:
+
+
+* ``export SCM_CHECK=true``
+
+**NOTE:**
+It is possible for themes to ignore the ``SCM_CHECK`` flag and query specific version control information directly.
+For example, themes that use functions like ``git_prompt_vars`` skip the ``SCM_CHECK`` flag to retrieve and display git prompt information.
+If you turned version control checking off and you still see version control information within your prompt, then functions like ``git_prompt_vars`` are most likely the reason why.
+
+Git prompt
+^^^^^^^^^^
+
+Bash-it has some nice features related to Git, continue reading to know more about these features.
+
+Repository info in the prompt
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bash-it can show some information about Git repositories in the shell prompt: the current branch, tag or commit you are at, how many commits the local branch is ahead or behind from the remote branch, and if you have changes stashed.
+
+Additionally, you can view the status of your working copy and get the count of *staged*\ , *unstaged* and *untracked* files.
+This feature is controlled through the flag ``SCM_GIT_SHOW_DETAILS`` as follows:
+
+Set ``SCM_GIT_SHOW_DETAILS`` to 'true' (the default value) to **show** the working copy details in your prompt:
+
+
+* ``export SCM_GIT_SHOW_DETAILS=true``
+
+Set ``SCM_GIT_SHOW_DETAILS`` to 'false' to **don't show** it:
+
+
+* ``export SCM_GIT_SHOW_DETAILS=false``
+
+**NOTE:** If using ``SCM_GIT_SHOW_MINIMAL_INFO=true``\ , then the value of ``SCM_GIT_SHOW_DETAILS`` is ignored.
+
+Remotes and remote branches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some git workflows, you must work with various remotes, for this reason, Bash-it can provide some useful information about your remotes and your remote branches, for example, the remote on you are working, or if your local branch is tracking a remote branch.
+
+You can control this feature with the flag ``SCM_GIT_SHOW_REMOTE_INFO`` as follows:
+
+Set ``SCM_GIT_SHOW_REMOTE_INFO`` to 'auto' (the default value) to activate it only when more than one remote is configured in the current repo:
+
+
+* ``export SCM_GIT_SHOW_REMOTE_INFO=auto``
+
+Set ``SCM_GIT_SHOW_REMOTE_INFO`` to 'true' to always activate the feature:
+
+
+* ``export SCM_GIT_SHOW_REMOTE_INFO=true``
+
+Set ``SCM_GIT_SHOW_REMOTE_INFO`` to 'false' to **disable the feature**\ :
+
+
+* ``export SCM_GIT_SHOW_REMOTE_INFO=false``
+
+**NOTE:** If using ``SCM_GIT_SHOW_MINIMAL_INFO=true``\ , then the value of ``SCM_GIT_SHOW_REMOTE_INFO`` is ignored.
+
+Untracked files
+^^^^^^^^^^^^^^^
+
+By default, the ``git status`` command shows information about *untracked* files.
+This behavior can be controlled through command-line flags or git configuration files.
+For big repositories, ignoring *untracked* files can make git faster.
+Bash-it uses ``git status`` to gather the repo information it shows in the prompt, so in some circumstances, it can be useful to instruct Bash-it to ignore these files.
+You can control this behavior with the flag ``SCM_GIT_IGNORE_UNTRACKED``\ :
+
+Set ``SCM_GIT_IGNORE_UNTRACKED`` to 'false' (the default value) to get information about *untracked* files:
+
+
+* ``export SCM_GIT_IGNORE_UNTRACKED=false``
+
+Set ``SCM_GIT_IGNORE_UNTRACKED`` to 'true' to **ignore** *untracked* files:
+
+
+* ``export SCM_GIT_IGNORE_UNTRACKED=true``
+
+Also, with this flag to false, Bash-it will not show the repository as dirty when the repo has *untracked* files, and will not display the count of *untracked* files.
+
+**NOTE:** If you set in git configuration file the option to ignore *untracked* files, this flag has no effect, and Bash-it will ignore *untracked* files always.
+
+Stash item count
+^^^^^^^^^^^^^^^^
+
+When ``SCM_GIT_SHOW_DETAILS`` is enabled, you can get the count of *stashed* items. This feature can be useful when a user has a lot of stash items.
+This feature is controlled through the flag ``SCM_GIT_SHOW_STASH_INFO`` as follows:
+
+Set ``SCM_GIT_SHOW_STASH_INFO`` to 'true' (the default value) to **show** the count of stashed items:
+
+
+* ``export SCM_GIT_SHOW_STASH_INFO=true``
+
+Set ``SCM_GIT_SHOW_STASH_INFO`` to 'false' to **don't show** it:
+
+
+* ``export SCM_GIT_SHOW_STASH_INFO=false``
+
+Ahead/Behind Count
+^^^^^^^^^^^^^^^^^^
+
+When displaying information regarding whether or not the local branch is ahead or behind its remote counterpart, you can opt to display the number of commits ahead/behind.
+This is useful if you only care whether or not you are ahead or behind and do not care how far ahead/behind you are.
+
+Set ``SCM_GIT_SHOW_COMMIT_COUNT`` to 'true' (the default value) to **show** the count of commits ahead/behind:
+
+
+* ``export SCM_GIT_SHOW_COMMIT_COUNT=true``
+
+Set ``SCM_GIT_SHOW_COMMIT_COUNT`` to 'false' to **don't show** it:
+
+
+* ``export SCM_GIT_SHOW_COMMIT_COUNT=false``
+
+Git user
+^^^^^^^^
+
+In some environments, it is useful to know the value of the current git user, which is used to mark all new commits.
+For example, any organization that uses the practice of pair programming will typically author each commit with `combined names of the two authors <https://github.com/pivotal/git_scripts>`_.
+When another pair uses the same pairing station, the authors are changed at the beginning of the session.
+
+To get up and running with this technique, run ``gem install pivotal_git_scripts``\ , and then edit your ``~/.pairs`` file, according to the specification on the `gem's homepage <https://github.com/pivotal/git_scripts>`_.
+After that, you should be able to run ``git pair kg as`` to set the author to, eg. "Konstantin Gredeskoul and Alex Saxby", assuming they've been added to the ``~/.pairs`` file.
+Please see gem's documentation for more information.
+
+To enable the display of the current pair in the prompt, you must set ``SCM_GIT_SHOW_CURRENT_USER`` to ``true``.
+Once set, the ``SCM_CURRENT_USER`` variable will be automatically populated with the initials of the git author(s).
+It will also be included in the default git prompt.
+Even if you do not have ``git pair`` installed, as long as your ``user.name`` is set, your initials will be computed from your name and shown in the prompt.
+
+You can control the prefix and the suffix of this component using the two variables:
+
+
+* ``export SCM_THEME_CURRENT_USER_PREFFIX=' ☺︎ '``
+
+And
+
+
+* ``export SCM_THEME_CURRENT_USER_SUFFIX=' ☺︎ '``
+
+**NOTE:** If using ``SCM_GIT_SHOW_MINIMAL_INFO=true``\ , then the value of ``SCM_GIT_SHOW_CURRENT_USER`` is ignored.
+
+Git show minimal status info
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To speed up the prompt while still getting minimal git status information displayed such as the value of ``HEAD`` and whether there are any dirty objects, you can set:
+
+.. code-block::
+
+   export SCM_GIT_SHOW_MINIMAL_INFO=true
+
+Ignore repo status
+^^^^^^^^^^^^^^^^^^
+
+When working in repos with a large codebase, Bash-it can slow down your prompt when checking the repo status.
+To avoid it, there is an option you can set via Git config to disable checking repo status in Bash-it.
+
+To disable checking the status in the current repo:
+
+.. code-block::
+
+   $ git config --add bash-it.hide-status 1
+
+But if you would like to disable it globally, and stop checking the status for all of your repos:
+
+.. code-block::
+
+   $ git config --global --add bash-it.hide-status 1
+
+Setting this flag globally has the same effect as ``SCM_CHECK=true``\ , but only for Git repos.
+
+Speed up git status calculations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As an alternative to ignoring repo status entirely, you can try out the ``gitstatus`` plugin.
+This plugin speeds up all ``git status`` calculations by up to 10x times!
+
+**NOTE**\ : You will need to clone ``gitstatus`` repo from `here <https://github.com/romkatv/gitstatus>`_.


### PR DESCRIPTION
Part of #1680 
I moved large parts of the documentation to `.rst` format, ready to be deployed to [readthedocs](https://readthedocs.org/)
[Here](https://my-bash-it.readthedocs.io/en/docs/) is a working example, based on my imported fork.

Some notes
- I did not change the documentation, only moved it to `rst` format.
- Some commands are still do not have docs (as I only ported the docs)
- We can now use auto-generation of some kind in order to generate some of the command docs
- In the [theme contribution docs](https://my-bash-it.readthedocs.io/en/docs/contributing/#contributing-theme) it is still suggested to update the wiki and create a `README.md`. We would want to move away from those solutions
- <del>There is no CI stage currently to check if the docs compile, and there should be one  
- <del>`README.md`, `DEVELOPMENT.md` and `CONTRIBUTING.md` are currently untouched, but they should be trimmed and mostly reference the docs hosted in rtd.
 

Lemme know what you guys think, and make sure to take a look at the docs I hosted. I am ready to put more hours into this! @tbhaxor @ahmadassaf @nwinkler @cornfeedhobo 