### PR TITLE
use absolute paths instead of changing directory

### DIFF
--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -1,6 +1,5 @@
 #!/bin/bash
 BASH_IT_LOG_PREFIX="core: reloader: "
-pushd "${BASH_IT}" >/dev/null || exit 1
 
 function _set-prefix-based-on-path()
 {
@@ -9,7 +8,7 @@ function _set-prefix-based-on-path()
   BASH_IT_LOG_PREFIX="$extension: $filename: "
 }
 
-if [ "$1" != "skip" ] && [ -d "./enabled" ]; then
+if [[ "$1" != "skip" ]] && [[ -d "$BASH_IT/enabled" ]]; then
   _bash_it_config_type=""
 
   case $1 in
@@ -20,7 +19,7 @@ if [ "$1" != "skip" ] && [ -d "./enabled" ]; then
       _log_debug "Loading all enabled components..." ;;
   esac
 
-  for _bash_it_config_file in $(sort <(compgen -G "./enabled/*${_bash_it_config_type}.bash")); do
+  for _bash_it_config_file in $(sort <(compgen -G "$BASH_IT/enabled/*${_bash_it_config_type}.bash")); do
     if [ -e "${_bash_it_config_file}" ]; then
       _set-prefix-based-on-path "${_bash_it_config_file}"
       _log_debug "Loading component..."
@@ -32,12 +31,12 @@ if [ "$1" != "skip" ] && [ -d "./enabled" ]; then
   done
 fi
 
-if [ -n "${2}" ] && [ -d "${2}/enabled" ]; then
+if [[ -n "${2}" ]] && [[ -d "$BASH_IT/${2}/enabled" ]]; then
   case $2 in
     aliases|completion|plugins)
       _log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
-      for _bash_it_config_file in $(sort <(compgen -G "./${2}/enabled/*.bash")); do
-        if [ -e "$_bash_it_config_file" ]; then
+      for _bash_it_config_file in $(sort <(compgen -G "$BASH_IT/${2}/enabled/*.bash")); do
+        if [[ -e "$_bash_it_config_file" ]]; then
           _set-prefix-based-on-path "${_bash_it_config_file}"
           _log_debug "Loading component..."
           # shellcheck source=/dev/null
@@ -51,4 +50,3 @@ fi
 
 unset _bash_it_config_file
 unset _bash_it_config_type
-popd >/dev/null || exit 1


### PR DESCRIPTION
## Description

This PR stops changing directories while reloading, which I'm calling a bug because it is completely different from my expectations and caused a lot of debugging confusion. I'm also labeling this as help-wanted because I'd like some people to test this manually since we don't really have integration tests yet, but I'm feeling pretty good about it.

## Motivation and Context

While playing around with the *env plugins, I discovered that if I started a fresh shell from a directory with a `.*-version` file, the tools were still unable to figure out the set version, because we are changing the working directory while loading.

## How Has This Been Tested?

locally and with bats

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
