### PR TITLE
Add history flushes on each command to the powerline themes

### DIFF
--- a/themes/powerline-multiline/powerline-multiline.base.bash
+++ b/themes/powerline-multiline/powerline-multiline.base.bash
@@ -60,6 +60,7 @@ function __powerline_prompt_command {
   SEGMENTS_AT_LEFT=0
   SEGMENTS_AT_RIGHT=0
   LAST_SEGMENT_COLOR=""
+  _save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 
   ## left prompt ##
   for segment in $POWERLINE_LEFT_PROMPT; do

--- a/themes/powerline-multiline/powerline-multiline.base.bash
+++ b/themes/powerline-multiline/powerline-multiline.base.bash
@@ -1,105 +1,107 @@
+# shellcheck shell=bash
 . "$BASH_IT/themes/powerline/powerline.base.bash"
 
 function __powerline_last_status_prompt {
-  [[ "$1" -ne 0 ]] && echo "$(set_color ${LAST_STATUS_THEME_PROMPT_COLOR} -) ${1} ${normal}"
+	[[ "$1" -ne 0 ]] && echo "$(set_color "${LAST_STATUS_THEME_PROMPT_COLOR}" -) ${1} ${normal}"
 }
 
 function __powerline_right_segment {
-  local OLD_IFS="${IFS}"; IFS="|"
-  local params=( $1 )
-  IFS="${OLD_IFS}"
-  local padding=0
-  local pad_before_segment=" "
+	local OLD_IFS="${IFS}"
+	IFS="|"
+	local params=("$1")
+	IFS="${OLD_IFS}"
+	local padding=0
+	local pad_before_segment=" "
 
-  if [[ "${SEGMENTS_AT_RIGHT}" -eq 0 ]]; then
-    if [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT}" -ne 0 ]]; then
-      pad_before_segment=""
-    fi
-    RIGHT_PROMPT+="$(set_color ${params[1]} -)${POWERLINE_RIGHT_END}${normal}"
-    (( padding += 1 ))
-  else
-    if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR}" -ne 0 ]]; then
-      pad_before_segment=""
-    fi
-    # Since the previous segment wasn't the last segment, add padding, if needed
-    #
-    if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR}" -eq 0 ]]; then
-      RIGHT_PROMPT+="$(set_color - ${LAST_SEGMENT_COLOR}) ${normal}"
-      (( padding += 1 ))
-    fi
-    if [[ "${LAST_SEGMENT_COLOR}" -eq "${params[1]}" ]]; then
-      RIGHT_PROMPT+="$(set_color - ${LAST_SEGMENT_COLOR})${POWERLINE_RIGHT_SEPARATOR_SOFT}${normal}"
-    else
-      RIGHT_PROMPT+="$(set_color ${params[1]} ${LAST_SEGMENT_COLOR})${POWERLINE_RIGHT_SEPARATOR}${normal}"
-    fi
-    (( padding += 1 ))
-  fi
+	if [[ "${SEGMENTS_AT_RIGHT}" -eq 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT}" -ne 0 ]]; then
+			pad_before_segment=""
+		fi
+		RIGHT_PROMPT+="$(set_color "${params[1]}" -)${POWERLINE_RIGHT_END}${normal}"
+		((padding += 1))
+	else
+		if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR}" -ne 0 ]]; then
+			pad_before_segment=""
+		fi
+		# Since the previous segment wasn't the last segment, add padding, if needed
+		#
+		if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR}" -eq 0 ]]; then
+			RIGHT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}") ${normal}"
+			((padding += 1))
+		fi
+		if [[ "${LAST_SEGMENT_COLOR}" -eq "${params[1]}" ]]; then
+			RIGHT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}")${POWERLINE_RIGHT_SEPARATOR_SOFT}${normal}"
+		else
+			RIGHT_PROMPT+="$(set_color "${params[1]}" "${LAST_SEGMENT_COLOR}")${POWERLINE_RIGHT_SEPARATOR}${normal}"
+		fi
+		((padding += 1))
+	fi
 
-  RIGHT_PROMPT+="$(set_color - ${params[1]})${pad_before_segment}${params[0]}${normal}"
+	RIGHT_PROMPT+="$(set_color - "${params[1]}")${pad_before_segment}${params[0]}${normal}"
 
