### PR TITLE
Clean atomic and axin theme

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -30,6 +30,8 @@ themes/agnoster
 themes/90210
 themes/powerline
 themes/barbuk
+themes/atomic
+themes/axin
 
 # plugins
 #

--- a/themes/atomic/atomic.theme.bash
+++ b/themes/atomic/atomic.theme.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 # Atomic Bash Prompt for Bash-it
 # By lfelipe base on the theme brainy of MunifTanjim
@@ -28,79 +28,79 @@ Face="\342\230\273"
 #############
 
 ____atomic_top_left_parse() {
-  ifs_old="${IFS}"
-  IFS="|"
-  args=( $1 )
-  IFS="${ifs_old}"
-  if [ -n "${args[3]}" ]; then
-    _TOP_LEFT+="${args[2]}${args[3]}"
-  fi
-  _TOP_LEFT+="${args[0]}${args[1]}"
-  if [ -n "${args[4]}" ]; then
-    _TOP_LEFT+="${args[2]}${args[4]}"
-  fi
-  _TOP_LEFT+=""
+	ifs_old="${IFS}"
+	IFS="|"
+	read -r -a args <<< "$@"
+	IFS="${ifs_old}"
+	if [ -n "${args[3]}" ]; then
+		_TOP_LEFT+="${args[2]}${args[3]}"
+	fi
+	_TOP_LEFT+="${args[0]}${args[1]}"
+	if [ -n "${args[4]}" ]; then
+		_TOP_LEFT+="${args[2]}${args[4]}"
+	fi
+	_TOP_LEFT+=""
 }
 
 ____atomic_top_right_parse() {
-  ifs_old="${IFS}"
-  IFS="|"
-  args=( $1 )
-  IFS="${ifs_old}"
-  _TOP_RIGHT+=" "
-  if [ -n "${args[3]}" ]; then
-    _TOP_RIGHT+="${args[2]}${args[3]}"
-  fi
-  _TOP_RIGHT+="${args[0]}${args[1]}"
-  if [ -n "${args[4]}" ]; then
-    _TOP_RIGHT+="${args[2]}${args[4]}"
-  fi
-  __TOP_RIGHT_LEN=$(( __TOP_RIGHT_LEN + ${#args[1]} + ${#args[3]} + ${#args[4]} + 1 ))
-  (( __SEG_AT_RIGHT += 1 ))
+	ifs_old="${IFS}"
+	IFS="|"
+	read -r -a args <<< "$@"
+	IFS="${ifs_old}"
+	_TOP_RIGHT+=" "
+	if [ -n "${args[3]}" ]; then
+		_TOP_RIGHT+="${args[2]}${args[3]}"
+	fi
+	_TOP_RIGHT+="${args[0]}${args[1]}"
+	if [ -n "${args[4]}" ]; then
+		_TOP_RIGHT+="${args[2]}${args[4]}"
+	fi
+	__TOP_RIGHT_LEN=$((__TOP_RIGHT_LEN + ${#args[1]} + ${#args[3]} + ${#args[4]} + 1))
+	((__SEG_AT_RIGHT += 1))
 }
 
 ____atomic_bottom_parse() {
-  ifs_old="${IFS}"
-  IFS="|"
-  args=( $1 )
-  IFS="${ifs_old}"
-  _BOTTOM+="${args[0]}${args[1]}"
-  [ ${#args[1]} -gt 0 ] && _BOTTOM+=" "
+	ifs_old="${IFS}"
+	IFS="|"
+	read -r -a args <<< "$@"
+	IFS="${ifs_old}"
+	_BOTTOM+="${args[0]}${args[1]}"
+	[ ${#args[1]} -gt 0 ] && _BOTTOM+=" "
 }
 
 ____atomic_top() {
-  _TOP_LEFT=""
-  _TOP_RIGHT=""
-  __TOP_RIGHT_LEN=0
-  __SEG_AT_RIGHT=0
+	_TOP_LEFT=""
+	_TOP_RIGHT=""
+	__TOP_RIGHT_LEN=0
+	__SEG_AT_RIGHT=0
 
-  for seg in ${___ATOMIC_TOP_LEFT}; do
-    info="$(___atomic_prompt_"${seg}")"
-    [ -n "${info}" ] && ____atomic_top_left_parse "${info}"
-  done
+	for seg in ${___ATOMIC_TOP_LEFT}; do
+		info="$(___atomic_prompt_"${seg}")"
+		[ -n "${info}" ] && ____atomic_top_left_parse "${info}"
+	done
 
-  ___cursor_right="\e[500C"
-  _TOP_LEFT+="${___cursor_right}"
+	___cursor_right="\e[500C"
+	_TOP_LEFT+="${___cursor_right}"
 
-  for seg in ${___ATOMIC_TOP_RIGHT}; do
-    info="$(___atomic_prompt_"${seg}")"
-    [ -n "${info}" ] && ____atomic_top_right_parse "${info}"
-  done
+	for seg in ${___ATOMIC_TOP_RIGHT}; do
+		info="$(___atomic_prompt_"${seg}")"
+		[ -n "${info}" ] && ____atomic_top_right_parse "${info}"
+	done
 
-  [ $__TOP_RIGHT_LEN -gt 0 ] && __TOP_RIGHT_LEN=$(( __TOP_RIGHT_LEN - 0 ))
-  ___cursor_adjust="\e[${__TOP_RIGHT_LEN}D"
-  _TOP_LEFT+="${___cursor_adjust}"
+	[ $__TOP_RIGHT_LEN -gt 0 ] && __TOP_RIGHT_LEN=$((__TOP_RIGHT_LEN - 0))
+	___cursor_adjust="\e[${__TOP_RIGHT_LEN}D"
+	_TOP_LEFT+="${___cursor_adjust}"
 
-  printf "%s%s" "${_TOP_LEFT}" "${_TOP_RIGHT}"
+	printf "%s%s" "${_TOP_LEFT}" "${_TOP_RIGHT}"
 }
 
 ____atomic_bottom() {
-  _BOTTOM=""
-  for seg in $___ATOMIC_BOTTOM; do
-    info="$(___atomic_prompt_"${seg}")"
-    [ -n "${info}" ] && ____atomic_bottom_parse "${info}"
-  done
-  printf "\n%s" "${_BOTTOM}"
+	_BOTTOM=""
+	for seg in $___ATOMIC_BOTTOM; do
+		info="$(___atomic_prompt_"${seg}")"
+		[ -n "${info}" ] && ____atomic_bottom_parse "${info}"
+	done
+	printf "\n%s" "${_BOTTOM}"
 }
 
 ##############
@@ -108,97 +108,97 @@ ____atomic_bottom() {
 ##############
 
 ___atomic_prompt_user_info() {
-  color=$white
-  box="${normal}${LineA}\$([[ \$? != 0 ]] && echo \"${BIWhite}[${IRed}${SX}${BIWhite}]${normal}${Line}\")${Line}${BIWhite}[|${BIWhite}]${normal}${Line}"
-  info="${IYellow}\u${IRed}@${IGreen}\h"
+	color=$white
+	box="${normal}${LineA}\$([[ \$? != 0 ]] && echo \"${BIWhite}[${IRed}${SX}${BIWhite}]${normal}${Line}\")${Line}${BIWhite}[|${BIWhite}]${normal}${Line}"
+	info="${IYellow}\u${IRed}@${IGreen}\h"
 
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${white}" "${box}"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${white}" "${box}"
 }
 
 ___atomic_prompt_dir() {
-  color=${IRed}
-  box="[|]${normal}"
-  info="\w"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
+	color=${IRed}
+	box="[|]${normal}"
+	info="\w"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
 }
 
 ___atomic_prompt_scm() {
-  [ "${THEME_SHOW_SCM}" != "true" ] && return
-  color=$bold_green
-  box="${Line}[${IWhite}$(scm_char)] "
-  info="$(scm_prompt_info)"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
+	[ "${THEME_SHOW_SCM}" != "true" ] && return
+	color=$bold_green
+	box="${Line}[${IWhite}$(scm_char)] "
+	info="$(scm_prompt_info)"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
 }
 
 ___atomic_prompt_python() {
-  [ "${THEME_SHOW_PYTHON}" != "true" ] && return
-  color=$bold_yellow
-  box="[|]"
-  info="$(python_version_prompt)"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_blue}" "${box}"
+	[ "${THEME_SHOW_PYTHON}" != "true" ] && return
+	color=$bold_yellow
+	box="[|]"
+	info="$(python_version_prompt)"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_blue}" "${box}"
 }
 
 ___atomic_prompt_ruby() {
-  [ "${THEME_SHOW_RUBY}" != "true" ] && return
-  color=$bold_white
-  box="[|]"
-  info="rb-$(ruby_version_prompt)"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_red}" "${box}"
+	[ "${THEME_SHOW_RUBY}" != "true" ] && return
+	color=$bold_white
+	box="[|]"
+	info="rb-$(ruby_version_prompt)"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_red}" "${box}"
 }
 
 ___atomic_prompt_todo() {
-  [ "${THEME_SHOW_TODO}" != "true" ] ||
-  [ -z "$(which todo.sh)" ] && return
-  color=$bold_white
-  box="[|]"
-  info="t:$(todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+)" | awk '{ print $4 }' )"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_green}" "${box}"
+	[ "${THEME_SHOW_TODO}" != "true" ] \
+		|| [ -z "$(which todo.sh)" ] && return
+	color=$bold_white
+	box="[|]"
+	info="t:$(todo.sh ls | grep -E "TODO: [0-9]+ of ([0-9]+)" | awk '{ print $4 }')"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_green}" "${box}"
 }
 
 ___atomic_prompt_clock() {
-  [ "${THEME_SHOW_CLOCK}" != "true" ] && return
-  color=$THEME_CLOCK_COLOR
-  box="[|]"
-  info="$(date +"${THEME_CLOCK_FORMAT}")"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
+	[ "${THEME_SHOW_CLOCK}" != "true" ] && return
+	color=$THEME_CLOCK_COLOR
+	box="[|]"
+	info="$(date +"${THEME_CLOCK_FORMAT}")"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
 }
 
 ___atomic_prompt_battery() {
-  ! _command_exists battery_percentage ||
-  [ "${THEME_SHOW_BATTERY}" != "true" ] ||
-  [ "$(battery_percentage)" = "no" ] && return
+	! _command_exists battery_percentage \
+		|| [ "${THEME_SHOW_BATTERY}" != "true" ] \
+		|| [ "$(battery_percentage)" = "no" ] && return
 
-  batp=$(battery_percentage)
-  if [ "$batp" -eq 50 ] || [ "$batp" -gt 50 ]; then
-    color=$bold_green
-    elif [ "$batp" -lt 50 ] && [ "$batp" -gt 25 ]; then
-    color=$bold_yellow
-    elif [ "$batp" -eq 25 ] || [ "$batp" -lt 25 ]; then
-    color=$IRed
-  fi
-  box="[|]"
-  ac_adapter_connected && info="+"
-  ac_adapter_disconnected && info="-"
-  info+=$batp
-  [ "$batp" -eq 100 ] || [ "$batp" -gt 100 ] && info="AC"
-  printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
+	batp=$(battery_percentage)
+	if [ "$batp" -eq 50 ] || [ "$batp" -gt 50 ]; then
+		color=$bold_green
+	elif [ "$batp" -lt 50 ] && [ "$batp" -gt 25 ]; then
+		color=$bold_yellow
+	elif [ "$batp" -eq 25 ] || [ "$batp" -lt 25 ]; then
+		color=$IRed
+	fi
+	box="[|]"
+	ac_adapter_connected && info="+"
+	ac_adapter_disconnected && info="-"
+	info+=$batp
+	[ "$batp" -eq 100 ] || [ "$batp" -gt 100 ] && info="AC"
+	printf "%s|%s|%s|%s" "${color}" "${info}" "${bold_white}" "${box}"
 }
 
 ___atomic_prompt_exitcode() {
-  [ "${THEME_SHOW_EXITCODE}" != "true" ] && return
-  color=$bold_purple
-  [ "$exitcode" -ne 0 ] && printf "%s|%s" "${color}" "${exitcode}"
+	[ "${THEME_SHOW_EXITCODE}" != "true" ] && return
+	color=$bold_purple
+	[ "$exitcode" -ne 0 ] && printf "%s|%s" "${color}" "${exitcode}"
 }
 
 ___atomic_prompt_char() {
-  color=$white
-  prompt_char="${__ATOMIC_PROMPT_CHAR_PS1}"
-  if [ "${THEME_SHOW_SUDO}" == "true" ]; then
-    if sudo -vn 1>/dev/null 2>&1; then
-      prompt_char="${__ATOMIC_PROMPT_CHAR_PS1_SUDO}"
-    fi
-  fi
-  printf "%s|%s" "${color}" "${prompt_char}"
+	color=$white
+	prompt_char="${__ATOMIC_PROMPT_CHAR_PS1}"
+	if [ "${THEME_SHOW_SUDO}" == "true" ]; then
+		if sudo -vn 1> /dev/null 2>&1; then
+			prompt_char="${__ATOMIC_PROMPT_CHAR_PS1_SUDO}"
+		fi
+	fi
+	printf "%s|%s" "${color}" "${prompt_char}"
 }
 
 #########
@@ -206,54 +206,56 @@ ___atomic_prompt_char() {
 #########
 
 __atomic_show() {
-  typeset _seg=${1:-}
-  shift
-  export THEME_SHOW_${_seg}=true
+	typeset _seg=${1:-}
+	shift
+	export "THEME_SHOW_${_seg}"=true
 }
 
 __atomic_hide() {
-  typeset _seg=${1:-}
-  shift
-  export THEME_SHOW_${_seg}=false
+	typeset _seg=${1:-}
+	shift
+	export "THEME_SHOW_${_seg}"=false
 }
 
 _atomic_completion() {
-  local cur _action actions segments
-  COMPREPLY=()
-  cur="${COMP_WORDS[COMP_CWORD]}"
-  _action="${COMP_WORDS[1]}"
-  actions="show hide"
-  segments="battery clock exitcode python ruby scm sudo todo"
-  case "${_action}" in
-    show)
-      COMPREPLY=( $(compgen -W "${segments}" -- "${cur}") )
-      return 0
-    ;;
-    hide)
-      COMPREPLY=( $(compgen -W "${segments}" -- "${cur}") )
-      return 0
-    ;;
-  esac
+	local cur _action actions segments
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	_action="${COMP_WORDS[1]}"
+	actions="show hide"
+	segments="battery clock exitcode python ruby scm sudo todo"
+	case "${_action}" in
+		show)
+			read -r -a COMPREPLY <<< "$(compgen -W "${segments}" -- "${cur}")"
+			return 0
+			;;
+		hide)
+			read -r -a COMPREPLY <<< "$(compgen -W "${segments}" -- "${cur}")"
+			return 0
+			;;
+	esac
 
-  COMPREPLY=( $(compgen -W "${actions}" -- "${cur}") )
-  return 0
+	read -r -a COMPREPLY <<< "$(compgen -W "${actions}" -- "${cur}")"
+	return 0
 }
 
 atomic() {
-  typeset action=${1:-}
-  shift
-  typeset segs=${*:-}
-  typeset func
-  case $action in
-    show)
-    func=__atomic_show;;
-    hide)
-    func=__atomic_hide;;
-  esac
-  for seg in ${segs}; do
-    seg=$(printf "%s" "${seg}" | tr '[:lower:]' '[:upper:]')
-    $func "${seg}"
-  done
+	typeset action=${1:-}
+	shift
+	typeset segs=${*:-}
+	typeset func
+	case $action in
+		show)
+			func=__atomic_show
+			;;
+		hide)
+			func=__atomic_hide
+			;;
+	esac
+	for seg in ${segs}; do
+		seg=$(printf "%s" "${seg}" | tr '[:lower:]' '[:upper:]')
+		$func "${seg}"
+	done
 }
 
 complete -F _atomic_completion atomic
