### PR TITLE
plugins: alias-completion: Revert back to read without -r

### DIFF
--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -49,7 +49,7 @@ function alias_completion {
 		# (leveraging that eval errs out if $alias_args contains unquoted shell metacharacters)
 		eval "local alias_arg_words; alias_arg_words=($alias_args)" 2> /dev/null || continue
 		# avoid expanding wildcards
-		read -ra alias_arg_words <<< "$alias_args"
+		read -a alias_arg_words <<< "$alias_args"
 
 		# skip alias if there is no completion function triggered by the aliased command
 		if [[ ! " ${completions[*]} " =~ $alias_cmd ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix read command in alias-completion plugin

## Description
<!--- Describe your changes in detail -->
In our lint process of alias-completion, we changed a "read" command to use the "-r" flag.
https://github.com/Bash-it/bash-it/blob/7b8dbd39bc821a5be25043375920823fd168e6ea/plugins/available/alias-completion.plugin.bash#L52
This broke the completion, so we revert this change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Broken plugin after

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
