### PR TITLE
Glob for *.bash properly when path contains spaces

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -1,145 +1,114 @@
 #!/usr/bin/env bash
+# shellcheck source-path=SCRIPTDIR/lib source-path=SCRIPTDIR/scripts
+# shellcheck disable=SC2034
+#
 # Initialize Bash It
 BASH_IT_LOG_PREFIX="core: main: "
-
-# Only set $BASH_IT if it's not already set
-if [ -z "${BASH_IT:-}" ]; then
-	# Setting $BASH to maintain backwards compatibility
-	export BASH_IT=$BASH
-	BASH="$(bash -c 'echo $BASH')"
-	export BASH
-	BASH_IT_OLD_BASH_SETUP=true
-fi
+: "${BASH_IT:=${BASH_SOURCE%/*}}"
+: "${BASH_IT_CUSTOM:=${BASH_IT}/custom}"
+: "${CUSTOM_THEME_DIR:="${BASH_IT_CUSTOM}/themes"}"
+: "${BASH_IT_BASHRC:=${BASH_SOURCE[${#BASH_SOURCE[@]} - 1]}}"
 
 # Load composure first, so we support function metadata
-# shellcheck disable=SC1090
-source "${BASH_IT}"/vendor/github.com/erichs/composure/composure.sh
-
-# Declare our end-of-main finishing hook
-declare -a _bash_it_library_finalize_hook
-
-# We need to load logging module early in order to be able to log
-# shellcheck source-path=SCRIPTDIR/lib
-source "${BASH_IT}/lib/log.bash"
-
-# We can only log it now
-[ -z "${BASH_IT_OLD_BASH_SETUP:-}" ] || _log_warning "BASH_IT variable not initialized, please upgrade your bash-it version and reinstall it!"
-
-# For backwards compatibility, look in old BASH_THEME location
-if [ -z "${BASH_IT_THEME:-}" ]; then
-	_log_warning "BASH_IT_THEME variable not initialized, please upgrade your bash-it version and reinstall it!"
-	export BASH_IT_THEME="${BASH_THEME:-}"
-	unset BASH_THEME
-fi
-
+# shellcheck source-path=SCRIPTDIR/vendor/github.com/erichs/composure
+source "${BASH_IT}/vendor/github.com/erichs/composure/composure.sh"
 # support 'plumbing' metadata
 cite _about _param _example _group _author _version
 cite about-alias about-plugin about-completion
 
+# Declare our end-of-main finishing hook, but don't use `declare`/`typeset`
+_bash_it_library_finalize_hook=()
+
+# We need to load logging module early in order to be able to log
+source "${BASH_IT}/lib/log.bash"
+
 # libraries, but skip appearance (themes) for now
 _log_debug "Loading libraries(except appearance)..."
-LIB="${BASH_IT}/lib/*.bash"
 APPEARANCE_LIB="${BASH_IT}/lib/appearance.bash"
-for _bash_it_config_file in $LIB; do
-	if [ "$_bash_it_config_file" != "$APPEARANCE_LIB" ]; then
-		filename=${_bash_it_config_file##*/}
-		filename=${filename%.bash}
-		BASH_IT_LOG_PREFIX="lib: ${filename}: "
-		_log_debug "Loading library file..."
-		# shellcheck disable=SC1090
-		source "$_bash_it_config_file"
-	fi
+for _bash_it_main_file_lib in "${BASH_IT}/lib"/*.bash; do
+	[[ "$_bash_it_main_file_lib" == "$APPEARANCE_LIB" ]] && continue
+	filename="${_bash_it_main_file_lib##*/}"
+	filename="${filename%.bash}"
+	BASH_IT_LOG_PREFIX="lib: ${filename}: "
+	_log_debug "Loading library file..."
+	# shellcheck disable=SC1090
+	source "$_bash_it_main_file_lib"
+	BASH_IT_LOG_PREFIX="core: main: "
 done
 
