### PR TITLE
lib: avoid duplicate inclusion

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# A collection of reusable functions.
+
+# Avoid duplicate inclusion
+if [[ -n "${__bash_it_lib_helpers:-}" ]]
+then
+    return 0
+fi
+__bash_it_lib_helpers="loaded"
 
 BASH_IT_LOAD_PRIORITY_DEFAULT_ALIAS=${BASH_IT_LOAD_PRIORITY_DEFAULT_ALIAS:-150}
 BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN=${BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN:-250}

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -3,11 +3,11 @@
 # A collection of reusable functions.
 
 # Avoid duplicate inclusion
-if [[ -n "${__bash_it_lib_helpers:-}" ]]
+if [[ "${__bash_it_lib_loaded[*]:-}" == *"${BASH_SOURCE#*/}"* ]]
 then
     return 0
 fi
-__bash_it_lib_helpers="loaded"
+__bash_it_lib_loaded=( "${BASH_SOURCE#*/}" "${__bash_it_lib_loaded[@]:-}" )
 
 BASH_IT_LOAD_PRIORITY_DEFAULT_ALIAS=${BASH_IT_LOAD_PRIORITY_DEFAULT_ALIAS:-150}
 BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN=${BASH_IT_LOAD_PRIORITY_DEFAULT_PLUGIN:-250}

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -1,4 +1,13 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# A collection of logging functions.
+
+# Avoid duplicate inclusion
+if [[ -n "${__bash_it_lib_log:-}" ]]
+then
+    return 0
+fi
+__bash_it_lib_log="loaded"
 
 export BASH_IT_LOG_LEVEL_ERROR=1
 export BASH_IT_LOG_LEVEL_WARNING=2

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -3,11 +3,11 @@
 # A collection of logging functions.
 
 # Avoid duplicate inclusion
-if [[ -n "${__bash_it_lib_log:-}" ]]
+if [[ "${__bash_it_lib_loaded[*]:-}" == *"${BASH_SOURCE#*/}"* ]]
 then
     return 0
 fi
-__bash_it_lib_log="loaded"
+__bash_it_lib_loaded=( "${BASH_SOURCE#*/}" "${__bash_it_lib_loaded[@]:-}" )
 
 export BASH_IT_LOG_LEVEL_ERROR=1
 export BASH_IT_LOG_LEVEL_WARNING=2

--- a/lib/search.bash
+++ b/lib/search.bash
@@ -1,6 +1,13 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 #
 # Search by Konstantin Gredeskoul «github.com/kigster»
+
+# Avoid duplicate inclusion
+if [[ -n "${__bash_it_lib_search:-}" ]]
+then
+    return 0
+fi
+__bash_it_lib_search="loaded"
 #———————————————————————————————————————————————————————————————————————————————
 # This function returns list of aliases, plugins and completions in bash-it,
 # whose name or description matches one of the search terms provided as arguments.

--- a/lib/search.bash
+++ b/lib/search.bash
@@ -3,11 +3,12 @@
 # Search by Konstantin Gredeskoul «github.com/kigster»
 
 # Avoid duplicate inclusion
-if [[ -n "${__bash_it_lib_search:-}" ]]
+if [[ "${__bash_it_lib_loaded[*]:-}" == *"${BASH_SOURCE#*/}"* ]]
 then
     return 0
 fi
-__bash_it_lib_search="loaded"
+__bash_it_lib_loaded=( "${BASH_SOURCE#*/}" "${__bash_it_lib_loaded[@]:-}" )
+
 #———————————————————————————————————————————————————————————————————————————————
 # This function returns list of aliases, plugins and completions in bash-it,
 # whose name or description matches one of the search terms provided as arguments.

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -3,11 +3,11 @@
 # A collection of reusable functions.
 
 # Avoid duplicate inclusion
-if [[ -n "${__bash_it_lib_utilities:-}" ]]
+if [[ "${__bash_it_lib_loaded[*]:-}" == *"${BASH_SOURCE#*/}"* ]]
 then
     return 0
 fi
-__bash_it_lib_utilities="loaded"
+__bash_it_lib_loaded=( "${BASH_SOURCE#*/}" "${__bash_it_lib_loaded[@]:-}" )
 
 ###########################################################################
 # Generic utilies

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -3,11 +3,10 @@
 # A collection of reusable functions.
 
 # Avoid duplicate inclusion
-if [[ "${__bash_it_lib_loaded[*]:-}" == *"${BASH_SOURCE#*/}"* ]]
-then
-    return 0
+if [[ "${__bash_it_lib_loaded[*]:-}" == *"${BASH_SOURCE#*/}"* ]]; then
+	return 0
 fi
-__bash_it_lib_loaded=( "${BASH_SOURCE#*/}" "${__bash_it_lib_loaded[@]:-}" )
+__bash_it_lib_loaded=("${BASH_SOURCE#*/}" "${__bash_it_lib_loaded[@]:-}")
 
 ###########################################################################
 # Generic utilies

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -2,6 +2,13 @@
 #
 # A collection of reusable functions.
 
+# Avoid duplicate inclusion
+if [[ -n "${__bash_it_lib_utilities:-}" ]]
+then
+    return 0
+fi
+__bash_it_lib_utilities="loaded"
+
 ###########################################################################
 # Generic utilies
 ###########################################################################


### PR DESCRIPTION
## Description
For lib/log and lib/utilities, add double-inclusion protection as we're so early in startup that these are loaded explicitly rather than through `reloader.sh` or even the early lib load loop.


## Motivation and Context
This *slightly* improves performance, but alsö improves debugging by reducing surface area. Both lib/log and lib/utilities are explicitly loaded and then re-loaded again by the library loading loop. 

## How Has This Been Tested?
This branch is live on my system now.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
