### PR TITLE
Remove deprecated kubectl run --generator

### DIFF
--- a/aliases/available/kubectl.aliases.bash
+++ b/aliases/available/kubectl.aliases.bash
@@ -18,7 +18,7 @@ function _set_pkg_aliases()
     alias kcgpan='kubectl get pods --all-namespaces'
     alias kcgdan='kubectl get deployments --all-namespaces'
     # launches a disposable netshoot pod in the k8s cluster
-    alias kcnetshoot='kubectl run --generator=run-pod/v1 netshoot-$(date +%s) --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
+    alias kcnetshoot='kubectl run netshoot-$(date +%s) --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
   fi
 }
 


### PR DESCRIPTION
## Description
It now defaults to pod, so the --generator option is not required.

## Motivation and Context
--generator will be removed in a future kubectl update

## How Has This Been Tested?
Running the command starts a pod, like intended

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] I have read the **CONTRIBUTING** document.
