### PR TITLE
Clean alias completion plugin

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -105,11 +105,7 @@ aliases/available/vim.aliases.bash
 aliases/available/git.aliases.bash
 
 # tests
-<<<<<<< Updated upstream
 test/plugins/alias-completion.plugin.bats
-=======
-test/alias-completion.plugin.bats
->>>>>>> Stashed changes
 test/test_helper.bash
 
 # vendor init files

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -50,6 +50,7 @@ themes/purity
 
 # plugins
 #
+plugins/available/alias-completion.plugin.bash
 plugins/available/basher.plugin.bash
 plugins/available/cmd-returned-notify.plugin.bash
 plugins/available/docker-machine.plugin.bash
@@ -104,6 +105,7 @@ aliases/available/vim.aliases.bash
 aliases/available/git.aliases.bash
 
 # tests
+test/alias-completion.plugin.bats
 test/test_helper.bash
 
 # vendor init files

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -105,7 +105,11 @@ aliases/available/vim.aliases.bash
 aliases/available/git.aliases.bash
 
 # tests
+<<<<<<< Updated upstream
+test/plugins/alias-completion.plugin.bats
+=======
 test/alias-completion.plugin.bats
+>>>>>>> Stashed changes
 test/test_helper.bash
 
 # vendor init files

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -56,9 +56,9 @@ plugins/available/docker-machine.plugin.bash
 plugins/available/git.plugin.bash
 plugins/available/go.plugin.bash
 plugins/available/goenv.plugin.bash
-plugins/available/history.plugin.bash
 plugins/available/history-search.plugin.bash
 plugins/available/history-substring-search.plugin.bash
+plugins/available/history.plugin.bash
 plugins/available/xterm.plugin.bash
 
 # completions

