### PR TITLE
Adds manual pre-commit usage to docs/development.rst

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -116,8 +116,8 @@ the pre-commit script in the following manner:
 
     BASH_IT='' pre-commit
 
-Doing this will help the schellcheck checker identify source includes
-within your scripts that require a ``shellcheck sourc=`` directive.
+Doing this will help the shellcheck checker identify source includes
+within our scripts that require a ``source`` directive.
 
 Although not vital, these issues are likely to come up later within
 the CI pipeline.
@@ -127,4 +127,4 @@ Catching and fixing them before creating a PR could save some time.
 For more information:
 
 -  `Shellcheck SC1090 - Can't follow non-constant
-   source <https://www.shellcheck.net/wiki/SC1090>`__
+   source <https://www.shellcheck.net/wiki/SC1090>`_

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -116,11 +116,13 @@ the pre-commit script in the following manner:
 
     BASH_IT='' pre-commit
 
-| Doing this will help the schellcheck checker identify source includes
+Doing this will help the schellcheck checker identify source includes
 within your scripts that require a ``shellcheck sourc=`` directive.
-| Although not vital, these issues are likely to come up later within
+
+Although not vital, these issues are likely to come up later within
 the CI pipeline.
-| Catching and fixing them before creating a PR could save some time.
+
+Catching and fixing them before creating a PR could save some time.
 
 For more information:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -94,7 +94,7 @@ For the full use of the tool, you may need to install also other third-party too
 `shellcheck <https://github.com/koalaman/shellcheck/>`_ and `shfmt <https://github.com/mvdan/sh>`_.
 
 Running pre-commit manually
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 | Once configured, pre-commit will auto-run against staged files as part
 of the commit process.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -96,9 +96,10 @@ For the full use of the tool, you may need to install also other third-party too
 Running pre-commit manually
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-| Once configured, pre-commit will auto-run against staged files as part
+Once configured, pre-commit will auto-run against staged files as part
 of the commit process.
-| You can also run pre-commit manually to check staged files without
+
+You can also run pre-commit manually to check staged files without
 having to initiate a commit:
 
 ::

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -92,3 +92,36 @@ This file configures the behavior of the a pre-commit hook based on `the Pre-Com
 installing it (with pip, brew or other tools) then run ``pre-commit install`` in the repo's root to activate the hook.
 For the full use of the tool, you may need to install also other third-party tools, such as
 `shellcheck <https://github.com/koalaman/shellcheck/>`_ and `shfmt <https://github.com/mvdan/sh>`_.
+
+Running pre-commit manually
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+| Once configured, pre-commit will auto-run against staged files as part
+of the commit process.
+| You can also run pre-commit manually to check staged files without
+having to initiate a commit:
+
+::
+
+    $ pre-commit
+
+shellcheck and $BASH\_IT variable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When doing local development within a bash-it shell, it is best to run
+the pre-commit script in the following manner:
+
+::
+
+    BASH_IT='' pre-commit
+
+| Doing this will help the schellcheck checker identify source includes
+within your scripts that require a ``shellcheck sourc=`` directive.
+| Although not vital, these issues are likely to come up later within
+the CI pipeline.
+| Catching and fixing them before creating a PR could save some time.
+
+For more information:
+
+-  `Shellcheck SC1090 - Can't follow non-constant
+   source <https://www.shellcheck.net/wiki/SC1090>`__


### PR DESCRIPTION
### Adds manual pre-commit usage to docs/development.rst

Moves the previously-attempted update text into `docs/development.rst`.

#### Auto-Converted from MD content

This content was auto-converted from the previous `.md` file content using an online tool:
* https://cloudconvert.com/md-to-rst

I attempted to verify the correctness of the conversion as best I could, but there may be some formatting errors in here.