### PR TITLE
pre-commit: Exclude docs _build folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@
 ---
 # fail_fast: true
 minimum_pre_commit_version: 1.18.1
+exclude: "docs/_build/"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0


### PR DESCRIPTION
Now that #1698 is merged, the lint checks `docs/_build` folder, which is unnecessary﻿
