### PR TITLE
Prioritize nvm via env-var over brew-prefix

### DIFF
--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -9,12 +9,16 @@ about-plugin 'node version manager configuration'
 
 export NVM_DIR=${NVM_DIR:-$HOME/.nvm}
 # This loads nvm
-if command -v brew &>/dev/null && [ -s $(brew --prefix nvm)/nvm.sh ]
+if [ -s "$NVM_DIR/nvm.sh" ]
 then
-  . $(brew --prefix nvm)/nvm.sh
+  source "$NVM_DIR/nvm.sh"
 else
-  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+  if command -v brew &>/dev/null && [ -s $(brew --prefix nvm)/nvm.sh ]
+  then
+    source $(brew --prefix nvm)/nvm.sh
+  fi
 fi
+
 
 if ! command -v nvm &>/dev/null
 then


### PR DESCRIPTION
As the `brew --prefix nvm` takes up to 2.5s on my machine, 
we should favor finding the `nvm.sh` using the `$NVM_DIR` 
over using `brew --prefix` option.