-BASH_IT_LOG_PREFIX="core: main: "
-# Load the global "enabled" directory
-# "family" param is empty so that files get sources in glob order
-# shellcheck source=./scripts/reloader.bash
-source "${BASH_IT}/scripts/reloader.bash"
-
-# Load enabled aliases, completion, plugins
-for file_type in "aliases" "plugins" "completion"; do
-	# shellcheck source=./scripts/reloader.bash
-	source "${BASH_IT}/scripts/reloader.bash" "skip" "$file_type"
+# Load the global "enabled" directory, then enabled aliases, completion, plugins
+# "file_type" param is empty so that files get sourced in glob order
+for file_type in "" "aliases" "plugins" "completion"; do
+	BASH_IT_LOG_PREFIX="core: reloader: "
+	source "${BASH_IT}/scripts/reloader.bash" "${file_type:+skip}" "$file_type"
+	BASH_IT_LOG_PREFIX="core: main: "
 done
 
 # Load theme, if a theme was set
-if [[ -n "${BASH_IT_THEME}" ]]; then
-	_log_debug "Loading \"${BASH_IT_THEME}\" theme..."
+# shellcheck source-path=SCRIPTDIR/themes
+if [[ -n "${BASH_IT_THEME:-}" ]]; then
+	_log_debug "Loading theme '${BASH_IT_THEME}'."
 	BASH_IT_LOG_PREFIX="themes: githelpers: "
-	# shellcheck source=./themes/githelpers.theme.bash
 	source "${BASH_IT}/themes/githelpers.theme.bash"
 	BASH_IT_LOG_PREFIX="themes: p4helpers: "
-	# shellcheck source=./themes/p4helpers.theme.bash
 	source "${BASH_IT}/themes/p4helpers.theme.bash"
 	BASH_IT_LOG_PREFIX="themes: command_duration: "
-	# shellcheck source=./themes/command_duration.theme.bash
 	source "${BASH_IT}/themes/command_duration.theme.bash"
 	BASH_IT_LOG_PREFIX="themes: base: "
-	# shellcheck source=./themes/base.theme.bash
 	source "${BASH_IT}/themes/base.theme.bash"
 
 	BASH_IT_LOG_PREFIX="lib: appearance: "
 	# appearance (themes) now, after all dependencies
-	# shellcheck source=./lib/appearance.bash
+	# shellcheck source=SCRIPTDIR/lib/appearance.bash
 	source "$APPEARANCE_LIB"
+	BASH_IT_LOG_PREFIX="core: main: "
 fi
 
-BASH_IT_LOG_PREFIX="core: main: "
 _log_debug "Loading custom aliases, completion, plugins..."
 for file_type in "aliases" "completion" "plugins"; do
-	if [ -e "${BASH_IT}/${file_type}/custom.${file_type}.bash" ]; then
+	if [[ -s "${BASH_IT}/${file_type}/custom.${file_type}.bash" ]]; then
 		BASH_IT_LOG_PREFIX="${file_type}: custom: "
 		_log_debug "Loading component..."
 		# shellcheck disable=SC1090
 		source "${BASH_IT}/${file_type}/custom.${file_type}.bash"
 	fi
+	BASH_IT_LOG_PREFIX="core: main: "
 done
 
 # Custom
-BASH_IT_LOG_PREFIX="core: main: "
 _log_debug "Loading general custom files..."
-CUSTOM="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/*.bash ${BASH_IT_CUSTOM:=${BASH_IT}/custom}/**/*.bash"
-for _bash_it_config_file in $CUSTOM; do
-	if [ -e "${_bash_it_config_file}" ]; then
-		filename=$(basename "${_bash_it_config_file}")
-		filename=${filename%*.bash}
-		# shellcheck disable=SC2034
+for _bash_it_main_file_custom in "${BASH_IT_CUSTOM}"/*.bash "${BASH_IT_CUSTOM}"/*/*.bash; do
+	if [[ -s "${_bash_it_main_file_custom}" ]]; then
+		filename="${_bash_it_main_file_custom##*/}"
+		filename="${filename%*.bash}"
 		BASH_IT_LOG_PREFIX="custom: $filename: "
 		_log_debug "Loading custom file..."
 		# shellcheck disable=SC1090
-		source "$_bash_it_config_file"
+		source "$_bash_it_main_file_custom"
 	fi
