### PR TITLE
plugins: Fix alias-completion by comparing completions to alias literally

### DIFF
--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -52,7 +52,7 @@ function alias_completion {
 		read -a alias_arg_words <<< "$alias_args"
 
 		# skip alias if there is no completion function triggered by the aliased command
-		if [[ ! " ${completions[*]} " =~ $alias_cmd ]]; then
+		if ! _bash-it-array-contains-element "$alias_cmd" "${completions[@]}"; then
 			if [[ -n "$completion_loader" ]]; then
 				# force loading of completions for the aliased command
 				eval "$completion_loader $alias_cmd"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
So, after having issues with alias-completion again, I re investigated and found out the correct fix

## Description
<!--- Describe your changes in detail -->
The completion comparison to the alias should not be regex at all, it should be literal check

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Local bug in alias-completion

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally, but better
I will add a test to combat the bugs here

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
