### PR TITLE
test: helper: cite plumbing metadata

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,3 +1,6 @@
+#!/usr/bin/env bats
+load ../../lib/composure
+
 unset BASH_IT_THEME
 unset GIT_HOSTING
 unset NGINX_PATH
@@ -15,6 +18,9 @@ export GIT_CONFIG_NOSYSTEM
 load "${TEST_DEPS_DIR}/bats-support/load.bash"
 load "${TEST_DEPS_DIR}/bats-assert/load.bash"
 load "${TEST_DEPS_DIR}/bats-file/load.bash"
+
+# support 'plumbing' metadata
+cite _about _param _example _group _author _version
 
 local_setup() {
   true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Stumbled across this when I fixed a test in #1776

## Description
<!--- Describe your changes in detail -->
Internal composure `cite`s are missing from the tests, this causes some confusing and misleading errors when
loading bash-it files which uses those `cites`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was pretty annoying, and I am happy to improve our tests

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
locally

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