+	BASH_IT_LOG_PREFIX="core: main: "
 done
 
-unset _bash_it_config_file
 if [[ -n "${PROMPT:-}" ]]; then
-	export PS1="\[""$PROMPT""\]"
+	PS1="${PROMPT}"
 fi
 
 # Adding Support for other OSes
-PREVIEW="less"
-
-if [ -s /usr/bin/gloobus-preview ]; then
+if _command_exists gloobus-preview; then
 	PREVIEW="gloobus-preview"
-elif [ -s /Applications/Preview.app ]; then
-	# shellcheck disable=SC2034
+elif [[ -d /Applications/Preview.app ]]; then
 	PREVIEW="/Applications/Preview.app"
+else
+	PREVIEW="less"
 fi
 
 # BASH_IT_RELOAD_LEGACY is set.
-if ! _command_exists reload && [[ -n "${BASH_IT_RELOAD_LEGACY:-}" ]]; then
-	case $OSTYPE in
-		darwin*)
-			alias reload='source ~/.bash_profile'
-			;;
-		*)
-			alias reload='source ~/.bashrc'
-			;;
-	esac
+if [[ -n "${BASH_IT_RELOAD_LEGACY:-}" ]] && ! _command_exists reload; then
+	# shellcheck disable=SC2139
+	alias reload="builtin source '${BASH_IT_BASHRC?}'"
 fi
 
 for _bash_it_library_finalize_f in "${_bash_it_library_finalize_hook[@]:-}"; do
 	eval "${_bash_it_library_finalize_f?}" # Use `eval` to achieve the same behavior as `$PROMPT_COMMAND`.
 done
-unset "${!_bash_it_library_finalize_@}"
+unset "${!_bash_it_library_finalize_@}" "${!_bash_it_main_file_@}" filename file_type

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -27,9 +27,7 @@ _log_debug "Loading libraries(except appearance)..."
 APPEARANCE_LIB="${BASH_IT}/lib/appearance.bash"
 for _bash_it_main_file_lib in "${BASH_IT}/lib"/*.bash; do
 	[[ "$_bash_it_main_file_lib" == "$APPEARANCE_LIB" ]] && continue
-	filename="${_bash_it_main_file_lib##*/}"
-	filename="${filename%.bash}"
-	BASH_IT_LOG_PREFIX="lib: ${filename}: "
+	_bash-it-log-prefix-by-path "${_bash_it_main_file_lib}"
 	_log_debug "Loading library file..."
 	# shellcheck disable=SC1090
 	source "$_bash_it_main_file_lib"
@@ -66,11 +64,13 @@ fi
 
 _log_debug "Loading custom aliases, completion, plugins..."
 for file_type in "aliases" "completion" "plugins"; do
-	if [[ -s "${BASH_IT}/${file_type}/custom.${file_type}.bash" ]]; then
-		BASH_IT_LOG_PREFIX="${file_type}: custom: "
+	_bash_it_main_file_custom="${BASH_IT}/${file_type}/custom.${file_type}.bash"
+	if [[ -s "${_bash_it_main_file_custom}" ]]; then
+		_bash-it-log-prefix-by-path "${_bash_it_main_file_custom}"
 		_log_debug "Loading component..."
+		# shellcheck source-path=SCRIPTDIR/aliases source-path=SCRIPTDIR/completions source-path=SCRIPTDIR/plugins
 		# shellcheck disable=SC1090
-		source "${BASH_IT}/${file_type}/custom.${file_type}.bash"
+		source "${_bash_it_main_file_custom}"
 	fi
 	BASH_IT_LOG_PREFIX="core: main: "
 done
@@ -79,9 +79,7 @@ done
 _log_debug "Loading general custom files..."
 for _bash_it_main_file_custom in "${BASH_IT_CUSTOM}"/*.bash "${BASH_IT_CUSTOM}"/*/*.bash; do
 	if [[ -s "${_bash_it_main_file_custom}" ]]; then
