### PR TITLE
added completion for notify-send command

### DIFF
--- a/completion/available/notify-send.completion.bash
+++ b/completion/available/notify-send.completion.bash
@@ -1,0 +1,20 @@
+if _binary_exists notify-send
+then
+    function __notify-send_completions ()
+    {
+        local curr=$(_get_cword)
+        local prev=$(_get_pword)
+
+        case $prev in
+            -u|--urgency)
+                COMPREPLY=($(compgen -W "low normal critical" -- "$curr"))
+            ;;
+            *)
+                COMPREPLY=($(compgen -W "-? --help -u --urgency -t --expire-time -a --app-name -i --icon -c --category -h --hint -v --verison" -- "$curr"))
+            ;;
+        esac
+    }
+
+
+    complete -F __notify-send_completions notify-send
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the bash completion script for `notify-send` command
 
## Motivation and Context

Personally for my `-?` in this command is frustrating. Everytime I had to do `man notify-send`

## How Has This Been Tested?
Ran multiple tests on my host and is working absolutely fine

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/28386721/104788783-1e121580-57b9-11eb-945b-529b67ad7df4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
