### PR TITLE
shellcheck: Disable SC2207, as it messes with COMPREPLY

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -4,3 +4,5 @@ disable=SC2154
 disable=SC2155
 # shellcheck is wrong on some
 disable=SC2034
+# Messing with our COMPREPLY completions
+disable=SC2207


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Disable SC2207

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This shellcheck option is really messing our code, as we use COMPREPLY in many places

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, saw that no such warnings were emitted the change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
