### PR TITLE
move to Libera.Chat

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 ![Docs Status](https://readthedocs.org/projects/bash-it/badge/)
 ![License](https://img.shields.io/github/license/Bash-it/bash-it)
 ![shell](https://img.shields.io/badge/Shell-Bash-blue)
-[![Join the chat at https://webchat.freenode.net/?channel=#bash-it](https://img.shields.io/badge/chat-on%20freenode-brightgreen.svg)](https://webchat.freenode.net/?channel=#bash-it)
+[![Join the chat at https://web.libera.chat/?channel=#bash-it](https://img.shields.io/badge/chat-on%20Libera.Chat-brightgreen.svg)](https://web.libera.chat/?channel=#bash-it)
 
 **Bash-it** is a collection of community Bash commands and scripts for Bash 3.2+.
 (And a shameless ripoff of [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh) :smiley:)


### PR DESCRIPTION
## Description
Change up chat networks

## Motivation and Context
Freenode changed owners and governance and as a result there has been a mass exodus to Libera.Chat. This includes other big names like KDE, Ubuntu, Debian, and many others.
