### PR TITLE
Gracefully handle unbound parameters

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -3,7 +3,7 @@
 BASH_IT_LOG_PREFIX="core: main: "
 
 # Only set $BASH_IT if it's not already set
-if [ -z "$BASH_IT" ]; then
+if [ -z "${BASH_IT:-}" ]; then
 	# Setting $BASH to maintain backwards compatibility
 	export BASH_IT=$BASH
 	BASH="$(bash -c 'echo $BASH')"
@@ -20,12 +20,12 @@ source "${BASH_IT}"/vendor/github.com/erichs/composure/composure.sh
 source "${BASH_IT}/lib/log.bash"
 
 # We can only log it now
-[ -z "$BASH_IT_OLD_BASH_SETUP" ] || _log_warning "BASH_IT variable not initialized, please upgrade your bash-it version and reinstall it!"
+[ -z "${BASH_IT_OLD_BASH_SETUP:-}" ] || _log_warning "BASH_IT variable not initialized, please upgrade your bash-it version and reinstall it!"
 
 # For backwards compatibility, look in old BASH_THEME location
-if [ -z "$BASH_IT_THEME" ]; then
+if [ -z "${BASH_IT_THEME:-}" ]; then
 	_log_warning "BASH_IT_THEME variable not initialized, please upgrade your bash-it version and reinstall it!"
-	export BASH_IT_THEME="$BASH_THEME"
+	export BASH_IT_THEME="${BASH_THEME:-}"
 	unset BASH_THEME
 fi
 
@@ -122,7 +122,7 @@ for _bash_it_config_file in $CUSTOM; do
 done
 
 unset _bash_it_config_file
-if [[ $PROMPT ]]; then
+if [[ "${PROMPT:-}" ]]; then
 	export PS1="\[""$PROMPT""\]"
 fi
 

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -144,7 +144,7 @@ if [ -e "$HOME/.jekyllconfig" ]; then
 fi
 
 # BASH_IT_RELOAD_LEGACY is set.
-if ! command -v reload &> /dev/null && [ -n "$BASH_IT_RELOAD_LEGACY" ]; then
+if ! command -v reload &> /dev/null && [ -n "${BASH_IT_RELOAD_LEGACY:-}" ]; then
 	case $OSTYPE in
 		darwin*)
 			alias reload='source ~/.bash_profile'

--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -3,6 +3,14 @@
 # Loads the system's Bash completion modules.
 # If Homebrew is installed (OS X), it's Bash completion modules are loaded.
 
+if shopt -qo nounset
+then # Bash-completion is too large and complex to expect to handle unbound variables throughout the whole codebase.
+	BASH_IT_RESTORE_NOUNSET=true
+	shopt -uo nounset
+else
+	BASH_IT_RESTORE_NOUNSET=false
+fi
+
 if [[ -r "${BASH_COMPLETION:-}" ]] ; then
 	source "${BASH_COMPLETION}"
 elif [[ -r /etc/bash_completion ]] ; then
@@ -22,3 +30,9 @@ then
     source "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh
   fi
 fi
+
+if $BASH_IT_RESTORE_NOUNSET
+then
+	shopt -so nounset
+fi
+unset BASH_IT_RESTORE_NOUNSET

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -156,7 +156,7 @@ bash-it ()
             $func $arg
         done
 
-        if [ -n "$BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE" ]; then
+        if [ -n "${BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE:-}" ]; then
           _bash-it-reload
         fi
     else

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -354,8 +354,8 @@ _bash-it-migrate() {
       disable_func="_disable-$single_type"
       enable_func="_enable-$single_type"
 
-      $disable_func $component_name
-      $enable_func $component_name
+      $disable_func "$component_name"
+      $enable_func "$component_name"
     done
   done
 
@@ -375,7 +375,7 @@ _bash-it-version() {
 
   cd "${BASH_IT}" || return
 
-  if [ -z $BASH_IT_REMOTE ]; then
+  if [ -z "${BASH_IT_REMOTE:-}" ]; then
     BASH_IT_REMOTE="origin"
   fi
 

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -45,7 +45,7 @@ function _log_warning()
   group 'log'
 
   [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_WARNING ]] || return 0
-  _log_general "${echo_yellow}" " WARN: " "$1"
+  _log_general "${echo_yellow:-}" " WARN: " "$1"
 }
 
 function _log_error()

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -22,8 +22,8 @@ function _log_general()
   param '3: message to log'
   group 'log'
 
-  message=$2${BASH_IT_LOG_PREFIX}$3
-  _has_colors && echo -e "$1${message}${echo_normal}" || echo -e "${message}"
+  message=$2${BASH_IT_LOG_PREFIX:-default: }$3
+  _has_colors && echo -e "$1${message}${echo_normal:-}" || echo -e "${message}"
 }
 
 function _log_debug()
@@ -33,8 +33,8 @@ function _log_debug()
   example '$ _log_debug "Loading plugin git..."'
   group 'log'
 
-  [[ "$BASH_IT_LOG_LEVEL" -ge $BASH_IT_LOG_LEVEL_ALL ]] || return 0
-  _log_general "${echo_green}" "DEBUG: " "$1"
+  [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_ALL ]] || return 0
+  _log_general "${echo_green:-}" "DEBUG: " "$1"
 }
 
 function _log_warning()
@@ -44,7 +44,7 @@ function _log_warning()
   example '$ _log_warning "git binary not found, disabling git plugin..."'
   group 'log'
 
-  [[ "$BASH_IT_LOG_LEVEL" -ge $BASH_IT_LOG_LEVEL_WARNING ]] || return 0
+  [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_WARNING ]] || return 0
   _log_general "${echo_yellow}" " WARN: " "$1"
 }
 
