### PR TITLE
Refactor scm_prompt usage in many themes

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -111,6 +111,7 @@ themes/command_duration.theme.bash
 themes/easy
 themes/modern
 themes/powerline
+themes/pure
 themes/purity
 
 # vendor init files

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -121,6 +121,18 @@ function scm {
 	fi
 }
 
+scm_prompt() {
+	local CHAR=$(scm_char)
+	local format=${SCM_PROMPT_FORMAT:-'[%s%s]'}
+
+	if [[ $CHAR = "$SCM_NONE_CHAR" ]]; then
+		return
+	else
+		# shellcheck disable=2059
+		printf "$format\n" "$CHAR" "$(scm_prompt_info)"
+	fi
+}
+
 function scm_prompt_char {
 	if [[ -z $SCM ]]; then scm; fi
 	if [[ $SCM == "$SCM_GIT" ]]; then

--- a/themes/binaryanomaly/binaryanomaly.theme.bash
+++ b/themes/binaryanomaly/binaryanomaly.theme.bash
@@ -31,15 +31,6 @@ function set_user_color() {
 	esac
 }
 
-scm_prompt() {
-	CHAR=$(scm_char)
-	if [ "$CHAR" = "$SCM_NONE_CHAR" ]; then
-		return
-	else
-		echo "[$(scm_char)$(scm_prompt_info)]"
-	fi
-}
-
 # Define custom colors we need
 # non-printable bytes in PS1 need to be contained within \[ \].
 # Otherwise, bash will count them in the length of the prompt

--- a/themes/brunton/brunton.theme.bash
+++ b/themes/brunton/brunton.theme.bash
@@ -15,16 +15,8 @@ is_vim_shell() {
 	fi
 }
 
-scm_prompt() {
-	CHAR=$(scm_char)
-	if [ "$CHAR" = "$SCM_NONE_CHAR" ]; then
-		return
-	else
-		echo " $(scm_char) (${white}$(scm_prompt_info)${normal})"
-	fi
-}
-
 prompt() {
+	SCM_PROMPT_FORMAT=' %s (%s)'
 	PS1="${white}${background_blue} \u${normal}${background_blue}@${red}${background_blue}\h $(clock_prompt) ${reset_color}${normal} $(battery_charge)\n${bold_black}${background_white} \w ${normal}$(scm_prompt)$(is_vim_shell)\n${white}>${normal} "
 }
 

--- a/themes/codeword/codeword.theme.bash
+++ b/themes/codeword/codeword.theme.bash
@@ -3,16 +3,6 @@ SCM_THEME_PROMPT_DIRTY="${bold_red} ✗${normal}"
 SCM_THEME_PROMPT_CLEAN="${bold_green} ✓${normal}"
 SCM_GIT_CHAR="${green}±${normal}"
 
-scm_prompt() {
-    CHAR=$(scm_char)
-    if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-            return
-        else
-            echo " [$(scm_char)$(scm_prompt_info)]"
-    fi
-}
-
 mark_prompt() {
     echo "${green}\$${normal}"
 }
@@ -25,6 +15,7 @@ user_host_path_prompt() {
 }
 
 prompt() {
+  SCM_PROMPT_FORMAT=' [%s%s]'
   PS1="$(user_host_path_prompt)$(virtualenv_prompt)$(scm_prompt) $(mark_prompt) "
 }
 

--- a/themes/doubletime/doubletime.theme.bash
+++ b/themes/doubletime/doubletime.theme.bash
@@ -28,17 +28,6 @@ else
     THEME_PROMPT_HOST_COLOR="$blue"
 fi
 
-doubletime_scm_prompt() {
-  CHAR=$(scm_char)
-  if [ $CHAR = $SCM_NONE_CHAR ]; then
-    return
-  elif [ $CHAR = $SCM_GIT_CHAR ]; then
-    echo "$(git_prompt_status)"
-  else
-    echo "[$(scm_prompt_info)]"
-  fi
-}
-
 function prompt_setter() {
   # Save history
   history -a
@@ -46,27 +35,9 @@ function prompt_setter() {
   history -r
   PS1="
 $(clock_prompt) $(scm_char) [${THEME_PROMPT_HOST_COLOR}\u@${THEME_PROMPT_HOST}$reset_color] $(virtualenv_prompt)$(ruby_version_prompt)\w
-$(doubletime_scm_prompt)$reset_color $ "
+$(scm_prompt)$reset_color $ "
   PS2='> '
   PS4='+ '
 }
 
 safe_append_prompt_command prompt_setter
-
-git_prompt_status() {
-  local git_status_output
-  git_status_output=$(git status 2> /dev/null )
-  if [ -n "$(echo $git_status_output | grep 'Changes not staged')" ]; then
-    git_status="${bold_red}$(scm_prompt_info) ✗"
-  elif [ -n "$(echo $git_status_output | grep 'Changes to be committed')" ]; then
-     git_status="${bold_yellow}$(scm_prompt_info) ^"
-  elif [ -n "$(echo $git_status_output | grep 'Untracked files')" ]; then
-     git_status="${bold_cyan}$(scm_prompt_info) +"
-  elif [ -n "$(echo $git_status_output | grep 'nothing to commit')" ]; then
-     git_status="${bold_green}$(scm_prompt_info) ${green}✓"
-  else
-    git_status="$(scm_prompt_info)"
-  fi
-  echo "[$git_status${normal}]"
-
-}

--- a/themes/gallifrey/gallifrey.theme.bash
+++ b/themes/gallifrey/gallifrey.theme.bash
@@ -4,26 +4,18 @@ SCM_THEME_PROMPT_SUFFIX=")${normal}"
 
 SCM_THEME_PROMPT_DIRTY="*"
 SCM_THEME_PROMPT_CLEAN=""
-SCM_GIT_CHAR="g"
-SCM_SVN_CHAR="s"
-SCM_HG_CHAR="h"
+SCM_GIT_CHAR="${green}±${normal}"
+SCM_SVN_CHAR="${bold_cyan}⑆${normal}"
+SCM_HG_CHAR="${bold_red}☿${normal}"
 
 ### TODO: openSUSE has already colors enabled, check if those differs from stock
 # LS colors, made with http://geoff.greer.fm/lscolors/
 # export LSCOLORS="Gxfxcxdxbxegedabagacad"
 # export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=41;33;01:ex=00;32:*.cmd=00;32:*.exe=01;32:*.com=01;32:*.bat=01;32:*.btm=01;32:*.dll=01;32:*.tar=00;31:*.tbz=00;31:*.tgz=00;31:*.rpm=00;31:*.deb=00;31:*.arj=00;31:*.taz=00;31:*.lzh=00;31:*.lzma=00;31:*.zip=00;31:*.zoo=00;31:*.z=00;31:*.Z=00;31:*.gz=00;31:*.bz2=00;31:*.tb2=00;31:*.tz2=00;31:*.tbz2=00;31:*.avi=01;35:*.bmp=01;35:*.fli=01;35:*.gif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mng=01;35:*.mov=01;35:*.mpg=01;35:*.pcx=01;35:*.pbm=01;35:*.pgm=01;35:*.png=01;35:*.ppm=01;35:*.tga=01;35:*.tif=01;35:*.xbm=01;35:*.xpm=01;35:*.dl=01;35:*.gl=01;35:*.wmv=01;35:*.aiff=00;32:*.au=00;32:*.mid=00;32:*.mp3=00;32:*.ogg=00;32:*.voc=00;32:*.wav=00;32:'
 
-scm_prompt() {
-    CHAR=$(scm_char)
-    if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-            return
-        else
-            echo "$(scm_prompt_info) "
-    fi
-}
+gallifrey_prompt() {
+	SCM_PROMPT_FORMAT='%s%s'
 
-pure_prompt() {
     ps_host="${green}\h${normal}";
     ps_user_mark="${bold}\$${normal}";
     ps_root_mark="${normal}§"
@@ -38,4 +30,4 @@ pure_prompt() {
     esac
 }
 
-safe_append_prompt_command pure_prompt
+safe_append_prompt_command gallifrey_prompt

--- a/themes/mairan/mairan.theme.bash
+++ b/themes/mairan/mairan.theme.bash
@@ -69,16 +69,6 @@ is_vim_shell() {
         fi
 }
 
-modern_scm_prompt() {
-        CHAR=$(scm_char)
-        if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-                return
-        else
-                echo "[$(scm_char)][$GREEN$(scm_prompt_info)]"
-        fi
-}
-
 # show chroot if exist
 chroot(){
     if [ -n "$debian_chroot" ]
@@ -99,7 +89,7 @@ my_ve(){
     }
 
 prompt() {
-
+	SCM_PROMPT_FORMAT="[%s$GREEN%s]"
     my_ps_host="$BOLD$ORANGE\h${normal}";
     # yes, these are the the same for now ...
     my_ps_host_root="$ORANGE\h${normal}";
@@ -114,10 +104,10 @@ prompt() {
 
     # nice prompt
     case "`id -u`" in
-        0) PS1="\n${TITLEBAR}${BRACKET_COLOR}┌─${normal}$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(modern_scm_prompt)$(__my_rvm_ruby_version)[${green}\w${normal}]$(is_vim_shell)${BRACKET_COLOR}
+        0) PS1="\n${TITLEBAR}${BRACKET_COLOR}┌─${normal}$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(scm_prompt)$(__my_rvm_ruby_version)[${green}\w${normal}]$(is_vim_shell)${BRACKET_COLOR}
 └─▪ ${prompt_symbol} ${normal}"
         ;;
-        *) PS1="\n${TITLEBAR}${BRACKET_COLOR}┌─${normal}$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(modern_scm_prompt)${normal}$(__my_rvm_ruby_version)[${green}\w${normal}]$(is_vim_shell)${BRACKET_COLOR}
+        *) PS1="\n${TITLEBAR}${BRACKET_COLOR}┌─${normal}$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(scm_prompt)${normal}$(__my_rvm_ruby_version)[${green}\w${normal}]$(is_vim_shell)${BRACKET_COLOR}
 └─▪ ${prompt_symbol} ${normal}"
         ;;
     esac

--- a/themes/modern-t/modern-t.theme.bash
+++ b/themes/modern-t/modern-t.theme.bash
@@ -32,26 +32,17 @@ is_vim_shell() {
 	fi
 }
 
-modern_scm_prompt() {
-	CHAR=$(scm_char)
-	if [ $CHAR = $SCM_NONE_CHAR ]
-	then
-		return
-	else
-		echo "[$(scm_char)][$(scm_prompt_info)]"
-	fi
-}
-
 prompt() {
+	SCM_PROMPT_FORMAT='[%s][%s]'
 	if [ $? -ne 0 ]
 	then
 		# Yes, the indenting on these is weird, but it has to be like
 		# this otherwise it won't display properly.
 
-		PS1="${TITLEBAR}${bold_red}┌─[${cyan}$(t | wc -l | sed -e's/ *//')${reset_color}]${reset_color}$(modern_scm_prompt)[${cyan}\W${normal}]$(is_vim_shell)
+		PS1="${TITLEBAR}${bold_red}┌─[${cyan}$(t | wc -l | sed -e's/ *//')${reset_color}]${reset_color}$(scm_prompt)[${cyan}\W${normal}]$(is_vim_shell)
 ${bold_red}└─▪${normal} "
 	else
-		PS1="${TITLEBAR}┌─[${cyan}$(t | wc -l | sed -e's/ *//')${reset_color}]$(modern_scm_prompt)[${cyan}\W${normal}]$(is_vim_shell)
+		PS1="${TITLEBAR}┌─[${cyan}$(t | wc -l | sed -e's/ *//')${reset_color}]$(scm_prompt)[${cyan}\W${normal}]$(is_vim_shell)
 └─▪ "
 	fi
 }

--- a/themes/modern-time/modern-time.theme.bash
+++ b/themes/modern-time/modern-time.theme.bash
@@ -28,30 +28,21 @@ is_vim_shell() {
 	fi
 }
 
-modern_scm_prompt() {
-	CHAR=$(scm_char)
-	if [ $CHAR = $SCM_NONE_CHAR ]
-	then
-		return
-	else
-		echo "[$(scm_char)][$(scm_prompt_info)]"
-	fi
-}
-
 modern_current_time_prompt() {
 	echo "[$(date '+%l:%M%p')]"
 }
 
 prompt() {
+	SCM_PROMPT_FORMAT='[%s][%s]'
 	if [ $? -ne 0 ]
 	then
 		# Yes, the indenting on these is weird, but it has to be like
 		# this otherwise it won't display properly.
 
-		PS1="${TITLEBAR}${bold_red}┌─${reset_color}$(modern_scm_prompt)$(modern_current_time_prompt)[${cyan}\W${normal}]$(is_vim_shell)
+		PS1="${TITLEBAR}${bold_red}┌─${reset_color}$(scm_prompt)$(modern_current_time_prompt)[${cyan}\W${normal}]$(is_vim_shell)
 ${bold_red}└─▪${normal} "
 	else
-		PS1="${TITLEBAR}┌─$(modern_scm_prompt)$(modern_current_time_prompt)[${cyan}\W${normal}]$(is_vim_shell)
+		PS1="${TITLEBAR}┌─$(scm_prompt)$(modern_current_time_prompt)[${cyan}\W${normal}]$(is_vim_shell)
 └─▪ "
 	fi
 }

--- a/themes/modern/modern.theme.bash
+++ b/themes/modern/modern.theme.bash
@@ -26,15 +26,6 @@ is_vim_shell() {
 	fi
 }
 
-modern_scm_prompt() {
-	CHAR=$(scm_char)
-	if [ "$CHAR" = "$SCM_NONE_CHAR" ]; then
-		return
-	else
-		echo "[$(scm_char)][$(scm_prompt_info)]"
-	fi
-}
-
 detect_venv() {
 	python_venv=""
 	# Detect python venv
@@ -46,11 +37,12 @@ detect_venv() {
 }
 
 prompt() {
+	SCM_PROMPT_FORMAT='[%s][%s]'
 	retval=$?
 	if [[ retval -ne 0 ]]; then
-		PS1="${TITLEBAR}${bold_red}┌─${reset_color}$(modern_scm_prompt)[${cyan}\u${normal}][${cyan}\w${normal}]$(is_vim_shell)\n${bold_red}└─▪${normal} "
+		PS1="${TITLEBAR}${bold_red}┌─${reset_color}$(scm_prompt)[${cyan}\u${normal}][${cyan}\w${normal}]$(is_vim_shell)\n${bold_red}└─▪${normal} "
 	else
-		PS1="${TITLEBAR}┌─$(modern_scm_prompt)[${cyan}\u${normal}][${cyan}\w${normal}]$(is_vim_shell)\n└─▪ "
+		PS1="${TITLEBAR}┌─$(scm_prompt)[${cyan}\u${normal}][${cyan}\w${normal}]$(is_vim_shell)\n└─▪ "
 	fi
 	detect_venv
 	PS1+="${python_venv}${dir_color}"

--- a/themes/pure/pure.theme.bash
+++ b/themes/pure/pure.theme.bash
@@ -18,15 +18,6 @@ VIRTUALENV_THEME_PROMPT_SUFFIX=")"
 # export LSCOLORS="Gxfxcxdxbxegedabagacad"
 # export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=41;33;01:ex=00;32:*.cmd=00;32:*.exe=01;32:*.com=01;32:*.bat=01;32:*.btm=01;32:*.dll=01;32:*.tar=00;31:*.tbz=00;31:*.tgz=00;31:*.rpm=00;31:*.deb=00;31:*.arj=00;31:*.taz=00;31:*.lzh=00;31:*.lzma=00;31:*.zip=00;31:*.zoo=00;31:*.z=00;31:*.Z=00;31:*.gz=00;31:*.bz2=00;31:*.tb2=00;31:*.tz2=00;31:*.tbz2=00;31:*.avi=01;35:*.bmp=01;35:*.fli=01;35:*.gif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mng=01;35:*.mov=01;35:*.mpg=01;35:*.pcx=01;35:*.pbm=01;35:*.pgm=01;35:*.png=01;35:*.ppm=01;35:*.tga=01;35:*.tif=01;35:*.xbm=01;35:*.xpm=01;35:*.dl=01;35:*.gl=01;35:*.wmv=01;35:*.aiff=00;32:*.au=00;32:*.mid=00;32:*.mp3=00;32:*.ogg=00;32:*.voc=00;32:*.wav=00;32:'
 
-scm_prompt() {
-	CHAR=$(scm_char)
-	if [[ $CHAR = "$SCM_NONE_CHAR" ]]; then
-		return
-	else
-		echo -e "[$(scm_char)$(scm_prompt_info)]"
-	fi
-}
-
 pure_prompt() {
 	ps_host="${bold_blue}\h${normal}"
 	ps_user="${green}\u${normal}"

--- a/themes/pure/pure.theme.bash
+++ b/themes/pure/pure.theme.bash
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 # scm theming
 SCM_THEME_PROMPT_PREFIX="|"
 SCM_THEME_PROMPT_SUFFIX=""
@@ -17,30 +19,30 @@ VIRTUALENV_THEME_PROMPT_SUFFIX=")"
 # export LS_COLORS='no=00:fi=00:di=01;34:ln=00;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=41;33;01:ex=00;32:*.cmd=00;32:*.exe=01;32:*.com=01;32:*.bat=01;32:*.btm=01;32:*.dll=01;32:*.tar=00;31:*.tbz=00;31:*.tgz=00;31:*.rpm=00;31:*.deb=00;31:*.arj=00;31:*.taz=00;31:*.lzh=00;31:*.lzma=00;31:*.zip=00;31:*.zoo=00;31:*.z=00;31:*.Z=00;31:*.gz=00;31:*.bz2=00;31:*.tb2=00;31:*.tz2=00;31:*.tbz2=00;31:*.avi=01;35:*.bmp=01;35:*.fli=01;35:*.gif=01;35:*.jpg=01;35:*.jpeg=01;35:*.mng=01;35:*.mov=01;35:*.mpg=01;35:*.pcx=01;35:*.pbm=01;35:*.pgm=01;35:*.png=01;35:*.ppm=01;35:*.tga=01;35:*.tif=01;35:*.xbm=01;35:*.xpm=01;35:*.dl=01;35:*.gl=01;35:*.wmv=01;35:*.aiff=00;32:*.au=00;32:*.mid=00;32:*.mp3=00;32:*.ogg=00;32:*.voc=00;32:*.wav=00;32:'
 
 scm_prompt() {
-    CHAR=$(scm_char)
-    if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-            return
-        else
-            echo "[$(scm_char)$(scm_prompt_info)]"
-    fi
+	CHAR=$(scm_char)
+	if [[ $CHAR = "$SCM_NONE_CHAR" ]]; then
+		return
+	else
+		echo -e "[$(scm_char)$(scm_prompt_info)]"
+	fi
 }
 
 pure_prompt() {
-    ps_host="${bold_blue}\h${normal}";
-    ps_user="${green}\u${normal}";
-    ps_user_mark="${green} $ ${normal}";
-    ps_root="${red}\u${red}";
-    ps_root_mark="${red} # ${normal}"
-    ps_path="${yellow}\w${normal}";
-
-    # make it work
-    case $(id -u) in
-        0) PS1="$(virtualenv_prompt)$ps_root@$ps_host$(scm_prompt):$ps_path$ps_root_mark"
-            ;;
-        *) PS1="$(virtualenv_prompt)$ps_user@$ps_host$(scm_prompt):$ps_path$ps_user_mark"
-            ;;
-    esac
+	ps_host="${bold_blue}\h${normal}"
+	ps_user="${green}\u${normal}"
+	ps_user_mark="${green} $ ${normal}"
+	ps_root="${red}\u${red}"
+	ps_root_mark="${red} # ${normal}"
+	ps_path="${yellow}\w${normal}"
+	# make it work
+	case $(id -u) in
+		0)
+			PS1="$(virtualenv_prompt)$ps_root@$ps_host$(scm_prompt):$ps_path$ps_root_mark"
+			;;
+		*)
+			PS1="$(virtualenv_prompt)$ps_user@$ps_host$(scm_prompt):$ps_path$ps_user_mark"
+			;;
+	esac
 }
 
 safe_append_prompt_command pure_prompt

--- a/themes/ramses/ramses.theme.bash
+++ b/themes/ramses/ramses.theme.bash
@@ -36,16 +36,6 @@ is_vim_shell() {
         fi
 }
 
-modern_scm_prompt() {
-        CHAR=$(scm_char)
-        if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-                return
-        else
-                echo "[$(scm_char)][$(scm_prompt_info)]"
-        fi
-}
-
 # show chroot if exist
 chroot(){
     if [ -n "$debian_chroot" ]
@@ -71,7 +61,7 @@ my_ve(){
     }
 
 prompt() {
-
+    SCM_PROMPT_FORMAT='[%s][%s]'
     my_ps_host="${green}\h${normal}";
     # yes, these are the the same for now ...
     my_ps_host_root="${green}\h${normal}";
@@ -86,10 +76,10 @@ prompt() {
 
     # nice prompt
     case "`id -u`" in
-        0) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(modern_scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]
+        0) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]
 ▪ "
         ;;
-        *) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(modern_scm_prompt)$(__my_rvm_ruby_version)
+        *) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(scm_prompt)$(__my_rvm_ruby_version)
 |─[${bold_purple}\w${normal}]
 ▪ "
         ;;

