### PR TITLE
test: alias-completion: Improve rm test by using function and not alias

### DIFF
--- a/test/plugins/alias-completion.plugin.bats
+++ b/test/plugins/alias-completion.plugin.bats
@@ -9,6 +9,13 @@ cite _about _param _example _group _author _version
 
 load ../../completion/available/capistrano.completion
 
+teardown() {
+  # Mostly for the hidden behind function test
+  unset -f rm
+
+  rm -f test.file
+}
+
 @test "alias-completion: See that aliases with double quotes and brackets do not break the plugin" {
   alias gtest="git log --graph --pretty=format:'%C(bold)%h%Creset%C(magenta)%d%Creset %s %C(yellow)<%an> %C(cyan)(%cr)%Creset' --abbrev-commit --date=relative"
   load ../../plugins/available/alias-completion.plugin
@@ -23,9 +30,13 @@ load ../../completion/available/capistrano.completion
   assert_success
 }
 
-@test "alias-completion: See that having aliased rm command does not output unnecessary output" {
-  alias rm='rm -v'
+@test "alias-completion: See that hidden behind function rm command does not change behavior" {
+  rm() {
+    touch test.file;
+    command rm "$@";
+  }
   load ../../plugins/available/alias-completion.plugin
 
-  refute_output
+  run stat test.file
+  assert_failure
 }


### PR DESCRIPTION
Improve the test I wrote in #1738

## Description
<!--- Describe your changes in detail -->
Uses a function rm instead of an alias to simulate a hidden command.
Adds a teardown function to address the changes I do in the test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test was not running properly, so I wanted to improve the coverage

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Removed the change 1c05d71, see that the test fail. Return the change, see that the test passes.
Also see that no artifacts remain

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
