### PR TITLE
helpers: Fix broken compoure references after vendor change

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -742,14 +742,14 @@ _help-plugins()
     printf '%s' 'please wait, building help...'
     typeset grouplist=$(mktemp -t grouplist.XXXXXX)
     typeset func
-    for func in $(typeset_functions)
+    for func in $(_typeset_functions)
     do
         typeset group="$(typeset -f $func | metafor group)"
         if [ -z "$group" ]; then
             group='misc'
         fi
         typeset about="$(typeset -f $func | metafor about)"
-        letterpress "$about" $func >> $grouplist.$group
+        _letterpress "$about" $func >> $grouplist.$group
         echo $grouplist.$group >> $grouplist
     done
     # clear progress message
@@ -788,7 +788,7 @@ all_groups ()
 
     typeset func
     typeset file=$(mktemp -t composure.XXXX)
-    for func in $(typeset_functions)
+    for func in $(_typeset_functions)
     do
         typeset -f $func | metafor group >> $file
     done

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -69,6 +69,11 @@ function local_setup {
   assert_line -n 0 ""
 }
 
+@test "helpers: bash-it help plugins" {
+  run bash-it help plugins
+  assert_line -n 1 "base:"
+}
+
 @test "helpers: bash-it help list aliases without any aliases enabled" {
   run _help-list-aliases "$BASH_IT/aliases/available/ag.aliases.bash"
   assert_line -n 0 "ag:"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix some broken things after the vendoring of the composure lib (#1820)

## Description
<!--- Describe your changes in detail -->
`bash-it help *` was broken after the vendoring change. This PR fixes that

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1846

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally and added a test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