--- a/themes/rjorgenson/rjorgenson.theme.bash
+++ b/themes/rjorgenson/rjorgenson.theme.bash
@@ -57,16 +57,6 @@ todo_txt_count() {
     fi
 }
 
-modern_scm_prompt() {
-        CHAR=$(scm_char)
-        if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-                return
-        else
-                echo "${BRACKET_COLOR}[${CHAR}${BRACKET_COLOR}][${STRING_COLOR}$(scm_prompt_info)${BRACKET_COLOR}]$normal"
-        fi
-}
-
 my_prompt_char() {
     if [[ $OSTYPE =~ "darwin" ]]; then
         echo "${BRACKET_COLOR}➞  ${normal}"
@@ -76,6 +66,7 @@ my_prompt_char() {
 }
 
 prompt() {
+	SCM_PROMPT_FORMAT="${BRACKET_COLOR}[%s${BRACKET_COLOR}][${STRING_COLOR}%s${BRACKET_COLOR}]"
 
     my_ps_host="${STRING_COLOR}\h${normal}";
     my_ps_user="${STRING_COLOR}\u${normal}";
@@ -84,10 +75,10 @@ prompt() {
 
     # nice prompt
     case "`id -u`" in
-        0) PS1="${TITLEBAR}${BRACKET_COLOR}┌─[$my_ps_root${BRACKET_COLOR}][$my_ps_host${BRACKET_COLOR}]$(modern_scm_prompt)$(__my_rvm_ruby_version)${BRACKET_COLOR}[${STRING_COLOR}\w${BRACKET_COLOR}]$(is_vim_shell)
+        0) PS1="${TITLEBAR}${BRACKET_COLOR}┌─[$my_ps_root${BRACKET_COLOR}][$my_ps_host${BRACKET_COLOR}]$(scm_prompt)$(__my_rvm_ruby_version)${BRACKET_COLOR}[${STRING_COLOR}\w${BRACKET_COLOR}]$(is_vim_shell)
 ${BRACKET_COLOR}└─$(my_prompt_char)${normal}"
         ;;
-        *) PS1="${TITLEBAR}${BRACKET_COLOR}┌─[$my_ps_user${BRACKET_COLOR}][$my_ps_host${BRACKET_COLOR}]$(modern_scm_prompt)$(__my_rvm_ruby_version)${BRACKET_COLOR}[${STRING_COLOR}\w${BRACKET_COLOR}]$(is_vim_shell)
+        *) PS1="${TITLEBAR}${BRACKET_COLOR}┌─[$my_ps_user${BRACKET_COLOR}][$my_ps_host${BRACKET_COLOR}]$(scm_prompt)$(__my_rvm_ruby_version)${BRACKET_COLOR}[${STRING_COLOR}\w${BRACKET_COLOR}]$(is_vim_shell)
 ${BRACKET_COLOR}└─$(todo_txt_count)$(my_prompt_char)"
         ;;
     esac

