### PR TITLE
ci: Remove macos-11.0 as it is unreliable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   bats-test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-10.15, macos-11.0]
+        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, macos-10.15]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
I am removing the macos-11 runner as it is crashing and causing us trouble

## Description
Removed the runner from our ci.yml, to address the runner issues

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This runner really caused us trouble by delaying builds and failing sometimes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