@@ -302,19 +304,19 @@ ___ATOMIC_BOTTOM=${___ATOMIC_BOTTOM:-"char"}
 ############
 
 __atomic_ps1() {
-  printf "%s%s%s" "$(____atomic_top)" "$(____atomic_bottom)" "${normal}"
+	printf "%s%s%s" "$(____atomic_top)" "$(____atomic_bottom)" "${normal}"
 }
 
 __atomic_ps2() {
-  color=$bold_white
-  printf "%s%s%s" "${color}" "${__ATOMIC_PROMPT_CHAR_PS2}  " "${normal}"
+	color=$bold_white
+	printf "%s%s%s" "${color}" "${__ATOMIC_PROMPT_CHAR_PS2}  " "${normal}"
 }
 
 _atomic_prompt() {
-  exitcode="$?"
+	exitcode="$?"
 
-  PS1="$(__atomic_ps1)"
-  PS2="$(__atomic_ps2)"
+	PS1="$(__atomic_ps1)"
+	PS2="$(__atomic_ps2)"
 }
 
 safe_append_prompt_command _atomic_prompt

--- a/themes/axin/axin.theme.bash
+++ b/themes/axin/axin.theme.bash
@@ -1,36 +1,36 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 # Axin Bash Prompt, inspired by theme "Sexy" and "Bobby"
 # thanks to them
 
 if tput setaf 1 &> /dev/null; then
