### PR TITLE
refactor reloader.bash for better error handling

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -18,6 +18,7 @@
 #
 docs
 hooks
+scripts
 
 # root files
 #

--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -1,54 +1,80 @@
-#!/bin/bash
-BASH_IT_LOG_PREFIX="core: reloader: "
-pushd "${BASH_IT}" >/dev/null || exit 1
+# shellcheck shell=bash
+# shellcheck disable=SC1090,SC2221,SC2222,SC2145,SC2064
 
-function _set-prefix-based-on-path()
-{
-  filename=$(_bash-it-get-component-name-from-path "$1")
-  extension=$(_bash-it-get-component-type-from-path "$1")
-  BASH_IT_LOG_PREFIX="$extension: $filename: "
+BASH_IT_LOG_PREFIX="core: reloader: "
+pushd "${BASH_IT}" > /dev/null || exit 1
+
+_bash-it-load-sources() {
+	if [[ -z "$1" ]]; then
+		return 0
+	fi
+
+	local scripts current output retval
+
+	scripts=("$@")
+	current="${scripts[0]}"
+	scripts=("${scripts[@]:1}")
+
+	filename=$(_bash-it-get-component-name-from-path "$current")
+	extension=$(_bash-it-get-component-type-from-path "$current")
+	BASH_IT_LOG_PREFIX="$extension: $filename: "
+
+	if [[ -e $current ]]; then
+
+		_log_debug "Loading component..."
+		output=$(
+			set -e
+			(source "$current") 2>&1
+		)
+		retval=$?
+		set +e
+
+		trap "_bash-it-load-sources ${scripts[@]}" EXIT
+		if [[ $retval -gt 0 ]]; then
+			_log_error 'Loading component failed...'
+			if [[ -n "$output" ]]; then
+				while read -r line; do _log_error "$line"; done <<< "$output"
+			fi
+		else
+			_log_debug 'Loading component successful!'
+			source "$current"
+		fi
+		trap - EXIT
+
+	else
+		_log_error "Unable to read $current"
+	fi
+
+	_bash-it-load-sources "${scripts[@]}"
 }
 
-if [ "$1" != "skip" ] && [ -d "./enabled" ]; then
-  _bash_it_config_type=""
+if [[ "$1" != "skip" ]] && [[ -d "./enabled" ]]; then
+	_bash_it_config_type=""
 
-  case $1 in
-    alias|completion|plugin)
-      _bash_it_config_type=$1
-      _log_debug "Loading enabled $1 components..." ;;
-    *|'')
-      _log_debug "Loading all enabled components..." ;;
-  esac
+	case $1 in
+		alias | completion | plugin)
+			_bash_it_config_type=$1
+			_log_debug "Loading enabled $1 components..."
+			;;
+		* | '')
+			_log_debug "Loading all enabled components..."
+			;;
+	esac
 
-  for _bash_it_config_file in $(sort <(compgen -G "./enabled/*${_bash_it_config_type}.bash")); do
-    if [ -e "${_bash_it_config_file}" ]; then
-      _set-prefix-based-on-path "${_bash_it_config_file}"
-      _log_debug "Loading component..."
-      # shellcheck source=/dev/null
-      source $_bash_it_config_file
-    else
-      echo "Unable to read ${_bash_it_config_file}" > /dev/stderr
-    fi
-  done
+	# shellcheck disable=SC2046
+	_bash-it-load-sources $(sort <(compgen -G "./enabled/*${_bash_it_config_type}.bash"))
 fi
 
-if [ -n "${2}" ] && [ -d "${2}/enabled" ]; then
-  case $2 in
-    aliases|completion|plugins)
-      _log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
-      for _bash_it_config_file in $(sort <(compgen -G "./${2}/enabled/*.bash")); do
-        if [ -e "$_bash_it_config_file" ]; then
-          _set-prefix-based-on-path "${_bash_it_config_file}"
-          _log_debug "Loading component..."
-          # shellcheck source=/dev/null
-          source "$_bash_it_config_file"
-        else
-          echo "Unable to locate ${_bash_it_config_file}" > /dev/stderr
-        fi
-      done ;;
-  esac
+if [[ -n "${2}" ]] && [[ -d "${2}/enabled" ]]; then
+	case $2 in
+		aliases | completion | plugins)
+			_log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
+			# shellcheck disable=SC2046
+			_bash-it-load-sources $(sort <(compgen -G "./${2}/enabled/*.bash"))
+			;;
+	esac
 fi
 
 unset _bash_it_config_file
 unset _bash_it_config_type
