### PR TITLE
Add clean_files.txt sorting hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,8 @@ repos:
         language: system
         files: "\\.bash$"
         types: [file]
+      - id: clean-files-txt
+        name: Check that clean_files.txt is sorted alphabetically.
+        entry: ./hooks/check-clean-files-txt.sh
+        language: system
+        files: clean_files.txt

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -16,15 +16,78 @@
 
 # root directories
 #
-docs
-hooks
+docs/
+hooks/
 
 # root files
 #
 .gitattributes
-lint_clean_files.sh
-install.sh
 bash_it.sh
+clean_files.txt
+install.sh
+lint_clean_files.sh
+
+# aliases
+#
+aliases/available/dnf.aliases.bash
+aliases/available/git.aliases.bash
+aliases/available/vim.aliases.bash
+
+# completions
+#
+completion/available/apm.completion.bash
+completion/available/awless.completion.bash
+completion/available/brew.completion.bash
+completion/available/cargo.completion.bash
+completion/available/composer.completion.bash
+completion/available/conda.completion.bash
+completion/available/consul.completion.bash
+completion/available/django.completion.bash
+completion/available/dmidecode.completion.bash
+completion/available/docker-machine.completion.bash
+completion/available/docker.completion.bash
+completion/available/gcloud.completion.bash
+completion/available/gem.completion.bash
+completion/available/github-cli.completion.bash
+completion/available/go.completion.bash
+completion/available/helm.completion.bash
+completion/available/jungle.completion.bash
+completion/available/knife.completion.bash
+completion/available/kontena.completion.bash
+completion/available/kubectl.completion.bash
+completion/available/lerna.completion.bash
+completion/available/minikube.completion.bash
+completion/available/ngrok.completion.bash
+completion/available/notify-send.completion.bash
+completion/available/npm.completion.bash
+completion/available/packer.completion.bash
+completion/available/pip.completion.bash
+completion/available/pip3.completion.bash
+completion/available/pipenv.completion.bash
+completion/available/pipx.completion.bash
+completion/available/rustup.completion.bash
+completion/available/sdkman.completion.bash
+completion/available/vault.completion.bash
+completion/available/vuejs.completion.bash
+
+# plugins
+#
+plugins/available/alias-completion.plugin.bash
+plugins/available/basher.plugin.bash
+plugins/available/cmd-returned-notify.plugin.bash
+plugins/available/docker-machine.plugin.bash
+plugins/available/git.plugin.bash
+plugins/available/go.plugin.bash
+plugins/available/goenv.plugin.bash
+plugins/available/history-search.plugin.bash
+plugins/available/history-substring-search.plugin.bash
+plugins/available/history.plugin.bash
+plugins/available/xterm.plugin.bash
+
+# tests
+#
+test/plugins/alias-completion.plugin.bats
+test/test_helper.bash
 
 # themes
 #
@@ -47,68 +110,6 @@ themes/easy
 themes/modern
 themes/powerline
 themes/purity
-
-# plugins
-#
-plugins/available/alias-completion.plugin.bash
-plugins/available/basher.plugin.bash
-plugins/available/cmd-returned-notify.plugin.bash
-plugins/available/docker-machine.plugin.bash
-plugins/available/git.plugin.bash
-plugins/available/go.plugin.bash
-plugins/available/goenv.plugin.bash
-plugins/available/history-search.plugin.bash
-plugins/available/history-substring-search.plugin.bash
-plugins/available/history.plugin.bash
-plugins/available/xterm.plugin.bash
-
-# completions
-#
-completion/available/apm.completion.bash
-completion/available/awless.completion.bash
-completion/available/brew.completion.bash
-completion/available/cargo.completion.bash
-completion/available/composer.completion.bash
-completion/available/conda.completion.bash
-completion/available/consul.completion.bash
-completion/available/django.completion.bash
-completion/available/dmidecode.completion.bash
-completion/available/docker.completion.bash
-completion/available/docker-machine.completion.bash
-completion/available/gcloud.completion.bash
-completion/available/gem.completion.bash
-completion/available/go.completion.bash
-completion/available/github-cli.completion.bash
-completion/available/helm.completion.bash
-completion/available/jungle.completion.bash
-completion/available/knife.completion.bash
-completion/available/kontena.completion.bash
-completion/available/kubectl.completion.bash
-completion/available/lerna.completion.bash
-completion/available/minikube.completion.bash
-completion/available/notify-send.completion.bash
-completion/available/ngrok.completion.bash
-completion/available/npm.completion.bash
-completion/available/packer.completion.bash
-completion/available/pip.completion.bash
-completion/available/pip3.completion.bash
-completion/available/pipenv.completion.bash
-completion/available/pipx.completion.bash
-completion/available/rustup.completion.bash
-completion/available/vault.completion.bash
-completion/available/sdkman.completion.bash
-completion/available/vuejs.completion.bash
-
-# aliases
-#
-aliases/available/dnf.aliases.bash
-aliases/available/vim.aliases.bash
-aliases/available/git.aliases.bash
-
-# tests
-#
-test/plugins/alias-completion.plugin.bats
-test/test_helper.bash
 
 # vendor init files
 #

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -1,7 +1,7 @@
 #######################################################################
 # Allow-list of files to be lint-checked by CI
 #
-# Directory Suport
+# Directory Support
 #   Directory references are allowed within the file, ie:
 #
 #       themes/powerline
@@ -106,9 +106,11 @@ aliases/available/vim.aliases.bash
 aliases/available/git.aliases.bash
 
 # tests
+#
 test/plugins/alias-completion.plugin.bats
 test/test_helper.bash
 
 # vendor init files
+#
 vendor/.gitattributes
 vendor/init.d

--- a/hooks/check-clean-files-txt.sh
+++ b/hooks/check-clean-files-txt.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+file=$1
+# Should only be run on clean_files.txt
+if [ "$file" != "clean_files.txt" ]; then
+	echo "Please run this script on clean_files.txt only!"
+	exit 1
+fi
+
+function compare_lines() {
+	prev=""
+	while read -r line; do
+		# Skip unimportant lines
+		[[ $line =~ "#" ]] && continue
+		[[ $line == "" ]] && continue
+		# Actual check
+		if [[ $prev > $line ]]; then
+			echo "$line should be before $prev"
+			exit 1
+		fi
+		prev=$line
+	done <<< "$1"
+}
+
+# Test root files
+compare_lines "$(grep -v "/" "$file")"
+
+# Test root directory
+compare_lines "$(grep "/$" "$file")"
+
+# Test non root directories
+compare_lines "$(grep "/." "$file")"
+
+# Yay, all good!
+exit 0

--- a/hooks/check-clean-files-txt.sh
+++ b/hooks/check-clean-files-txt.sh
@@ -22,6 +22,9 @@ function compare_lines() {
 	done <<< "$1"
 }
 
+# We compare using the legacy way
+shopt -s compat31
+
 # Test root files
 compare_lines "$(grep -v "/" "$file")"
 
@@ -31,5 +34,6 @@ compare_lines "$(grep "/$" "$file")"
 # Test non root directories
 compare_lines "$(grep "/." "$file")"
 
+shopt -u compat31
 # Yay, all good!
 exit 0


### PR DESCRIPTION
We now sort clean_files.txt alphabetically!
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a hook that checks that the lines in clean_files.txt are sorted alphabetically.
I have splitted the checks into 3 parts- root files, root directories, and non root directories
I also sorted clean_files.txt according to said feedback :smile:

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1871

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, by runnnig `lint_clean_files.sh`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