-    if [[ $(tput colors) -ge 256 ]] 2>/dev/null; then
-      MAGENTA=$(tput setaf 9)
-      ORANGE=$(tput setaf 172)
-      GREEN=$(tput setaf 190)
-      PURPLE=$(tput setaf 141)
-      WHITE=$(tput setaf 0)
-    else
-      MAGENTA=$(tput setaf 5)
-      ORANGE=$(tput setaf 4)
-      GREEN=$(tput setaf 2)
-      PURPLE=$(tput setaf 1)
-      WHITE=$(tput setaf 7)
-    fi
-    BOLD=$(tput bold)
-    RESET=$(tput sgr0)
+	if [[ $(tput colors) -ge 256 ]] 2> /dev/null; then
+		MAGENTA=$(tput setaf 9)
+		ORANGE=$(tput setaf 172)
+		GREEN=$(tput setaf 190)
+		PURPLE=$(tput setaf 141)
+		WHITE=$(tput setaf 0)
+	else
+		MAGENTA=$(tput setaf 5)
+		ORANGE=$(tput setaf 4)
+		GREEN=$(tput setaf 2)
+		PURPLE=$(tput setaf 1)
+		WHITE=$(tput setaf 7)
+	fi
+	BOLD=$(tput bold)
+	RESET=$(tput sgr0)
 else