--- a/themes/slick/slick.theme.bash
+++ b/themes/slick/slick.theme.bash
@@ -43,18 +43,8 @@ is_vim_shell() {
         fi
 }
 
-modern_scm_prompt() {
-        CHAR=$(scm_char)
-        if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-                return
-        else
-                echo "[$(scm_char)][$(scm_prompt_info)]"
-        fi
-}
-
 prompt() {
-
+   SCM_PROMPT_FORMAT='[%s][%s]'
    case $HOSTNAME in
     "clappy"* ) my_ps_host="${green}\h${normal}";
             ;;
@@ -70,10 +60,10 @@ prompt() {
 
     # nice prompt
     case "`id -u`" in
-        0) PS1="${TITLEBAR}[$my_ps_root][$my_ps_host]$(modern_scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]$(is_vim_shell)
+        0) PS1="${TITLEBAR}[$my_ps_root][$my_ps_host]$(scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]$(is_vim_shell)
 $ "
         ;;
-      *) PS1="${TITLEBAR}[$my_ps_user][$my_ps_host]$(modern_scm_prompt)$(__my_rvm_ruby_version)$(__my_venv_prompt)[${cyan}\w${normal}]$(is_vim_shell)
+      *) PS1="${TITLEBAR}[$my_ps_user][$my_ps_host]$(scm_prompt)$(__my_rvm_ruby_version)$(__my_venv_prompt)[${cyan}\w${normal}]$(is_vim_shell)
 $ "
         ;;
     esac