-		filename="${_bash_it_main_file_custom##*/}"
-		filename="${filename%*.bash}"
-		BASH_IT_LOG_PREFIX="custom: $filename: "
+		_bash-it-log-prefix-by-path "${_bash_it_main_file_custom}"
 		_log_debug "Loading custom file..."
 		# shellcheck disable=SC1090
 		source "$_bash_it_main_file_custom"
@@ -111,4 +109,4 @@ fi
 for _bash_it_library_finalize_f in "${_bash_it_library_finalize_hook[@]:-}"; do
 	eval "${_bash_it_library_finalize_f?}" # Use `eval` to achieve the same behavior as `$PROMPT_COMMAND`.
 done
-unset "${!_bash_it_library_finalize_@}" "${!_bash_it_main_file_@}" filename file_type
+unset "${!_bash_it_library_finalize_@}" "${!_bash_it_main_file_@}" file_type

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -35,10 +35,10 @@ for _bash_it_main_file_lib in "${BASH_IT}/lib"/*.bash; do
 done
 
 # Load the global "enabled" directory, then enabled aliases, completion, plugins
-# "file_type" param is empty so that files get sourced in glob order
-for file_type in "" "aliases" "plugins" "completion"; do
+# "_bash_it_main_file_type" param is empty so that files get sourced in glob order
+for _bash_it_main_file_type in "" "aliases" "plugins" "completion"; do
 	BASH_IT_LOG_PREFIX="core: reloader: "
-	source "${BASH_IT}/scripts/reloader.bash" "${file_type:+skip}" "$file_type"
+	source "${BASH_IT}/scripts/reloader.bash" "${_bash_it_main_file_type:+skip}" "$_bash_it_main_file_type"
 	BASH_IT_LOG_PREFIX="core: main: "
 done
 
@@ -63,12 +63,11 @@ if [[ -n "${BASH_IT_THEME:-}" ]]; then
 fi
 
 _log_debug "Loading custom aliases, completion, plugins..."
-for file_type in "aliases" "completion" "plugins"; do
-	_bash_it_main_file_custom="${BASH_IT}/${file_type}/custom.${file_type}.bash"
+for _bash_it_main_file_type in "aliases" "completion" "plugins"; do
+	_bash_it_main_file_custom="${BASH_IT}/${_bash_it_main_file_type}/custom.${_bash_it_main_file_type}.bash"
 	if [[ -s "${_bash_it_main_file_custom}" ]]; then
 		_bash-it-log-prefix-by-path "${_bash_it_main_file_custom}"
 		_log_debug "Loading component..."
-		# shellcheck source-path=SCRIPTDIR/aliases source-path=SCRIPTDIR/completions source-path=SCRIPTDIR/plugins
 		# shellcheck disable=SC1090
 		source "${_bash_it_main_file_custom}"
 	fi
@@ -109,4 +108,4 @@ fi
 for _bash_it_library_finalize_f in "${_bash_it_library_finalize_hook[@]:-}"; do
 	eval "${_bash_it_library_finalize_f?}" # Use `eval` to achieve the same behavior as `$PROMPT_COMMAND`.
 done
-unset "${!_bash_it_library_finalize_@}" "${!_bash_it_main_file_@}" file_type
+unset "${!_bash_it_library_finalize_@}" "${!_bash_it_main_file_@}"


### PR DESCRIPTION
## Description
Instead of $LIB and $CUSTOM variables, use the glob pattern in the foreach statement quoting the path but not the glob. Quoting the glob will make it not a glob, but when expanding the not-quoted $LIB or $CUSTOM variable Bash will split all words, including spaces in the actual path. This helps towards #1696.

This is literally one of the examples under Code Style on the contribution page.

Closes #1435.

## Motivation and Context
This resolves the failure to source the files under $BASH_IT/lib when there is any space in $BASH_IT, such as when the user name contains a space or the path to the repository contains a space.

You can reproduce this with a user short name with a space, which is possible with the "MacBuddy" default setup assistant on Mac OS X, or if $BASH_IT is set to a path containing an (additional) space, like if I cloned to ~/Library/Application Support/Bash It. Windows commonly has user names with spaces. 

## How Has This Been Tested?
This is my current working branch since July on my system where $BASH_IT is ~/Library/Application Support/Bash It (that's two spaces in the path).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
