### PR TITLE
Fix npm version 7.17.0 will give errors.

### DIFF
--- a/plugins/available/proxy.plugin.bash
+++ b/plugins/available/proxy.plugin.bash
@@ -133,7 +133,7 @@ npm-disable-proxy ()
 	if $(command -v npm &> /dev/null) ; then
 		npm config delete proxy
 		npm config delete https-proxy
-		npm config delete noproxy
+		npm config delete no_proxy
 		echo "Disabled npm proxy settings"
 	fi
 }
@@ -150,7 +150,7 @@ npm-enable-proxy ()
 	if $(command -v npm &> /dev/null) ; then
 		npm config set proxy $my_http_proxy
 		npm config set https-proxy $my_https_proxy
-		npm config set noproxy $my_no_proxy
+		npm config set no_proxy $my_no_proxy
 		echo "Enabled npm proxy settings"
 	fi
 }


### PR DESCRIPTION
## Description

After upgrade node's npm to version 7.17.0, it will give errors when type `enable-proxy`.

## Motivation and Context

It's a bug fix.

## How Has This Been Tested?

Works in my machine.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
