### PR TITLE
Support multiple sdkman output formats

### DIFF
--- a/completion/available/sdkman.completion.bash
+++ b/completion/available/sdkman.completion.bash
@@ -59,8 +59,18 @@ _sdkman_candidate_all_versions() {
 	if [ "$SDKMAN_OFFLINE_MODE" = "true" ]; then
 		CANDIDATE_VERSIONS=$CANDIDATE_LOCAL_VERSIONS
 	else
-		CANDIDATE_ONLINE_VERSIONS="$(__sdkman_list_versions "$1" | grep " " | grep "\." | cut -c 62-)"
-		CANDIDATE_VERSIONS="$(echo "$CANDIDATE_ONLINE_VERSIONS $CANDIDATE_LOCAL_VERSIONS" | tr ' ' '\n' | sort | uniq -u) "
+		# sdkman has a specific output format for Java candidate since
+		# there are multiple vendors and builds.
+		if [ "$candidate" = "java" ]; then
+			CANDIDATE_ONLINE_VERSIONS="$(__sdkman_list_versions "$candidate" | grep " " | grep "\." | cut -c 62-)"
+		else
+			CANDIDATE_ONLINE_VERSIONS="$(__sdkman_list_versions "$candidate" | grep " " | grep "\." | cut -c 6-)"
+		fi
+		# the last grep is used to filter out sdkman flags, such as:
+		# "+" - local version
+		# "*" - installed
+		# ">" - currently in use
+		CANDIDATE_VERSIONS="$(echo "$CANDIDATE_ONLINE_VERSIONS $CANDIDATE_LOCAL_VERSIONS" | tr ' ' '\n' | grep -v -e '^[[:space:]|\*|\>|\+]*$' | sort | uniq -u) "
 	fi
 
 }


### PR DESCRIPTION
## Description

sdkman has a specific output format for Java candidate since
there are multiple vendors and builds. For example, when running
`sdk list maven`, the format is a simple list like:

    3.6.2
    3.6.1
    3.6.0
    3.5.4
    3.5.3
    3.5.2
    3.5.0
    3.3.9

But for `sbt list java`, the output is a table like:

    ================================================================================
     Vendor        | Use | Version      | Dist    | Status     | Identifier
    --------------------------------------------------------------------------------
     AdoptOpenJDK  |     | 15.0.1.j9    | adpt    |            | 15.0.1.j9-adpt
                   |     | 15.0.1.hs    | adpt    | installed  | 15.0.1.hs-adpt
     ...
     Amazon        |     | 15.0.1       | amzn    |            | 15.0.1-amzn
                   |     | 11.0.9       | amzn    |            | 11.0.9-amzn
     ...
     Azul Zulu     |     | 15.0.1       | zulu    |            | 15.0.1-zulu
                   |     | 15.0.1.fx    | zulu    |            | 15.0.1.fx-zulu
     ...

Therefore, the completion script has to handle both formats.


## Motivation and Context

Fix the parsing of different outputs provided by sdkman.

## How Has This Been Tested?

Manually against all possible packages that sdkman manages (for most of them I've just checked the output is consistent with each other. `java` is the only exception.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