-popd >/dev/null || exit 1
+popd > /dev/null || exit 1

--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -1,5 +1,4 @@
 # shellcheck shell=bash
-# shellcheck disable=SC1090,SC2221,SC2222,SC2145,SC2064
 
 BASH_IT_LOG_PREFIX="core: reloader: "
 pushd "${BASH_IT}" > /dev/null || exit 1
@@ -24,12 +23,13 @@ _bash-it-load-sources() {
 		_log_debug "Loading component..."
 		output=$(
 			set -e
+			# shellcheck disable=SC1090
 			(source "$current") 2>&1
 		)
 		retval=$?
 		set +e
 
-		trap "_bash-it-load-sources ${scripts[@]}" EXIT
+		trap '_bash-it-load-sources ${scripts[@]}' EXIT
 		if [[ $retval -gt 0 ]]; then
 			_log_error 'Loading component failed...'
 			if [[ -n "$output" ]]; then
@@ -37,6 +37,7 @@ _bash-it-load-sources() {
 			fi
 		else
 			_log_debug 'Loading component successful!'
+			# shellcheck disable=SC1090
 			source "$current"
 		fi
 		trap - EXIT
@@ -51,6 +52,7 @@ _bash-it-load-sources() {
 if [[ "$1" != "skip" ]] && [[ -d "./enabled" ]]; then
 	_bash_it_config_type=""
 
+	# shellcheck disable=SC2221,SC2222
 	case $1 in
 		alias | completion | plugin)
 			_bash_it_config_type=$1

--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -23,8 +23,10 @@ _bash-it-load-sources() {
 		_log_debug "Loading component..."
 		output=$(
 			set -e
+			BASH_IT_LOG_PREFIX=""
 			# shellcheck disable=SC1090
 			(source "$current") 2>&1
+			BASH_IT_LOG_PREFIX="$extension: $filename: "
 		)
 		retval=$?
 		set +e

--- a/test/bash_it/bash_it.bats
+++ b/test/bash_it/bash_it.bats
@@ -1,20 +1,10 @@
 #!/usr/bin/env bats
 
 load ../test_helper
-load ../../lib/composure
 
 function local_setup {
   setup_test_fixture
-
-  # Copy the test fixture to the Bash-it folder
-  if command -v rsync &> /dev/null
-  then
-    rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
-  else
-    find "$BASH_IT/test/fixtures/bash_it" \
-      -mindepth 1 -maxdepth 1 \
-      -exec cp -r {} "$BASH_IT/" \;
-  fi
+  copy_test_fixtures
 }
 
 @test "bash-it: verify that the test fixture is available" {

--- a/test/fixtures/bash_it/plugins/available/exit-nonzero.bash
+++ b/test/fixtures/bash_it/plugins/available/exit-nonzero.bash
@@ -1,0 +1,7 @@
+# shellcheck shell=bash
+about-plugin 'fixture plugin for testing plugins that exit with non-0 exit codes'
+
+printf 'exit-nonzero: stdout message\n'
+printf 'exit-nonzero: stderr message\n' >&2
+
+exit 123

--- a/test/fixtures/bash_it/plugins/available/exit-zero.bash
+++ b/test/fixtures/bash_it/plugins/available/exit-zero.bash
@@ -1,0 +1,7 @@
+# shellcheck shell=bash
+about-plugin 'fixture plugin for testing plugins that exit with a 0 exit code'
+
+printf 'exit-zero: stdout message\n'
+printf 'exit-zero: stderr message\n' >&2
+
+exit 0

--- a/test/fixtures/bash_it/plugins/available/return-nonzero.bash
+++ b/test/fixtures/bash_it/plugins/available/return-nonzero.bash
@@ -1,0 +1,7 @@
+# shellcheck shell=bash
+about-plugin 'fixture plugin for testing plugins that return with a non-0 return code'
+
+printf 'return-nonzero: stdout message\n'
+printf 'return-nonzero: stderr message\n' >&2
+
+return 123

--- a/test/fixtures/bash_it/plugins/available/return-zero.bash
+++ b/test/fixtures/bash_it/plugins/available/return-zero.bash
@@ -1,0 +1,7 @@
+# shellcheck shell=bash
+about-plugin 'fixture plugin for testing plugins that return with a 0 return code'
+
+printf 'return-zero: stdout message\n'
+printf 'return-zero: stderr message\n' >&2
+
+return 0

--- a/test/fixtures/bash_it/plugins/available/zz.plugin.bash
+++ b/test/fixtures/bash_it/plugins/available/zz.plugin.bash
@@ -1,0 +1,4 @@
+# shellcheck shell=bash
+about-plugin 'here to load last. a canary test for silent failures.'
+
+printf 'You found me!'

--- a/test/lib/reloader.bats
+++ b/test/lib/reloader.bats
@@ -1,0 +1,82 @@
+
+#!/usr/bin/env bats
+
+load ../test_helper
+
+function local_setup {
+  setup_test_fixture
+  copy_test_fixtures
+
+  # log everything to verify output
+  BASH_IT_LOG_LEVEL=3
+}
+
+@test "reloader: exit-nonzero" {
+  # use bash-it to enable the fixture
+  load "$BASH_IT/bash_it.sh"
+
+  run bash-it enable plugin exit-nonzero
+  assert_success
+
+  run bash-it enable plugin zz
+  assert_success
+
+  run source "${BASH_IT}/scripts/reloader.bash"
+  assert_success
+}
+
+@test "reloader: exit-zero" {
+  # use bash-it to enable the fixture
+  load "$BASH_IT/bash_it.sh"
+
+  run bash-it enable plugin exit-zero
+  assert_success
+
+  run bash-it enable plugin zz
+  assert_success
+
+  run source "${BASH_IT}/scripts/reloader.bash"
+  assert_success
+}
+
+@test "reloader: return-nonzero" {
+  # use bash-it to enable the fixture
+  load "$BASH_IT/bash_it.sh"
+
+  run bash-it enable plugin return-nonzero
+  assert_success
+
+  run bash-it enable plugin zz
+  assert_success
+
+  run source "${BASH_IT}/scripts/reloader.bash"
+  assert_success
+
+  assert_line 'DEBUG: bash: return-nonzero.bash: Loading component...'
+  assert_line 'return-nonzero: stdout message'
+  assert_line 'return-nonzero: stderr message'
+
+  assert_line 'DEBUG: plugin: zz: Loading component...'
+  assert_line 'You found me!'
+}
+
+@test "reloader: return-zero" {
+  # use bash-it to enable the fixture
+  load "$BASH_IT/bash_it.sh"
+
+  run bash-it enable plugin return-zero
+  assert_success
+
+  run bash-it enable plugin zz
+  assert_success
+
+  run source "${BASH_IT}/scripts/reloader.bash"
+  assert_success
+
+  assert_line 'DEBUG: bash: return-zero.bash: Loading component...'
+  assert_line 'return-zero: stdout message'
+  assert_line 'return-zero: stderr message'
+
+  assert_line 'DEBUG: plugin: zz: Loading component...'
+  assert_line 'You found me!'
+}

--- a/test/lib/reloader.bats
+++ b/test/lib/reloader.bats
@@ -23,6 +23,17 @@ function local_setup {
 
   run source "${BASH_IT}/scripts/reloader.bash"
   assert_success
+
+  # test that loading proceeds properly
+  assert_line 'DEBUG: plugin: zz: Loading component...'
+  assert_line 'DEBUG: plugin: zz: Loading component successful!'
+  assert_line 'You found me!'
+
+  # test that the expected plugin is acting as expected
+  assert_line 'DEBUG: bash: exit-nonzero.bash: Loading component...'
+  assert_line 'ERROR: bash: exit-nonzero.bash: Loading component failed...'
+  assert_line 'ERROR: bash: exit-nonzero.bash: exit-nonzero: stdout message'
+  assert_line 'ERROR: bash: exit-nonzero.bash: exit-nonzero: stderr message'
 }
 
 @test "reloader: exit-zero" {
@@ -37,6 +48,15 @@ function local_setup {
 
   run source "${BASH_IT}/scripts/reloader.bash"
   assert_success
+
+  assert_line 'DEBUG: plugin: zz: Loading component...'
+  assert_line 'DEBUG: plugin: zz: Loading component successful!'
+  assert_line 'You found me!'
+
+  assert_line 'DEBUG: bash: exit-zero.bash: Loading component...'
+  assert_line 'DEBUG: bash: exit-zero.bash: Loading component successful!'
+  assert_line 'exit-zero: stdout message'
+  assert_line 'exit-zero: stderr message'
 }
 
 @test "reloader: return-nonzero" {
@@ -52,12 +72,14 @@ function local_setup {
   run source "${BASH_IT}/scripts/reloader.bash"
   assert_success
 
-  assert_line 'DEBUG: bash: return-nonzero.bash: Loading component...'
-  assert_line 'return-nonzero: stdout message'
-  assert_line 'return-nonzero: stderr message'
-
   assert_line 'DEBUG: plugin: zz: Loading component...'
+  assert_line 'DEBUG: plugin: zz: Loading component successful!'
   assert_line 'You found me!'
+
+  assert_line 'DEBUG: bash: return-nonzero.bash: Loading component...'
+  assert_line 'ERROR: bash: return-nonzero.bash: Loading component failed...'
+  assert_line 'ERROR: bash: return-nonzero.bash: return-nonzero: stdout message'
+  assert_line 'ERROR: bash: return-nonzero.bash: return-nonzero: stderr message'
 }
 
 @test "reloader: return-zero" {
@@ -73,10 +95,12 @@ function local_setup {
   run source "${BASH_IT}/scripts/reloader.bash"
   assert_success
 
+  assert_line 'DEBUG: plugin: zz: Loading component...'
+  assert_line 'DEBUG: plugin: zz: Loading component successful!'
+  assert_line 'You found me!'
+
   assert_line 'DEBUG: bash: return-zero.bash: Loading component...'
+  assert_line 'DEBUG: bash: return-zero.bash: Loading component successful!'
   assert_line 'return-zero: stdout message'
   assert_line 'return-zero: stderr message'
-
-  assert_line 'DEBUG: plugin: zz: Loading component...'
-  assert_line 'You found me!'
 }

--- a/test/run
+++ b/test/run
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
+
 test_directory="$(cd "$(dirname "$0")" && pwd)"
 bats_executable="${test_directory}/../test_lib/bats-core/bin/bats"
 
 git submodule init && git submodule update
 
 if [ -z "${BASH_IT}" ]; then
-  declare BASH_IT
-  BASH_IT=$(cd ${test_directory} && dirname "$(pwd)")
-  export BASH_IT
+	declare BASH_IT
+	BASH_IT=$(cd "${test_directory}" && dirname "$(pwd)")
+	export BASH_IT
 fi
 
 if [ -z "$1" ]; then
-  test_dirs=( ${test_directory}/{bash_it,completion,install,lib,plugins,themes} )
+	test_dirs=("${test_directory}"/{bash_it,completion,install,lib,plugins,themes})
 else
-  test_dirs=( "$1" )
+	test_dirs=("$1")
 fi
 
 # Make sure that the `parallel` command is installed,
@@ -21,28 +22,24 @@ fi
 # If that is the case, try to guess the number of CPU cores,
 # so we can run `bats` in parallel processing mode, which is a lot faster.
 if command -v parallel &> /dev/null \
-  && parallel -V &> /dev/null \
-  && { parallel -V 2> /dev/null | grep -q '^GNU\>'; }
-then
-  # Expect to run at least on a dual-core CPU; slightly degraded performance
-  # shouldn't matter otherwise.
-  declare -i -r test_jobs_default=2
-  declare -i -r test_jobs_effective="$(
-    if [ "${TEST_JOBS:-detect}" = "detect" ] \
-      && command -v nproc &> /dev/null
-    then
-      nproc
-    elif [ -n "${TEST_JOBS}" ] \
-      && [ "${TEST_JOBS}" != "detect" ]
-    then
-      echo "${TEST_JOBS}"
-    else
-      echo ${test_jobs_default}
-    fi
-  )"
-  exec "$bats_executable" ${CI:+--tap} --jobs ${test_jobs_effective} \
-    "${test_dirs[@]}"
+	&& parallel -V &> /dev/null \
+	&& { parallel -V 2> /dev/null | grep -q '^GNU\>'; }; then
+	# Expect to run at least on a dual-core CPU; slightly degraded performance
+	# shouldn't matter otherwise.
+	declare -i -r test_jobs_default=2
+	declare -i -r test_jobs_effective="$(
+		if [ "${TEST_JOBS:-detect}" = "detect" ] \
+			&& command -v nproc &> /dev/null; then
+			nproc
+		elif [ -n "${TEST_JOBS}" ] \
+			&& [ "${TEST_JOBS}" != "detect" ]; then
+			echo "${TEST_JOBS}"
+		else
+			echo ${test_jobs_default}
+		fi
+	)"
+	exec "$bats_executable" ${CI:+--tap} --jobs "${test_jobs_effective}" "${test_dirs[@]}"
 else
-  # Run `bats` in single-threaded mode.
-  exec "$bats_executable" ${CI:+--tap} "${test_dirs[@]}"
+	# Run `bats` in single-threaded mode.
+	exec "$bats_executable" ${CI:+--tap} "${test_dirs[@]}"
 fi

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-load ../../lib/composure
 
 unset BASH_IT_THEME
 unset GIT_HOSTING
@@ -20,14 +19,16 @@ load "${TEST_DEPS_DIR}/bats-assert/load.bash"
 load "${TEST_DEPS_DIR}/bats-file/load.bash"
 
 # support 'plumbing' metadata
+load ../../lib/composure
 cite _about _param _example _group _author _version
+cite about-alias about-completion about-plugin
 
 local_setup() {
-  true
+	true
 }
 
 local_teardown() {
-  true
+	true
 }
 
 # This function sets up a local test fixture, i.e. a completely
@@ -35,71 +36,81 @@ local_teardown() {
 # messing with your own Bash-it source directory.
 # If you need this, call it in your .bats file's `local_setup` function.
 setup_test_fixture() {
-  mkdir -p "$BASH_IT"
-  lib_directory="$(cd "$(dirname "$0")" && pwd)"
-  local src_topdir="$lib_directory/../../../.."
+	mkdir -p "$BASH_IT"
+	lib_directory="$(cd "$(dirname "$0")" && pwd)"
+	local src_topdir="$lib_directory/../../../.."
 
-  if command -v rsync &> /dev/null
-  then
-    # Use rsync to copy Bash-it to the temp folder
-    rsync -qavrKL -d --delete-excluded --exclude=.git --exclude=enabled "$src_topdir" "$BASH_IT"
-  else
-    rm -rf "$BASH_IT"
-    mkdir -p "$BASH_IT"
+	if command -v rsync &> /dev/null; then
+		# Use rsync to copy Bash-it to the temp folder
+		rsync -qavrKL -d --delete-excluded --exclude=.git --exclude=enabled "$src_topdir" "$BASH_IT"
+	else
+		rm -rf "$BASH_IT"
+		mkdir -p "$BASH_IT"
 
-    find "$src_topdir" \
-      -mindepth 1 -maxdepth 1 \
-      -not -name .git \
-      -exec cp -r {} "$BASH_IT" \;
-  fi
+		find "$src_topdir" \
+			-mindepth 1 -maxdepth 1 \
+			-not -name .git \
+			-exec cp -r {} "$BASH_IT" \;
+	fi
 
-  rm -rf "$BASH_IT"/enabled
-  rm -rf "$BASH_IT"/aliases/enabled
-  rm -rf "$BASH_IT"/completion/enabled
-  rm -rf "$BASH_IT"/plugins/enabled
+	rm -rf "$BASH_IT"/enabled
+	rm -rf "$BASH_IT"/aliases/enabled
+	rm -rf "$BASH_IT"/completion/enabled
+	rm -rf "$BASH_IT"/plugins/enabled
 
-  mkdir -p "$BASH_IT"/enabled
-  mkdir -p "$BASH_IT"/aliases/enabled
-  mkdir -p "$BASH_IT"/completion/enabled
-  mkdir -p "$BASH_IT"/plugins/enabled
+	mkdir -p "$BASH_IT"/enabled
+	mkdir -p "$BASH_IT"/aliases/enabled
+	mkdir -p "$BASH_IT"/completion/enabled
+	mkdir -p "$BASH_IT"/plugins/enabled
 
-  # Some tests use the BASH_IT_TEST_HOME variable, e.g. install/uninstall
-  export BASH_IT_TEST_HOME="$TEST_TEMP_DIR"
+	# Some tests use the BASH_IT_TEST_HOME variable, e.g. install/uninstall
+	export BASH_IT_TEST_HOME="$TEST_TEMP_DIR"
+}
+
+copy_test_fixtures() {
+	# Copy the test fixture to the Bash-it folder
+	if command -v rsync &> /dev/null; then
+		rsync -qa "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
+	else
+		find "$BASH_IT/test/fixtures/bash_it" \
+			-mindepth 1 -maxdepth 1 \
+			-exec cp -r {} "$BASH_IT/" \;
+	fi
 }
 
 setup() {
-  # The `temp_make` function from "bats-file" requires the tralston/bats-file fork,
-  # since the original ztombol/bats-file's `temp_make` does not work on macOS.
-  TEST_TEMP_DIR="$(temp_make --prefix 'bash-it-test-')"
-  export TEST_TEMP_DIR
+	# The `temp_make` function from "bats-file" requires the tralston/bats-file fork,
+	# since the original ztombol/bats-file's `temp_make` does not work on macOS.
+	TEST_TEMP_DIR="$(temp_make --prefix 'bash-it-test-')"
+	export TEST_TEMP_DIR
 
-  export BASH_IT_TEST_DIR="${TEST_TEMP_DIR}/.bash_it"
+	export BASH_IT_TEST_DIR="${TEST_TEMP_DIR}/.bash_it"
 
-  export BASH_IT_ROOT="${BASH_IT_TEST_DIR}/root"
-  export BASH_IT=$BASH_IT_TEST_DIR
+	export BASH_IT_ROOT="${BASH_IT_TEST_DIR}/root"
+	export BASH_IT=$BASH_IT_TEST_DIR
 
-  mkdir -p -- "${BASH_IT_ROOT}"
+	mkdir -p -- "${BASH_IT_ROOT}"
 
-  # Some tools, e.g. `git` use configuration files from the $HOME directory,
-  # which interferes with our tests. The only way to keep `git` from doing this
-  # seems to set HOME explicitly to a separate location.
-  # Refer to https://git-scm.com/docs/git-config#FILES.
-  unset XDG_CONFIG_HOME
-  export HOME="${TEST_TEMP_DIR}"
-  mkdir -p "${HOME}"
+	# Some tools, e.g. `git` use configuration files from the $HOME directory,
+	# which interferes with our tests. The only way to keep `git` from doing this
+	# seems to set HOME explicitly to a separate location.
+	# Refer to https://git-scm.com/docs/git-config#FILES.
+	unset XDG_CONFIG_HOME
+	export HOME="${TEST_TEMP_DIR}"
+	mkdir -p "${HOME}"
 
-  # For `git` tests to run well, user name and email need to be set.
-  # Refer to https://git-scm.com/docs/git-commit#_commit_information.
-  # This goes to the test-specific config, due to the $HOME overridden above.
-  git config --global user.name "John Doe"
-  git config --global user.email "johndoe@example.com"
+	# For `git` tests to run well, user name and email need to be set.
+	# Refer to https://git-scm.com/docs/git-commit#_commit_information.
+	# This goes to the test-specific config, due to the $HOME overridden above.
+	git config --global user.name "John Doe"
+	git config --global user.email "johndoe@example.com"
 
-  local_setup
+	local_setup
 }
 
 teardown() {
-  local_teardown
+	local_teardown
 
-  rm -rf "${BASH_IT_TEST_DIR}"
-  temp_del "${TEST_TEMP_DIR}"
+	rm -rf "${BASH_IT_TEST_DIR}"
+	temp_del "${TEST_TEMP_DIR}"
 }


### PR DESCRIPTION
## Description

This PR seeks to:

- Apply linting for shfmt and shellcheck
- Ensure all tests use double bracket expansion (`[[]]`)
- Modify the loader loop to handle any scripts that may lead to an `exit`
    - This is done using recursion
    - Protects users from having a shell that unexpectedly exits before presenting a prompt
- **This approach has the side-effect of allowing plugin developers to not think about explicit `return`s**

_Devil's advocate:  It's possible that the complexity here isn't worth it. I think an alternate route could be to add an EXIT trap to `bash_it.sh` to short-circuit if a subshell leads to an `exit`, which would allow us to assume all plugins will only result in implicit or explicit `return`s, and reduce a lot of this complexity. I have not tested this idea though..._

## Motivation and Context

@NoahGorny asked about logging success conditions, and I said I'd rather centralize that. This addresses that, and more.

## How Has This Been Tested?

Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
