### PR TITLE
Don't call external `uname` when `$OSTYPE` will do

### DIFF
--- a/completion/available/brew.completion.bash
+++ b/completion/available/brew.completion.bash
@@ -5,7 +5,7 @@ about-completion "brew completion"
 # Load late to make sure `system` completion loads first
 # BASH_IT_LOAD_PRIORITY: 375
 
-if [[ "$(uname -s)" != 'Darwin' ]]; then
+if [[ "$OSTYPE" != 'darwin'* ]]; then
 	_log_warning "unsupported operating system - only 'Darwin' is supported"
 	return 0
 fi

--- a/completion/available/fabric.completion.bash
+++ b/completion/available/fabric.completion.bash
@@ -41,8 +41,8 @@ export FAB_COMPLETION_CACHED_TASKS_FILENAME=".fab_tasks~"
 
 
 # Set command to get time of last file modification as seconds since Epoch
-case `uname` in
-    Darwin|FreeBSD)
+case "$OSTYPE" in
+    'darwin'*|'freebsd'*)
         __FAB_COMPLETION_MTIME_COMMAND="stat -f '%m'"
         ;;
     *)

--- a/completion/available/git.completion.bash
+++ b/completion/available/git.completion.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Only operate on MacOS since there are no linux paths
-if [[ "$(uname -s)" != 'Darwin' ]] ; then
+if [[ "$OSTYPE" != 'darwin'* ]] ; then
   _log_warning "unsupported operating system - only 'Darwin' is supported"
   return 0
 fi
@@ -24,7 +24,7 @@ _git_bash_completion_paths=(
 
 # Load the first completion file found
 for _comp_path in "${_git_bash_completion_paths[@]}" ; do
-  if [ -r "$_comp_path" ] ; then
+  if [[ -r "$_comp_path" ]] ; then
     _git_bash_completion_found=true
     source "$_comp_path"
     break

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -11,8 +11,8 @@ BASH_IT_LOAD_PRIORITY_SEPARATOR="---"
 # To use this in Bash-it for inline replacements with `sed`, use the following syntax:
 # sed "${BASH_IT_SED_I_PARAMETERS[@]}" -e "..." file
 BASH_IT_SED_I_PARAMETERS=(-i)
-case "$(uname)" in
-  Darwin*) BASH_IT_SED_I_PARAMETERS=(-i "")
+case "$OSTYPE" in
+  'darwin'*) BASH_IT_SED_I_PARAMETERS=(-i "")
 esac
 
 function _command_exists ()

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -33,7 +33,7 @@ function myip ()
     for url in ${list[*]}
     do
         res=$(curl -fs "${url}")
-        if [ $? -eq 0 ];then
+        if [[ $? -eq 0 ]];then
             break;
         fi
     done
@@ -48,7 +48,7 @@ function pickfrom ()
     example '$ pickfrom /usr/share/dict/words'
     group 'base'
     local file=$1
-    [ -z "$file" ] && reference $FUNCNAME && return
+    [[ -z "$file" ]] && reference $FUNCNAME && return
     length=$(cat $file | wc -l)
     n=$(expr $RANDOM \* $length \/ 32768 + 1)
     head -n $n $file | tail -1
@@ -70,7 +70,7 @@ function passgen ()
 
 # Create alias pass to passgen when pass isn't installed or
 # BASH_IT_LEGACY_PASS is true.
-if ! command -v pass &>/dev/null || [ "$BASH_IT_LEGACY_PASS" = true ]
+if ! command -v pass &>/dev/null || [[ "$BASH_IT_LEGACY_PASS" = true ]]
 then
   alias pass=passgen
 fi
@@ -129,15 +129,15 @@ function usage ()
     about 'disk usage per directory, in Mac OS X and Linux'
     param '1: directory name'
     group 'base'
-    if [ $(uname) = "Darwin" ]; then
+    if [[ "$OSTYPE" == 'darwin'* ]]; then
         if [ -n "$1" ]; then
             du -hd 1 "$1"
         else
             du -hd 1
         fi
 
-    elif [ $(uname) = "Linux" ]; then
-        if [ -n "$1" ]; then
+    elif [[ "$OSTYPE" = 'linux'* ]]; then
+        if [[ -n "$1" ]]; then
             du -h --max-depth=1 "$1"
         else
             du -h --max-depth=1
@@ -145,7 +145,8 @@ function usage ()
     fi
 }
 
