### PR TITLE
Fix rbenv version prompt

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -389,7 +389,7 @@ function rvm_version_prompt {
 function rbenv_version_prompt {
 	if which rbenv &> /dev/null; then
 		rbenv=$(rbenv version-name) || return
-		$rbenv commands | grep -q gemset && gemset=$(rbenv gemset active 2> /dev/null) && rbenv="$rbenv@${gemset%% *}"
+		rbenv commands | grep -q gemset && gemset=$(rbenv gemset active 2> /dev/null) && rbenv="$rbenv@${gemset%% *}"
 		if [ "$rbenv" != "system" ]; then
 			echo -e "$RBENV_THEME_PROMPT_PREFIX$rbenv$RBENV_THEME_PROMPT_SUFFIX"
 		fi


### PR DESCRIPTION
## Description

Fix a typo in rbenv_version_prompt function.

## Motivation and Context

When using `rbenv_version_prompt` to display ruby version
with rbenv installed, there is an error:

```bash
bash: 2.7.2: command not found

87% 2021-01-16 09:24:20 ⌚  |2.7.2| ThinkbUk in ~
○ →
```

The function define a variable containing the ruby version with `rbenv version-name`
and use that variable like the `rbenv` binary.

`rbenv commands | grep -q gemset` is a valid command when using [rbenv gemset](https://github.com/jf/rbenv-gemset).

## How Has This Been Tested?

No error after modification.
Using rbenv-gemset display the gemset used.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.