### PR TITLE
Add support to newer versions of sdkman

### DIFF
--- a/completion/available/sdkman.completion.bash
+++ b/completion/available/sdkman.completion.bash
@@ -6,33 +6,36 @@ _sdkman_complete()
   COMPREPLY=()
 
   if [ $COMP_CWORD -eq 1 ]; then
-    COMPREPLY=( $(compgen -W "install uninstall rm list ls use current outdated version default selfupdate broadcast offline help flush" -- ${COMP_WORDS[COMP_CWORD]}) )
+    COMPREPLY=( $(compgen -W "install uninstall rm list ls use default home env current upgrade ug version broadcast help offline selfupdate update flush" -- ${COMP_WORDS[COMP_CWORD]}) )
   elif [ $COMP_CWORD -eq 2 ]; then
     case "${COMP_WORDS[COMP_CWORD-1]}" in
-      "install" | "uninstall" | "rm" | "list" | "ls" | "use" | "current" | "outdated" )
+      "install" | "i" | "uninstall" | "rm" | "list" | "ls" | "use" | "u" | "default" | "d" | "home" | "h" | "current" | "c" | "upgrade" | "ug" )
         CANDIDATES=$(echo "${SDKMAN_CANDIDATES_CSV}" | tr ',' ' ')
         COMPREPLY=( $(compgen -W "$CANDIDATES" -- ${COMP_WORDS[COMP_CWORD]}) )
+        ;;
+      "env" )
+        COMPREPLY=( $(compgen -W "init" -- ${COMP_WORDS[COMP_CWORD]}) )
         ;;
       "offline" )
         COMPREPLY=( $(compgen -W "enable disable" -- ${COMP_WORDS[COMP_CWORD]}) )
         ;;
       "selfupdate" )
-        COMPREPLY=( $(compgen -W "force" -P "[" -S "]" -- ${COMP_WORDS[COMP_CWORD]}) )
+        COMPREPLY=( $(compgen -W "force" -- ${COMP_WORDS[COMP_CWORD]}) )
         ;;
       "flush" )
-        COMPREPLY=( $(compgen -W "candidates broadcast archives temp" -- ${COMP_WORDS[COMP_CWORD]}) )
+        COMPREPLY=( $(compgen -W "archives tmp broadcast version" -- ${COMP_WORDS[COMP_CWORD]}) )
         ;;
       *)
         ;;
     esac
   elif [ $COMP_CWORD -eq 3 ]; then
     case "${COMP_WORDS[COMP_CWORD-2]}" in
-      "uninstall" | "rm" | "use" | "default" )
-        _sdkman_candidate_versions ${COMP_WORDS[COMP_CWORD-1]}
+      "uninstall" | "rm" | "use" | "u" | "default" | "d" | "home" | "h" )
+        _sdkman_candidate_local_versions ${COMP_WORDS[COMP_CWORD-1]}
         COMPREPLY=( $(compgen -W "$CANDIDATE_VERSIONS" -- ${COMP_WORDS[COMP_CWORD]}) )
         ;;
-      "install")
-        _sdkman_candidate_not_installed_versions ${COMP_WORDS[COMP_CWORD-1]}
+      "install" | "i" )
+        _sdkman_candidate_all_versions ${COMP_WORDS[COMP_CWORD-1]}
         COMPREPLY=( $(compgen -W "$CANDIDATE_VERSIONS" -- ${COMP_WORDS[COMP_CWORD]}) )
         ;;
       *)
@@ -43,24 +46,22 @@ _sdkman_complete()
   return 0
 }
 
-_sdkman_candidate_versions(){
+_sdkman_candidate_local_versions(){
+
+  CANDIDATE_VERSIONS=$(__sdkman_cleanup_local_versions $1)
+
+}
+
+_sdkman_candidate_all_versions(){
 
   CANDIDATE_LOCAL_VERSIONS=$(__sdkman_cleanup_local_versions $1)
   if [ "$SDKMAN_OFFLINE_MODE" = "true" ]; then
     CANDIDATE_VERSIONS=$CANDIDATE_LOCAL_VERSIONS
   else
-    CANDIDATE_ONLINE_VERSIONS="$(curl -s "${SDKMAN_SERVICE}/candidates/$1" | tr ',' ' ')"
-    CANDIDATE_VERSIONS="$(echo $CANDIDATE_ONLINE_VERSIONS $CANDIDATE_LOCAL_VERSIONS |sort | uniq ) "
-  fi
-
-}
-
-_sdkman_candidate_not_installed_versions(){
-  CANDIDATE_LOCAL_VERSIONS=$(__sdkman_cleanup_local_versions $1)
-  if [ "$SDKMAN_OFFLINE_MODE" = "false" ]; then
-    CANDIDATE_ONLINE_VERSIONS="$(__sdkman_list_versions $1 | grep " " | grep "\." | cut -c 6-)"
+    CANDIDATE_ONLINE_VERSIONS="$(__sdkman_list_versions $1 | grep " " | grep "\." | cut -c 62-)"
     CANDIDATE_VERSIONS="$(echo $CANDIDATE_ONLINE_VERSIONS $CANDIDATE_LOCAL_VERSIONS | tr ' ' '\n' | sort | uniq -u) "
   fi
+
 }
 
 __sdkman_cleanup_local_versions(){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The sdkman CLI added new commands, command aliases, and changed some output formats. This pull request adapts the completion script to support such changes. These were all tested using sdkman `5.9.1`, but I suspect most of them were present in recent previous versions.

## Motivation and Context

Properly support newer versions of sdkman.

## How Has This Been Tested?

I've tested locally using sdkman `5.9.1` and with the following bash version:

```
GNU bash, version 5.1.0(1)-release (x86_64-apple-darwin20.1.0)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

Tested all the commands and validated that they are all working.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to change)

It is a breaking change in the sense that older versions of sdkman won't work.

## Checklist:

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