-  (( padding += ${#pad_before_segment} ))
-  (( padding += ${#params[0]} ))
+	((padding += ${#pad_before_segment}))
+	((padding += ${#params[0]}))
 
-  (( RIGHT_PROMPT_LENGTH += padding ))
-  LAST_SEGMENT_COLOR="${params[1]}"
-  (( SEGMENTS_AT_RIGHT += 1 ))
+	((RIGHT_PROMPT_LENGTH += padding))
+	LAST_SEGMENT_COLOR="${params[1]}"
+	((SEGMENTS_AT_RIGHT += 1))
 }
 
 function __powerline_right_first_segment_padding {
-  RIGHT_PROMPT+="$(set_color - ${LAST_SEGMENT_COLOR}) ${normal}"
-  (( RIGHT_PROMPT_LENGTH += 1 ))
+	RIGHT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}") ${normal}"
+	((RIGHT_PROMPT_LENGTH += 1))
 }
 
 function __powerline_prompt_command {
-  local last_status="$?" ## always the first
-  local move_cursor_rightmost='\033[500C'
+	local last_status="$?" ## always the first
+	local move_cursor_rightmost='\033[500C'
 
-  LEFT_PROMPT=""
-  RIGHT_PROMPT=""
-  RIGHT_PROMPT_LENGTH=${POWERLINE_PADDING}
-  SEGMENTS_AT_LEFT=0
-  SEGMENTS_AT_RIGHT=0
-  LAST_SEGMENT_COLOR=""
-  _save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
+	LEFT_PROMPT=""
+	RIGHT_PROMPT=""
+	RIGHT_PROMPT_LENGTH=${POWERLINE_PADDING}
+	SEGMENTS_AT_LEFT=0
+	SEGMENTS_AT_RIGHT=0
+	LAST_SEGMENT_COLOR=""
+	_save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 
-  ## left prompt ##
-  for segment in $POWERLINE_LEFT_PROMPT; do
-    local info="$(__powerline_${segment}_prompt)"
-    [[ -n "${info}" ]] && __powerline_left_segment "${info}"
-  done
+	## left prompt ##
+	for segment in $POWERLINE_LEFT_PROMPT; do
+		local info="$(__powerline_"${segment}"_prompt)"
+		[[ -n "${info}" ]] && __powerline_left_segment "${info}"
+	done
 
-  if [[ -n "${LEFT_PROMPT}" ]] && [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT}" -eq 0 ]]; then
-    __powerline_left_last_segment_padding
-  fi
+	if [[ -n "${LEFT_PROMPT}" ]] && [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT}" -eq 0 ]]; then
+		__powerline_left_last_segment_padding
+	fi
 
-  [[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -)${POWERLINE_LEFT_END}${normal}"
+	[[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="$(set_color "${LAST_SEGMENT_COLOR}" -)${POWERLINE_LEFT_END}${normal}"
 
-  ## right prompt ##
-  if [[ -n "${POWERLINE_RIGHT_PROMPT}" ]]; then
-    # LEFT_PROMPT+="${move_cursor_rightmost}"
-    for segment in $POWERLINE_RIGHT_PROMPT; do
-      local info="$(__powerline_${segment}_prompt)"
-      [[ -n "${info}" ]] && __powerline_right_segment "${info}"
-    done
+	## right prompt ##
+	if [[ -n "${POWERLINE_RIGHT_PROMPT}" ]]; then
+		# LEFT_PROMPT+="${move_cursor_rightmost}"
+		for segment in $POWERLINE_RIGHT_PROMPT; do
+			local info="$(__powerline_"${segment}"_prompt)"
+			[[ -n "${info}" ]] && __powerline_right_segment "${info}"
+		done
 
-    if [[ -n "${RIGHT_PROMPT}" ]] && [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT}" -eq 0 ]]; then
-      __powerline_right_first_segment_padding
-    fi
+		if [[ -n "${RIGHT_PROMPT}" ]] && [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT}" -eq 0 ]]; then
+			__powerline_right_first_segment_padding
+		fi
 
-    RIGHT_PAD=$(printf "%.s " $(seq 1 $RIGHT_PROMPT_LENGTH))
-    LEFT_PROMPT+="${RIGHT_PAD}${move_cursor_rightmost}"
-    LEFT_PROMPT+="\033[$(( ${#RIGHT_PAD} - 1 ))D"
-  fi
+		RIGHT_PAD=$(printf "%.s " $(seq 1 "$RIGHT_PROMPT_LENGTH"))
+		LEFT_PROMPT+="${RIGHT_PAD}${move_cursor_rightmost}"
+		LEFT_PROMPT+="\033[$((${#RIGHT_PAD} - 1))D"
+	fi
 
-  local prompt="${PROMPT_CHAR}"
-  if [[ "${POWERLINE_COMPACT_PROMPT}" -eq 0 ]]; then
-    prompt+=" "
-  fi
+	local prompt="${PROMPT_CHAR}"
+	if [[ "${POWERLINE_COMPACT_PROMPT}" -eq 0 ]]; then
+		prompt+=" "
+	fi
 
-  PS1="${LEFT_PROMPT}${RIGHT_PROMPT}\n$(__powerline_last_status_prompt ${last_status})${prompt}"
+	PS1="${LEFT_PROMPT}${RIGHT_PROMPT}\n$(__powerline_last_status_prompt ${last_status})${prompt}"
 
-  ## cleanup ##
-  unset LAST_SEGMENT_COLOR \
-        LEFT_PROMPT RIGHT_PROMPT RIGHT_PROMPT_LENGTH \
-        SEGMENTS_AT_LEFT SEGMENTS_AT_RIGHT
+	## cleanup ##
+	unset LAST_SEGMENT_COLOR \
+		LEFT_PROMPT RIGHT_PROMPT RIGHT_PROMPT_LENGTH \
+		SEGMENTS_AT_LEFT SEGMENTS_AT_RIGHT
 }

--- a/themes/powerline-naked/powerline-naked.base.bash
+++ b/themes/powerline-naked/powerline-naked.base.bash
@@ -26,6 +26,7 @@ function __powerline_left_segment {
   LEFT_PROMPT+="$(set_color ${params[1]} -)${pad_before_segment}${params[0]}${normal}"
   LAST_SEGMENT_COLOR=${params[1]}
   (( SEGMENTS_AT_LEFT += 1 ))
+  _save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 }
 
 function __powerline_left_last_segment_padding {

--- a/themes/powerline-naked/powerline-naked.base.bash
+++ b/themes/powerline-naked/powerline-naked.base.bash
@@ -1,34 +1,36 @@
+# shellcheck shell=bash
 . "$BASH_IT/themes/powerline/powerline.base.bash"
 
 function __powerline_left_segment {
-  local OLD_IFS="${IFS}"; IFS="|"
-  local params=( $1 )
-  IFS="${OLD_IFS}"
-  local separator=""
-  local pad_before_segment=" "
+	local OLD_IFS="${IFS}"
+	IFS="|"
+	local params=("$1")
+	IFS="${OLD_IFS}"
+	local separator=""
+	local pad_before_segment=" "
 
-  if [[ "${SEGMENTS_AT_LEFT}" -eq 0 ]]; then
-    if [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT}" -ne 0 ]]; then
-      pad_before_segment=""
-    fi
-  else
-    if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR}" -ne 0 ]]; then
-      pad_before_segment=""
-    fi
-    # Since the previous segment wasn't the last segment, add padding, if needed
-    #
-    if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR}" -eq 0 ]]; then
-      LEFT_PROMPT+=" "
-    fi
-    LEFT_PROMPT+="${POWERLINE_LEFT_SEPARATOR}"
-  fi
+	if [[ "${SEGMENTS_AT_LEFT}" -eq 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT}" -ne 0 ]]; then
+			pad_before_segment=""
+		fi
+	else
+		if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR}" -ne 0 ]]; then
+			pad_before_segment=""
+		fi
+		# Since the previous segment wasn't the last segment, add padding, if needed
+		#
+		if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR}" -eq 0 ]]; then
+			LEFT_PROMPT+=" "
+		fi
+		LEFT_PROMPT+="${POWERLINE_LEFT_SEPARATOR}"
+	fi
 
-  LEFT_PROMPT+="$(set_color ${params[1]} -)${pad_before_segment}${params[0]}${normal}"
-  LAST_SEGMENT_COLOR=${params[1]}
-  (( SEGMENTS_AT_LEFT += 1 ))
-  _save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
+	LEFT_PROMPT+="$(set_color "${params[1]}" -)${pad_before_segment}${params[0]}${normal}"
+	LAST_SEGMENT_COLOR=${params[1]}
+	((SEGMENTS_AT_LEFT += 1))
+	_save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 }
 
 function __powerline_left_last_segment_padding {
-  LEFT_PROMPT+="$(set_color ${LAST_SEGMENT_COLOR} -) ${normal}"
+	LEFT_PROMPT+="$(set_color "${LAST_SEGMENT_COLOR}" -) ${normal}"
 }

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -255,6 +255,7 @@ function __powerline_prompt_command() {
 	LEFT_PROMPT=""
 	SEGMENTS_AT_LEFT=0
 	LAST_SEGMENT_COLOR=""
+	save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 
 	if [[ -n "${POWERLINE_PROMPT_DISTRO_LOGO}" ]]; then
 		LEFT_PROMPT+="$(set_color "${PROMPT_DISTRO_LOGO_COLOR}" "${PROMPT_DISTRO_LOGO_COLORBG}")${PROMPT_DISTRO_LOGO}$(set_color - -)"


### PR DESCRIPTION
## Description
History autosave enabled for a few more themes I use.

## Motivation and Context
Was only supported by one theme, I wanted it on the powerline-multiline too.

## How Has This Been Tested?
I eat my own dogfood :-)


## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