-    MAGENTA="\033[1;31m"
-    ORANGE="\033[1;33m"
-    GREEN="\033[1;32m"
-    PURPLE="\033[1;35m"
-    WHITE="\033[1;37m"
-    BOLD=""
-    RESET="\033[m"
+	MAGENTA="\033[1;31m"
+	ORANGE="\033[1;33m"
+	GREEN="\033[1;32m"
+	PURPLE="\033[1;35m"
+	WHITE="\033[1;37m"
+	BOLD=""
+	RESET="\033[m"
 fi
 
 function prompt_command() {
-  PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]@ \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\[$SCM_THEME_PROMPT_PREFIX\]$(clock_prompt) \[$PURPLE\]$(scm_prompt_info) \n\$ \[$RESET\]"
+	PS1="\[${BOLD}${MAGENTA}\]\u \[$WHITE\]@ \[$ORANGE\]\h \[$WHITE\]in \[$GREEN\]\w\[$WHITE\]\[$SCM_THEME_PROMPT_PREFIX\]$(clock_prompt) \[$PURPLE\]$(scm_prompt_info) \n\$ \[$RESET\]"
 }
 
 THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"${white}"}


### PR DESCRIPTION
## Description

 - axin theme was just linted
 - atomic theme needed an update of the args parsing in internal function to be compliant with shellcheck:
 
 ```bash
 args=($1)
 ```

become

 ```bash
read -r -a args <<< "$@"
 ```

## Motivation and Context

https://github.com/Bash-it/bash-it/issues/1696

## How Has This Been Tested?

Tested both theme by using before and after the update

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.