### PR TITLE
docs: Add simple installation instructions to readme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
+[*.{md,rst}]
 trim_trailing_whitespace = false
 
 [.git*]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
 *.sh text eol=lf
 *.bash text eol=lf
 
+# Docs allow trailing whitespaces
+*.md whitespace=-blank-at-eol
+*.rst whitespace=-blank-at-eol
+
 # Windows files
 *.bat text eol=crlf

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: v2.3.0
     hooks:
       - id: trailing-whitespace
+        exclude: ".(md|rst)$"
       - id: end-of-file-fixer
       - id: check-merge-conflict
       - id: mixed-line-ending

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ Stop polluting your `~/bin` directory and your `.bashrc` file, fork/clone Bash-i
 
 - [Main Page](https://bash-it.readthedocs.io/en/latest)
 - [Contributing](#contributing)
-- [Installation](https://bash-it.readthedocs.io/en/latest/installation)
+- [Installation](#installation)
   - [Install Options](https://bash-it.readthedocs.io/en/latest/installation/#install-options)
   - [via Docker](https://bash-it.readthedocs.io/en/latest/installation/#install-using-docker)
   - [Updating](https://bash-it.readthedocs.io/en/latest/installation/#updating)
@@ -32,6 +32,17 @@ Stop polluting your `~/bin` directory and your `.bashrc` file, fork/clone Bash-i
 - [Misc](https://bash-it.readthedocs.io/en/latest/misc)
 - [Help Out](https://bash-it.readthedocs.io/en/latest/#help-out)
 - [Contributors](#contributors)
+
+## Installation
+
+1) Check out a clone of this repo to a location of your choice, such as
+   ``git clone --depth=1 https://github.com/Bash-it/bash-it.git ~/.bash_it``
+2) Run ``~/.bash_it/install.sh``
+
+Thats it! :smiley:  
+You can check out more components of Bash-it, and customize it to your desire.  
+For more information, see detailed instructions [here](https://bash-it.readthedocs.io/en/latest/installation/).
+
 
 ## Contributing
 


### PR DESCRIPTION
This will help newcomers, and not confuse them by redirecting them to
another site instantly. @cornfeedhobo I think you will like this :)
