### PR TITLE
Import bash-completion slightly more carefully

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-
+#
 # Loads the system's Bash completion modules.
 # If Homebrew is installed (OS X), it's Bash completion modules are loaded.
 
-if [[ -r /etc/bash_completion ]] ; then
+if [[ -r "${BASH_COMPLETION:-}" ]] ; then
+	source "${BASH_COMPLETION}"
+elif [[ -r /etc/bash_completion ]] ; then
   # shellcheck disable=SC1091
   source /etc/bash_completion
 
@@ -12,9 +14,7 @@ elif [[ -r /etc/profile.d/bash_completion.sh ]] ; then
   # shellcheck disable=SC1091
   source /etc/profile.d/bash_completion.sh
 
-fi
-
-if [[ $OSTYPE == 'darwin'* ]] && _command_exists brew ; then
+elif [[ $OSTYPE == 'darwin'* ]] && _command_exists brew ; then
   BREW_PREFIX=${BREW_PREFIX:-$(brew --prefix)}
 
   # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path


### PR DESCRIPTION
## Description
Uses the `$BASH_COMPLETION` variable to locate the script if defined, falling back to the existing waterfall. For the final case (Homebrew), use `$OSTYPE` instead of running an external command, and then import the script itself rather than the wrapper in the `profile.d` folder. 

## Motivation and Context
The bash-completion script itself allows for `$BASH_COMPLETION`, `$BASH_COMPLETION_COMPAT_DIR`, and `$BASH_COMPLETION_DIR` to be set prior to invocation and in fact at least `$BASH_COMPLETION_COMPAT_DIR` needs to be in order to be useful. This can allow for different versions to be used when, for example, Bash is v4+ or not. 

However, the wrapper script in `.../etc/profile.d/bash_completion.sh` on many distributions actually short-circuits if `$BASH_COMPLETION` is defined. When the `profile.d` wrapper is used while `$BASH_COMPLETION` is already defined, bash-completion is simply never once loaded as the wrapper and the actual script disagree about this variable. 

## How Has This Been Tested?
This is live on my branch on my computer currently.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
