### PR TITLE
defaults: Revert "defaults: Revert to old comparison"

### DIFF
--- a/completion/available/defaults.completion.bash
+++ b/completion/available/defaults.completion.bash
@@ -56,7 +56,7 @@ _defaults()
 
 	# Both a domain and command have been specified
 
-	if [[ ${COMP_WORDS[1]} == [${cmds// /|}] ]]; then
+	if [[ ${COMP_WORDS[1]} =~ [${cmds// /|}] ]]; then
 		cmd=${COMP_WORDS[1]}
 		domain=${COMP_WORDS[2]}
 		key_index=3


### PR DESCRIPTION
The change in #1918 (reverting #1913 / #188) breaks case-insensitive domain completion. Example: `defaults read com.apple.term<TAB>` should complete to `defaults read com.apple.Terminal`, but it does not due to the change from `=~` to `==`. This was the reason for the initial PR.