### PR TITLE
Moves lint logic into lint_clean_files.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
       GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt;
       curl https://pre-commit.com/install-local.py | python3 -
     script:
-      pre-commit run --files `cat clean_files.txt`;
+      ./lint_clean_files.sh;
 
   - <<: *native_job
     name: Ubuntu 16.04

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -1,1 +1,2 @@
+lint_clean_files.sh
 themes/90210/90210.theme.bash

--- a/lint_clean_files.sh
+++ b/lint_clean_files.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Pull list of checkable files from clean_files.txt
+#
+mapfile -t FILES < clean_files.txt
+
+pre-commit run --files "${FILES[@]}"


### PR DESCRIPTION
### Moves lint logic into lint_clean_files.sh

Moves the lint logic from `.travis.yml` into `lint_clean_files.sh`, updating travis to use it.

(open to a better name for the shell script)

This makes it easier to run the lint checks manually.

I added `lint_clean_files.sh` itself to `clean_files.txt` and fixed warnings accordingly.

Other than lint warnings/fixes, this PR contains the minimal changes for moving the lint check into a separate file.

I will save the addition of directory/comment support for a separate PR.

---

@NoahGorny you still around today?
