### PR TITLE
purity theme, added virtualenv name display

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -44,6 +44,7 @@ themes/brainy
 themes/brunton
 themes/command_duration.theme.bash
 themes/modern
+themes/purity
 
 # plugins
 #

--- a/themes/purity/purity.theme.bash
+++ b/themes/purity/purity.theme.bash
@@ -21,8 +21,8 @@ venv_prompt() {
 		python_venv="($PYTHON_VENV_CHAR${CONDA_DEFAULT_ENV}) "
 	elif [[ -n "${VIRTUAL_ENV}" ]]; then
 		python_venv="($PYTHON_VENV_CHAR$(basename "${VIRTUAL_ENV}")) "
-	[[ -n "${python_venv}" ]] && echo "${python_venv}"
 	fi
+	[[ -n "${python_venv}" ]] && echo "${python_venv}"
 }
 
 function prompt_command() {

--- a/themes/purity/purity.theme.bash
+++ b/themes/purity/purity.theme.bash
@@ -14,9 +14,21 @@ STATUS_THEME_PROMPT_BAD="${bold_red}❯${reset_color}${normal} "
 STATUS_THEME_PROMPT_OK="${bold_green}❯${reset_color}${normal} "
 PURITY_THEME_PROMPT_COLOR="${PURITY_THEME_PROMPT_COLOR:=$blue}"
 
+detect_venv() {
+	python_venv=""
+	# Detect python venv
+	if [[ -n "${CONDA_DEFAULT_ENV}" ]]; then
+		python_venv="($PYTHON_VENV_CHAR${CONDA_DEFAULT_ENV}) "
+	elif [[ -n "${VIRTUAL_ENV}" ]]; then
+		python_venv="($PYTHON_VENV_CHAR$(basename "${VIRTUAL_ENV}")) "
+	fi
+}
+
 function prompt_command() {
     local ret_status="$( [ $? -eq 0 ] && echo -e "$STATUS_THEME_PROMPT_OK" || echo -e "$STATUS_THEME_PROMPT_BAD")"
-    PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status} "
+    PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status}"
+    detect_venv
+    PS1+="${python_venv}"
 }
 
 safe_append_prompt_command prompt_command

--- a/themes/purity/purity.theme.bash
+++ b/themes/purity/purity.theme.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 SCM_THEME_PROMPT_DIRTY=" ${bold_red}⊘${normal}"
 SCM_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"
@@ -26,8 +26,9 @@ venv_prompt() {
 }
 
 function prompt_command() {
-    local ret_status="$( [ $? -eq 0 ] && echo -e "$STATUS_THEME_PROMPT_OK" || echo -e "$STATUS_THEME_PROMPT_BAD")"
-    PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status}$(venv_prompt)"
+	retval=$?
+	local ret_status="$([ $retval -eq 0 ] && echo -e "$STATUS_THEME_PROMPT_OK" || echo -e "$STATUS_THEME_PROMPT_BAD")"
+	PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status}$(venv_prompt)"
 }
 
 safe_append_prompt_command prompt_command

--- a/themes/purity/purity.theme.bash
+++ b/themes/purity/purity.theme.bash
@@ -14,21 +14,20 @@ STATUS_THEME_PROMPT_BAD="${bold_red}❯${reset_color}${normal} "
 STATUS_THEME_PROMPT_OK="${bold_green}❯${reset_color}${normal} "
 PURITY_THEME_PROMPT_COLOR="${PURITY_THEME_PROMPT_COLOR:=$blue}"
 
-detect_venv() {
+venv_prompt() {
 	python_venv=""
 	# Detect python venv
 	if [[ -n "${CONDA_DEFAULT_ENV}" ]]; then
 		python_venv="($PYTHON_VENV_CHAR${CONDA_DEFAULT_ENV}) "
 	elif [[ -n "${VIRTUAL_ENV}" ]]; then
 		python_venv="($PYTHON_VENV_CHAR$(basename "${VIRTUAL_ENV}")) "
+	[[ -n "${python_venv}" ]] && echo "${python_venv}"
 	fi
 }
 
 function prompt_command() {
     local ret_status="$( [ $? -eq 0 ] && echo -e "$STATUS_THEME_PROMPT_OK" || echo -e "$STATUS_THEME_PROMPT_BAD")"
-    PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status}"
-    detect_venv
-    PS1+="${python_venv}"
+    PS1="\n${PURITY_THEME_PROMPT_COLOR}\w $(scm_prompt_info)\n${ret_status}$(venv_prompt)"
 }
 
 safe_append_prompt_command prompt_command


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a function to show the name of the python virtualenv, when its being used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I consider having the name of the virtual environment we're in very useful.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Entering and leaving a virtualenv has the desired behaviour.

## Screenshots (if appropriate):
[Demo](https://imgur.com/qS2tvca)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
