### PR TITLE
Support multiple versions of _Bash Completion_

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -5,14 +5,16 @@
 
 if shopt -qo nounset
 then # Bash-completion is too large and complex to expect to handle unbound variables throughout the whole codebase.
-	BASH_IT_RESTORE_NOUNSET=true
+	__bash_it_restore_nounset=true
 	shopt -uo nounset
 else
-	BASH_IT_RESTORE_NOUNSET=false
+	__bash_it_restore_nounset=false
 fi
 
 if [[ -r "${BASH_COMPLETION:-}" ]] ; then
+  # shellcheck disable=SC1091
 	source "${BASH_COMPLETION}"
+
 elif [[ -r /etc/bash_completion ]] ; then
   # shellcheck disable=SC1091
   source /etc/bash_completion
@@ -24,15 +26,34 @@ elif [[ -r /etc/profile.d/bash_completion.sh ]] ; then
 
 elif _bash_it_homebrew_check
 then
-  # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
-  if [[ -r "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh ]] ; then
-    # shellcheck disable=SC1090
-    source "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh
-  fi
+  : ${BASH_COMPLETION_COMPAT_DIR:=$BASH_IT_HOMEBREW_PREFIX/etc/bash_completion.d}
+
+  case "${BASH_VERSION}" in
+  1*|2*|3.0*|3.1*)
+    _log_warning "Cannot load completion due to version of shell."
+    ;;
+  3.2*|4.0*|4.1*)
+    # Import version 1.x of bash-completion, if installed.
+    BASH_COMPLETION="$BASH_IT_HOMEBREW_PREFIX/opt/bash-completion@1/etc/bash_completion"
+    if [[ -r "$BASH_COMPLETION" ]] ; then
+      # shellcheck disable=SC1090
+      source "$BASH_COMPLETION"
+    else
+      unset BASH_COMPLETION
+    fi
+    ;;
+  4.2*|5*|*)
+    # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
+    if [[ -r "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh ]] ; then
+      # shellcheck disable=SC1090
+      source "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh
+    fi
+    ;;
+  esac
 fi
 
-if $BASH_IT_RESTORE_NOUNSET
+if $__bash_it_restore_nounset
 then
 	shopt -so nounset
 fi
-unset BASH_IT_RESTORE_NOUNSET
+unset __bash_it_restore_nounset

--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -30,7 +30,7 @@ then
 
   case "${BASH_VERSION}" in
   1*|2*|3.0*|3.1*)
-    _log_warning "Cannot load completion due to version of shell."
+    _log_warning "Cannot load completion due to version of shell. Are you using Bash 3.2+?"
     ;;
   3.2*|4.0*|4.1*)
     # Import version 1.x of bash-completion, if installed.


### PR DESCRIPTION
## Description
On Mac OS X, where _Bash_ as shipped is version 3.2, support loading _Bash Completion_ version 1 or version 2 from [Homebrew](https://brew.sh) based on the version of the _Bash_ shell in operation. E.g., if we're running _Bash_ v4+, then source _Bash Completion_ from /usr/local/opt/bash-completion@2/etc/profile.d/bash_completion.sh, but if we're running the built-in _Bash_ v3.2, then source from /usr/local/opt/bash-completion@1/etc/bash_completion.

## Motivation and Context
I want to install _Bash_ from [Homebrew], but I alsö don't want to.

## How Has This Been Tested?
Tested locally and CI passes.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
...more of an optimization...

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
