### PR TITLE
fix update not popping back cwd

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -194,7 +194,10 @@ _bash-it-update-stable() {
   _bash-it-update- stable "$@"
 }
 
-_bash-it_pull_and_update_inner() {
+_bash-it_update_migrate_and_restart() {
+	_about 'Checks out the wanted version, pops directory and restart. Does not return (because of the restart!)'
+  _param '1: Which branch to checkout to'
+  _param '2: Which type of version we are using'
   git checkout "$1" &> /dev/null
   if [[ $? -eq 0 ]]; then
     echo "Bash-it successfully updated."
@@ -203,7 +206,9 @@ _bash-it_pull_and_update_inner() {
     _bash-it-migrate
     echo ""
     echo "All done, enjoy!"
-    bash-it restart
+    # Don't forget to restore the original pwd!
+    popd &> /dev/null
+    _bash-it-restart
   else
     echo "Error updating Bash-it, please, check if your Bash-it installation folder (${BASH_IT}) is clean."
   fi
@@ -220,9 +225,8 @@ _bash-it-update-() {
       silent=true
     fi
   done
-  local old_pwd="${PWD}"
 
-  cd "${BASH_IT}" || return
+  pushd "${BASH_IT}" &> /dev/null || return
 
   DIFF=$(git diff --name-status)
   [ -n "$DIFF" ] && echo -e "Local changes detected in bash-it directory. Clean '$BASH_IT' directory to proceed.\n$DIFF" && return 1
@@ -243,7 +247,7 @@ _bash-it-update-() {
 
     if [[ -z "$TARGET" ]]; then
       echo "Can not find tags, so can not update to latest stable version..."
-      cd "${old_pwd}" &> /dev/null
+      popd &> /dev/null
       return
     fi
   else
@@ -284,12 +288,12 @@ _bash-it-update-() {
 
     if [[ $silent ]]; then
       echo "Updating to ${TARGET}($(git log -1 --format=%h "${TARGET}"))..."
-      _bash-it_pull_and_update_inner $TARGET $version
+      _bash-it_update_migrate_and_restart $TARGET $version
     else
       read -e -n 1 -p "Would you like to update to ${TARGET}($(git log -1 --format=%h "${TARGET}"))? [Y/n] " RESP
       case $RESP in
         [yY]|"")
-          _bash-it_pull_and_update_inner $TARGET $version
+          _bash-it_update_migrate_and_restart $TARGET $version
           ;;
         [nN])
           echo "Not updating…"
@@ -306,7 +310,7 @@ _bash-it-update-() {
       echo "Bash-it is up to date, nothing to do!"
     fi
   fi
-  cd "${old_pwd}" &> /dev/null || return
+  popd &> /dev/null
 }
 
 _bash-it-migrate() {

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -243,6 +243,7 @@ _bash-it-update-() {
 
     if [[ -z "$TARGET" ]]; then
       echo "Can not find tags, so can not update to latest stable version..."
+      cd "${old_pwd}" &> /dev/null
       return
     fi
   else


### PR DESCRIPTION
Correctly restore old pwd in all cases of bash-it update

## Description
When we update, we usually call `bash-it restart`, which re-execs bash. It means that the code of restoring
old pwd at the end is not being executed. I fixed this and another problem by correctly `cd`ing into to old pwd in time.

## Motivation and Context
Closes #1920

## How Has This Been Tested?
Locally, sadly it is very hard to automate testing of bash-it update, as it uses actual git repo and tries to pull information.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
