### PR TITLE
Improved systemd aliases

### DIFF
--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -5,7 +5,7 @@ case $OSTYPE in
     linux*)
 	alias sc='systemctl'
 	alias scu='systemctl --user'
-	alias scd='systemctl daemon-reload'
+	alias scdr='systemctl daemon-reload'
 	alias scdu='systemctl --user daemon-reload'
 	alias scr='systemctl restart'
 	alias scru='systemctl --user restart'

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -4,12 +4,14 @@ about-alias 'systemd service'
 case $OSTYPE in
     linux*)
 	alias sc='systemctl'
-	alias scr='systemctl daemon-reload'
 	alias scu='systemctl --user'
-	alias scur='systemctl --user daemon-reload'
+	alias scd='systemctl daemon-reload'
+	alias scdu='systemctl --user daemon-reload'
+	alias scr='systemctl restart'
+	alias scru='systemctl --user restart'
 	alias sce='systemctl stop'
-	alias scue='systemctl --user stop'
+	alias sceu='systemctl --user stop'
 	alias scs='systemctl start'
-	alias scus='systemctl --user start'
+	alias scsu='systemctl --user start'
     ;;
 esac

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -17,6 +17,6 @@ case $OSTYPE in
 # Keeping previous aliases for a non-breaking change.
 	alias scue='systemctl --user stop'
 	alias scus='systemctl --user start'
-	alias scur='systemctl --user daemon-reload'
+	alias scur='scdru'
     ;;
 esac

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -13,5 +13,11 @@ case $OSTYPE in
 	alias sceu='systemctl --user stop'
 	alias scs='systemctl start'
 	alias scsu='systemctl --user start'
+	
+# Keeping previous aliases for a non-braking change.
+	alias scue='systemctl --user stop'
+	alias scus='systemctl --user start'
+	alias scr='systemctl daemon-reload'
+	alias scur='systemctl --user daemon-reload'
     ;;
 esac

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -3,6 +3,7 @@ about-alias 'systemd service'
 
 case $OSTYPE in
     linux*)
+# Improve aliases by bringing the common root `sc|scd` + `sre` for action + `u` for user
 	alias sc='systemctl'
 	alias scu='systemctl --user'
 	alias scdr='systemctl daemon-reload'

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -14,7 +14,6 @@ case $OSTYPE in
 	alias sceu='systemctl --user stop'
 	alias scs='systemctl start'
 	alias scsu='systemctl --user start'
-	
 # Keeping previous aliases for a non-braking change.
 	alias scue='systemctl --user stop'
 	alias scus='systemctl --user start'

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -14,7 +14,7 @@ case $OSTYPE in
 	alias sceu='systemctl --user stop'
 	alias scs='systemctl start'
 	alias scsu='systemctl --user start'
-# Keeping previous aliases for a non-braking change.
+# Keeping previous aliases for a non-breaking change.
 	alias scue='systemctl --user stop'
 	alias scus='systemctl --user start'
 	alias scr='systemctl daemon-reload'

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -16,7 +16,7 @@ case $OSTYPE in
 	alias scsu='systemctl --user start'
 # Keeping previous aliases for a non-breaking change.
 	alias scue='sceu'
-	alias scus='systemctl --user start'
+	alias scus='scsu'
 	alias scur='scdru'
     ;;
 esac

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -6,7 +6,7 @@ case $OSTYPE in
 	alias sc='systemctl'
 	alias scu='systemctl --user'
 	alias scdr='systemctl daemon-reload'
-	alias scdu='systemctl --user daemon-reload'
+	alias scdru='systemctl --user daemon-reload'
 	alias scr='systemctl restart'
 	alias scru='systemctl --user restart'
 	alias sce='systemctl stop'

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -17,7 +17,6 @@ case $OSTYPE in
 # Keeping previous aliases for a non-breaking change.
 	alias scue='systemctl --user stop'
 	alias scus='systemctl --user start'
-	alias scr='systemctl daemon-reload'
 	alias scur='systemctl --user daemon-reload'
     ;;
 esac

--- a/aliases/available/systemd.aliases.bash
+++ b/aliases/available/systemd.aliases.bash
@@ -15,7 +15,7 @@ case $OSTYPE in
 	alias scs='systemctl start'
 	alias scsu='systemctl --user start'
 # Keeping previous aliases for a non-breaking change.
-	alias scue='systemctl --user stop'
+	alias scue='sceu'
 	alias scus='systemctl --user start'
 	alias scur='scdru'
     ;;


### PR DESCRIPTION
Refactor naming
Add restart

<!--- Provide a general summary of your changes in the Title above -->

## Description
Systemd Aliases don't include restart.
I converted naming to be postfix-oriented.
As restart-daemon is always restart, then "r" is not semantic, I changed it to "d" for daemon.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better naming. Adds restart.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually via aliases I use in my Arch.

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