@@ -55,6 +55,6 @@ function _log_error()
   example '$ _log_error "Failed to load git plugin..."'
   group 'log'
 
-  [[ "$BASH_IT_LOG_LEVEL" -ge $BASH_IT_LOG_LEVEL_ERROR ]] || return 0
-  _log_general "${echo_red}" "ERROR: " "$1"
+  [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_ERROR ]] || return 0
+  _log_general "${echo_red:-}" "ERROR: " "$1"
 }

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -33,7 +33,7 @@ function _log_debug()
   example '$ _log_debug "Loading plugin git..."'
   group 'log'
 
-  [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_ALL ]] || return 0
+  [[ "${BASH_IT_LOG_LEVEL:-0}" -ge $BASH_IT_LOG_LEVEL_ALL ]] || return 0
   _log_general "${echo_green:-}" "DEBUG: " "$1"
 }
 
@@ -44,7 +44,7 @@ function _log_warning()
   example '$ _log_warning "git binary not found, disabling git plugin..."'
   group 'log'
 
-  [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_WARNING ]] || return 0
+  [[ "${BASH_IT_LOG_LEVEL:-0}" -ge $BASH_IT_LOG_LEVEL_WARNING ]] || return 0
   _log_general "${echo_yellow:-}" " WARN: " "$1"
 }
 
@@ -55,6 +55,6 @@ function _log_error()
   example '$ _log_error "Failed to load git plugin..."'
   group 'log'
 
-  [[ "${BASH_IT_LOG_LEVEL:-1}" -ge $BASH_IT_LOG_LEVEL_ERROR ]] || return 0
+  [[ "${BASH_IT_LOG_LEVEL:-0}" -ge $BASH_IT_LOG_LEVEL_ERROR ]] || return 0
   _log_general "${echo_red:-}" "ERROR: " "$1"
 }

--- a/lib/preview.bash
+++ b/lib/preview.bash
@@ -1,4 +1,4 @@
-if [[ $BASH_PREVIEW ]];
+if [[ "${BASH_PREVIEW:-}" ]];
 then
   unset BASH_PREVIEW #Prevent infinite looping
   echo "

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -58,7 +58,7 @@ _bash-it-array-dedup() {
 
 # Outputs a full path of the grep found on the filesystem
 _bash-it-grep() {
-  if [[ -z "${BASH_IT_GREP}" ]] ; then
+  if [[ -z "${BASH_IT_GREP:-}" ]] ; then
     export BASH_IT_GREP="$(which egrep || which grep || '/usr/bin/grep')"
   fi
   printf "%s " "${BASH_IT_GREP}"

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -70,7 +70,7 @@ function passgen ()
 
 # Create alias pass to passgen when pass isn't installed or
 # BASH_IT_LEGACY_PASS is true.
-if ! command -v pass &>/dev/null || [[ "$BASH_IT_LEGACY_PASS" = true ]]
+if ! command -v pass &>/dev/null || [[ "${BASH_IT_LEGACY_PASS:-}" = true ]]
 then
   alias pass=passgen
 fi

--- a/test/lib/log.bats
+++ b/test/lib/log.bats
@@ -11,19 +11,19 @@ load ../../lib/log
 @test "lib log: basic debug logging with BASH_IT_LOG_LEVEL_ALL" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_ALL
   run _log_debug "test test test"
-  assert_output "DEBUG: test test test"
+  assert_output "DEBUG: default: test test test"
 }
 
 @test "lib log: basic warning logging with BASH_IT_LOG_LEVEL_ALL" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_ALL
   run _log_warning "test test test"
-  assert_output " WARN: test test test"
+  assert_output " WARN: default: test test test"
 }
 
 @test "lib log: basic error logging with BASH_IT_LOG_LEVEL_ALL" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_ALL
   run _log_error "test test test"
-  assert_output "ERROR: test test test"
+  assert_output "ERROR: default: test test test"
 }
 
 @test "lib log: basic debug logging with BASH_IT_LOG_LEVEL_WARNING" {
@@ -35,13 +35,13 @@ load ../../lib/log
 @test "lib log: basic warning logging with BASH_IT_LOG_LEVEL_WARNING" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_WARNING
   run _log_warning "test test test"
-  assert_output " WARN: test test test"
+  assert_output " WARN: default: test test test"
 }
 
 @test "lib log: basic error logging with BASH_IT_LOG_LEVEL_WARNING" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_WARNING
   run _log_error "test test test"
-  assert_output "ERROR: test test test"
+  assert_output "ERROR: default: test test test"
 }
 
 
@@ -60,7 +60,7 @@ load ../../lib/log
 @test "lib log: basic error logging with BASH_IT_LOG_LEVEL_ERROR" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_ERROR
   run _log_error "test test test"
-  assert_output "ERROR: test test test"
+  assert_output "ERROR: default: test test test"
 }
 
 @test "lib log: basic debug silent logging" {


### PR DESCRIPTION
## Description
Expressly handle parameter values as empty when the parameter is not set at all, instead of letting comparisons fail for missing arguments. Change $BASH_PREVIEW to "${BASH_PREVIEW:-}" and similar for $BASH_IT_LOG_PREFIX, $BASH_IT_LOG_LEVEL, &c. This helps towards #1696.

## Motivation and Context
This reduces errors by explicitly testing for blank values rather than silent syntax errors. I'm very careful about what code I allow to run, and I use `set -u` to ensure that I'm not inadvertently confusing an edge-case when scripting. There's a lot of unbound variables here.

## How Has This Been Tested?
This is my live branch in use on my own system now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
