### PR TITLE
Don't set `indent_size` when using tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,6 @@ indent_style = tab
 
 [{**.*sh,test/run}]
 indent_style = tab
-indent_size = 4
 
 shell_variant      = bash
 binary_next_line   = true  # like -bn


### PR DESCRIPTION
## Description
`indent_size` should be set to `tab`, and `tab_width` should be set to the desired indentation distance. However, `tab_width` is a deeply personal religious conviction and should not be set by a shared community project.

## Motivation and Context
It's possible someone forces `tab_width` to 8 and then their editor may half-tab by using spaces of `indent_size`...which is somehow worse than always using tabs or always using spaces...

## How Has This Been Tested?
I've never used `.editorconfig` before, but I installed the TextMate plugin.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