-if [ ! -e "${BASH_IT}/plugins/enabled/todo.plugin.bash" ] && [ ! -e "${BASH_IT}/plugins/enabled/*${BASH_IT_LOAD_PRIORITY_SEPARATOR}todo.plugin.bash" ]; then
+if [[ ! -e "${BASH_IT}/plugins/enabled/todo.plugin.bash" ]] && [[ ! -e "${BASH_IT}/plugins/enabled/*${BASH_IT_LOAD_PRIORITY_SEPARATOR}todo.plugin.bash" ]]
+then
 # if user has installed todo plugin, skip this...
     function t ()
     {
@@ -180,11 +181,11 @@ mkiso ()
     group 'base'
 
     if type "mkisofs" > /dev/null; then
-        [ -z ${1+x} ] && local isoname=${PWD##*/} || local isoname=$1
-        [ -z ${2+x} ] && local destpath=../ || local destpath=$2
-        [ -z ${3+x} ] && local srcpath=${PWD} || local srcpath=$3
+        [[ -z ${1+x} ]] && local isoname=${PWD##*/} || local isoname=$1
+        [[ -z ${2+x} ]] && local destpath=../ || local destpath=$2
+        [[ -z ${3+x} ]] && local srcpath=${PWD} || local srcpath=$3
 
-        if [ ! -f "${destpath}${isoname}.iso" ]; then
+        if [[ ! -f "${destpath}${isoname}.iso" ]]; then
             echo "writing ${isoname}.iso to ${destpath} from ${srcpath}"
             mkisofs -V ${isoname} -iso-level 3 -r -o "${destpath}${isoname}.iso" "${srcpath}"
         else

--- a/plugins/available/boot2docker.plugin.bash
+++ b/plugins/available/boot2docker.plugin.bash
@@ -3,7 +3,7 @@ about-plugin 'Helpers to get Docker setup correctly for boot2docker'
 
 # Note, this might need to be different if you have an older version
 # of boot2docker, or its configured for a different IP
-if [[ `uname -s` == "Darwin" ]]; then
+if [[ "$OSTYPE" == 'darwin'* ]]; then
   export DOCKER_HOST="tcp://192.168.59.103:2376"
   export DOCKER_CERT_PATH="~/.boot2docker/certs/boot2docker-vm"
   export DOCKER_TLS_VERIFY=1

--- a/plugins/available/osx.plugin.bash
+++ b/plugins/available/osx.plugin.bash
@@ -2,7 +2,7 @@ cite about-plugin
 about-plugin 'osx-specific functions'
 
 # OS X: Open new tabs in same directory
-if [ $(uname) = "Darwin" ]; then
+if [[ $OSTYPE == 'darwin'* ]]; then
   if type update_terminal_cwd > /dev/null 2>&1 ; then
     if ! [[ $PROMPT_COMMAND =~ (^|;)update_terminal_cwd($|;) ]] ; then
       PROMPT_COMMAND="${PROMPT_COMMAND%;};update_terminal_cwd"
@@ -46,13 +46,13 @@ function dock-switch() {
     example '$ dock-switch 2d'
     group 'osx'
 
-    if [ $(uname) = "Darwin" ]; then
+    if [[ "$OSTYPE" = 'darwin'* ]]; then
 
-        if [ $1 = 3d ] ; then
+        if [[ $1 = 3d ]] ; then
             defaults write com.apple.dock no-glass -boolean NO
             killall Dock
 
-        elif [ $1 = 2d ] ; then
+        elif [[ $1 = 2d ]] ; then
             defaults write com.apple.dock no-glass -boolean YES
             killall Dock
 
@@ -90,7 +90,7 @@ function prevcurl() {
   param '1: url'
   group 'osx'
 
-  if [ ! $(uname) = "Darwin" ]
+  if [[ ! $OSTYPE = 'darwin'* ]]
   then
     echo "This function only works with Mac OS X"
     return 1
@@ -103,7 +103,7 @@ function refresh-launchpad() {
   example '$ refresh-launchpad'
   group 'osx'
 
-  if [ $(uname) = "Darwin" ];then
+  if [[ "$OSTYPE" = 'darwin'* ]];then
     defaults write com.apple.dock ResetLaunchPad -bool TRUE
     killall Dock
   else

--- a/plugins/available/python.plugin.bash
+++ b/plugins/available/python.plugin.bash
@@ -1,7 +1,7 @@
 cite about-plugin
 about-plugin 'alias "shttp" to SimpleHTTPServer'
 
-if [ $(uname) = "Linux" ]
+if [[ "$OSTYPE" == 'linux'* ]]
 then
   alias shttp='python2 -m SimpleHTTPServer'
 else
@@ -16,7 +16,7 @@ function pyedit() {
 
     xpyc=`python -c "import os, sys; f = open(os.devnull, 'w'); sys.stderr = f; module = __import__('$1'); sys.stdout.write(module.__file__)"`
 
-    if [ "$xpyc" == "" ]; then
+    if [[ "$xpyc" == "" ]]; then
         echo "Python module $1 not found"
         return -1
 

--- a/themes/demula/demula.theme.bash
+++ b/themes/demula/demula.theme.bash
@@ -98,7 +98,7 @@ prompt() {
   local MOVE_CURSOR_RIGHTMOST='\033[500C'
   local MOVE_CURSOR_5_LEFT='\033[5D'
 
-  if [ $(uname) = "Linux" ];
+  if [[ "$OSTYPE" = 'linux'* ]]
   then
     PS1="${TITLEBAR}${SAVE_CURSOR}${MOVE_CURSOR_RIGHTMOST}${MOVE_CURSOR_5_LEFT}
 $(safe_battery_charge)${RESTORE_CURSOR}\

--- a/themes/rana/rana.theme.bash
+++ b/themes/rana/rana.theme.bash
@@ -181,7 +181,7 @@ prompt() {
   local MOVE_CURSOR_RIGHTMOST='\033[500C'
   local MOVE_CURSOR_5_LEFT='\033[5D'
 
-  if [ $(uname) = "Linux" ];
+  if [[ "$OSTYPE" == 'linux'* ]];
   then
     PS1="${TITLEBAR}
 ${SAVE_CURSOR}${MOVE_CURSOR_RIGHTMOST}${MOVE_CURSOR_5_LEFT}\


### PR DESCRIPTION
## Description
The only use case for invoking the `uname` binary in our usage is to find out if we're on Darwin or Linux or whatnot. `$OSTYPE` is a shell builtin constant that tells us this, so use it.

## Motivation and Context
I'm on a bit of a crusade to reduce launching external programs and to make use of constants and features already provided by Bash. This is _Bash It_, after all!

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
More of an *optimization* than a fix...

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