--- a/themes/zork/zork.theme.bash
+++ b/themes/zork/zork.theme.bash
@@ -36,16 +36,6 @@ is_vim_shell() {
         fi
 }
 
-modern_scm_prompt() {
-        CHAR=$(scm_char)
-        if [ $CHAR = $SCM_NONE_CHAR ]
-        then
-                return
-        else
-                echo "[$(scm_char)][$(scm_prompt_info)]"
-        fi
-}
-
 # show chroot if exist
 chroot(){
     if [ -n "$debian_chroot" ]
@@ -71,7 +61,7 @@ my_ve(){
     }
 
 prompt() {
-
+	SCM_PROMPT_FORMAT='[%s][%s]'
     my_ps_host="${green}\h${normal}";
     # yes, these are the the same for now ...
     my_ps_host_root="${green}\h${normal}";
@@ -86,10 +76,10 @@ prompt() {
 
     # nice prompt
     case "`id -u`" in
-        0) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(modern_scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]$(is_vim_shell)
+        0) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_root][$my_ps_host_root]$(scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]$(is_vim_shell)
 └─▪ "
         ;;
-        *) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(modern_scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]$(is_vim_shell)
+        *) PS1="${TITLEBAR}┌─$(my_ve)$(chroot)[$my_ps_user][$my_ps_host]$(scm_prompt)$(__my_rvm_ruby_version)[${cyan}\w${normal}]$(is_vim_shell)
 └─▪ "
         ;;
     esac


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Lint "pure" theme, and refactor `scm_prompt` usage in themes, which used copied code instead of a centralised location

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Problems I encountered during debugging of https://github.com/akinomyoga/ble.sh/issues/110 prompted me to fix the theme.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