--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -38,7 +38,10 @@ function alias_completion {
 
 	# read in "<alias> '<aliased command>' '<command args>'" lines from defined aliases
 	local line
-	while read -r line; do
+
+	# shellcheck disable=SC2162
+	# some aliases do have backslashes that needs to be interpreted
+	while read line; do
 		eval "local alias_tokens; alias_tokens=($line)" 2> /dev/null || continue # some alias arg patterns cause an eval parse error
 		local alias_name="${alias_tokens[0]}" alias_cmd="${alias_tokens[1]}" alias_args="${alias_tokens[2]# }"
 

--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -96,7 +96,7 @@ function alias_completion {
 			echo "$new_completion" >> "$tmp_file"
 		fi
 	done < <(alias -p | sed -Ene "s/$alias_regex/\2 '\3' '\4'/p")
-	# shellcheck disable=SC1090
+	# shellcheck source=/dev/null
 	source "$tmp_file" && command rm -f "$tmp_file"
 }
 

--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Load after the other completions to understand what needs to be completed
 # BASH_IT_LOAD_PRIORITY: 365
 
@@ -17,54 +18,58 @@ about-plugin 'Automatic completion of aliases'
 
 # Automatically add completion for all aliases to commands having completion functions
 function alias_completion {
-    local namespace="alias_completion"
+	local namespace="alias_completion"
 
-    # parse function based completion definitions, where capture group 2 => function and 3 => trigger
-    local compl_regex='complete( +[^ ]+)* -F ([^ ]+) ("[^"]+"|[^ ]+)'
-    # parse alias definitions, where capture group 1 => trigger, 2 => command, 3 => command arguments
-    local alias_regex="alias( -- | )([^=]+)='(\"[^\"]+\"|[^ ]+)(( +[^ ]+)*)'"
+	# parse function based completion definitions, where capture group 2 => function and 3 => trigger
+	local compl_regex='complete( +[^ ]+)* -F ([^ ]+) ("[^"]+"|[^ ]+)'
+	# parse alias definitions, where capture group 1 => trigger, 2 => command, 3 => command arguments
+	local alias_regex="alias( -- | )([^=]+)='(\"[^\"]+\"|[^ ]+)(( +[^ ]+)*)'"
 
-    # create array of function completion triggers, keeping multi-word triggers together
-    eval "local completions=($(complete -p | sed -Ene "/$compl_regex/s//'\3'/p"))"
-    (( ${#completions[@]} == 0 )) && return 0
+	# create array of function completion triggers, keeping multi-word triggers together
+	eval "local completions=($(complete -p | sed -Ene "/$compl_regex/s//'\3'/p"))"
+	((${#completions[@]} == 0)) && return 0
 
-    # create temporary file for wrapper functions and completions
-    local tmp_file; tmp_file="$(mktemp -t "${namespace}-${RANDOM}XXXXXX")" || return 1
+	# create temporary file for wrapper functions and completions
+	local tmp_file
+	tmp_file="$(mktemp -t "${namespace}-${RANDOM}XXXXXX")" || return 1
 
-    local completion_loader; completion_loader="$(complete -p -D 2>/dev/null | sed -Ene 's/.* -F ([^ ]*).*/\1/p')"
+	local completion_loader
+	completion_loader="$(complete -p -D 2> /dev/null | sed -Ene 's/.* -F ([^ ]*).*/\1/p')"
 
-    # read in "<alias> '<aliased command>' '<command args>'" lines from defined aliases
-    local line; while read line; do
-        eval "local alias_tokens; alias_tokens=($line)" 2>/dev/null || continue # some alias arg patterns cause an eval parse error
-        local alias_name="${alias_tokens[0]}" alias_cmd="${alias_tokens[1]}" alias_args="${alias_tokens[2]# }"
+	# read in "<alias> '<aliased command>' '<command args>'" lines from defined aliases
+	local line
+	while read -r line; do
+		eval "local alias_tokens; alias_tokens=($line)" 2> /dev/null || continue # some alias arg patterns cause an eval parse error
+		local alias_name="${alias_tokens[0]}" alias_cmd="${alias_tokens[1]}" alias_args="${alias_tokens[2]# }"
 
-        # skip aliases to pipes, boolean control structures and other command lists
-        # (leveraging that eval errs out if $alias_args contains unquoted shell metacharacters)
-        eval "local alias_arg_words; alias_arg_words=($alias_args)" 2>/dev/null || continue
-        # avoid expanding wildcards
-        read -a alias_arg_words <<< "$alias_args"
+		# skip aliases to pipes, boolean control structures and other command lists
+		# (leveraging that eval errs out if $alias_args contains unquoted shell metacharacters)
+		eval "local alias_arg_words; alias_arg_words=($alias_args)" 2> /dev/null || continue
+		# avoid expanding wildcards
+		read -ra alias_arg_words <<< "$alias_args"
 
-        # skip alias if there is no completion function triggered by the aliased command
-        if [[ ! " ${completions[*]} " =~ " $alias_cmd " ]]; then
-            if [[ -n "$completion_loader" ]]; then
-                # force loading of completions for the aliased command
-                eval "$completion_loader $alias_cmd"
-                # 124 means completion loader was successful
-                [[ $? -eq 124 ]] || continue
-                completions+=($alias_cmd)
-            else
-                continue
-            fi
-        fi
-        local new_completion="$(complete -p "$alias_cmd" 2>/dev/null)"
+		# skip alias if there is no completion function triggered by the aliased command
+		if [[ ! " ${completions[*]} " =~ $alias_cmd ]]; then
+			if [[ -n "$completion_loader" ]]; then
+				# force loading of completions for the aliased command
+				eval "$completion_loader $alias_cmd"
+				# 124 means completion loader was successful
+				[[ $? -eq 124 ]] || continue
+				completions+=("$alias_cmd")
+			else
+				continue
+			fi
+		fi
+		local new_completion="$(complete -p "$alias_cmd" 2> /dev/null)"
 
-        # create a wrapper inserting the alias arguments if any
-        if [[ -n $alias_args ]]; then
-            local compl_func="${new_completion/#* -F /}"; compl_func="${compl_func%% *}"
-            # avoid recursive call loops by ignoring our own functions
-            if [[ "${compl_func#_$namespace::}" == $compl_func ]]; then
-                local compl_wrapper="_${namespace}::${alias_name}"
-                    echo "function $compl_wrapper {
+		# create a wrapper inserting the alias arguments if any
+		if [[ -n $alias_args ]]; then
+			local compl_func="${new_completion/#* -F /}"
+			compl_func="${compl_func%% *}"
+			# avoid recursive call loops by ignoring our own functions
+			if [[ "${compl_func#_$namespace::}" == "$compl_func" ]]; then
+				local compl_wrapper="_${namespace}::${alias_name}"
+				echo "function $compl_wrapper {
                         local compl_word=\$2
                         local prec_word=\$3
                         # check if prec_word is the alias itself. if so, replace it
@@ -81,15 +86,17 @@ function alias_completion {
                         (( COMP_POINT += \${#COMP_LINE} ))
                         $compl_func \"$alias_cmd\" \"\$compl_word\" \"\$prec_word\"
                     }" >> "$tmp_file"
-                    new_completion="${new_completion/ -F $compl_func / -F $compl_wrapper }"
-            fi
-        fi
+				new_completion="${new_completion/ -F $compl_func / -F $compl_wrapper }"
+			fi
+		fi
 
-        # replace completion trigger by alias
-        if [[ -n $new_completion ]]; then
-            new_completion="${new_completion% *} $alias_name"
-            echo "$new_completion" >> "$tmp_file"
-        fi
-    done < <(alias -p | sed -Ene "s/$alias_regex/\2 '\3' '\4'/p")
-    source "$tmp_file" && command rm -f "$tmp_file"
-}; alias_completion
+		# replace completion trigger by alias
+		if [[ -n $new_completion ]]; then
+			new_completion="${new_completion% *} $alias_name"
+			echo "$new_completion" >> "$tmp_file"
+		fi
+	done < <(alias -p | sed -Ene "s/$alias_regex/\2 '\3' '\4'/p")
+	source "$tmp_file" && command rm -f "$tmp_file"
+}
+
+alias_completion

--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -96,6 +96,7 @@ function alias_completion {
 			echo "$new_completion" >> "$tmp_file"
 		fi
 	done < <(alias -p | sed -Ene "s/$alias_regex/\2 '\3' '\4'/p")
+	# shellcheck disable=SC1090
 	source "$tmp_file" && command rm -f "$tmp_file"
 }
 


### PR DESCRIPTION
Add these files to `clean_files.txt`

`plugins/available/alias-completion.plugin.bash`
`test/plugins/available/alias-completion.plugin.bats`

ran `./lint_clean_files.sh` and fix errors.