### PR TITLE
Allow logic operators as newline operators

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,6 @@ indent_style = tab
 indent_size = 4
 
 shell_variant      = bash
-binary_next_line   = true  # like -bn
 switch_case_indent = true  # like -ci
 space_redirects    = true  # like -sr
 keep_padding       = true  # like -kp

--- a/completion/available/knife.completion.bash
+++ b/completion/available/knife.completion.bash
@@ -88,8 +88,8 @@ _KAC_clean_cache() {
 		_KAC_is_file_newer_than "$FILE" "$_KNIFE_AUTOCOMPLETE_MAX_CACHE_AGE" || rm -f "$FILE"
 	done
 	# refresh really stale caches
-	find "$_KNIFE_AUTOCOMPLETE_CACHE_DIR" -maxdepth 1 -type f -not -name '.*' \
-		| while read -r FILE; do
+	find "$_KNIFE_AUTOCOMPLETE_CACHE_DIR" -maxdepth 1 -type f -not -name '.*' |
+		while read -r FILE; do
 			_KAC_is_file_newer_than "$FILE" "$_KNIFE_AUTOCOMPLETE_MAX_CACHE_AGE" && continue
 			# first let's get the original command
 			CMD=$(_KAC_get_command_from_cache_name "$(basename "$FILE")")

--- a/lint_clean_files.sh
+++ b/lint_clean_files.sh
@@ -7,10 +7,10 @@
 #
 # shellcheck disable=SC2002  # Prefer 'cat' for cleaner script
 mapfile -t FILES < <(
-	cat clean_files.txt \
-		| grep -v -E '^\s*$' \
-		| grep -v -E '^\s*#' \
-		| xargs -n1 -I{} find "{}" -type f
+	cat clean_files.txt |
+		grep -v -E '^\s*$' |
+		grep -v -E '^\s*#' |
+		xargs -n1 -I{} find "{}" -type f
 )
 
 # We clear the BASH_IT variable to help the shellcheck checker


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes the config setting that forced logical operators to be at the start of newlines

## Motivation and Context

I noticed this the other day when I was linting and thought it was a bug, but it's our new editorconfig settings.

The POSIX grammar explains that [linebreaks are allowed after any and/or](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_10_02).

I think this is a more portable pattern and I'd like to push for it before we get too deep into the linting clean up.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
