### PR TITLE
fix: Git alias quote style broke functionality

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -84,7 +84,7 @@ alias glsum='git diff --name-only --diff-filter=U' # Show unmerged (conflicted) 
 alias ggui='git gui'
 
 # home
-alias ghm='cd '\''$(git rev-parse --show-toplevel)'\''' # Git home
+alias ghm='cd "$(git rev-parse --show-toplevel)"' # Git home
 # appendage to ghm
 if ! _command_exists gh; then
 	alias gh='ghm'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- I have not updated my bashit in a while so this alias broke for me recently. Included are some screenshots of what I am seeing. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The alias is broken in bash `version 5.1.4(1)-release`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- see below


## Screenshots (if appropriate):
### Before
<img width="688" alt="Screen Shot 2021-02-25 at 7 50 16 PM" src="https://user-images.githubusercontent.com/290254/109243836-3eaf9100-77a3-11eb-9402-540db9130f91.png">

### After
<img width="556" alt="Screen Shot 2021-02-25 at 7 51 40 PM" src="https://user-images.githubusercontent.com/290254/109243838-3f482780-77a3-11eb-86cd-51fe07b8388a.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
