### PR TITLE
defaults: Revert to old comparison

### DIFF
--- a/completion/available/defaults.completion.bash
+++ b/completion/available/defaults.completion.bash
@@ -41,8 +41,8 @@ _defaults()
 			COMPREPLY=( $( compgen -W "$cmds" -- $cur ) )
 			return 0
 		elif [[ "$prev" == "-host" ]]; then
-			return 0
 			_known_hosts -a
+			return 0
 		else
 			_defaults_domains
 			return 0
@@ -56,7 +56,7 @@ _defaults()
 
 	# Both a domain and command have been specified
 
-	if [[ ${COMP_WORDS[1]} =~ [${cmds// /|}] ]]; then
+	if [[ ${COMP_WORDS[1]} == [${cmds// /|}] ]]; then
 		cmd=${COMP_WORDS[1]}
 		domain=${COMP_WORDS[2]}
 		key_index=3


### PR DESCRIPTION
Also fix a small bug along the way :)

## Description
Revert back to straight comparison instead of regex one

## Motivation and Context
Mistakenly added in #1913
I want to say that this file is seemingly broken in many ways already, so I did not bother fixing all of the other stuff
that did not work..

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
