### PR TITLE
Use parameter substitution instead of `dirname`/`basename`, where safe to do so

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -184,7 +184,7 @@ if [[ $no_modify_config ]] && [[ $append_to_config ]]; then
 	exit 1
 fi
 
-BASH_IT="$(cd "$(dirname "$0")" && pwd)"
+BASH_IT="$(cd "${BASH_SOURCE%/*}" && pwd)"
 
 case $OSTYPE in
 	darwin*)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -340,7 +340,7 @@ _bash-it-migrate() {
   do
     for f in `sort <(compgen -G "${BASH_IT}/$file_type/enabled/*.bash")`
     do
-      typeset ff=$(basename $f)
+      typeset ff="${f##*/}"
 
       # Get the type of component from the extension
       typeset single_type=$(echo $ff | sed -e 's/.*\.\(.*\)\.bash/\1/g' | sed 's/aliases/alias/g')
@@ -501,7 +501,7 @@ _bash-it-describe ()
     do
         # Check for both the old format without the load priority, and the extended format with the priority
         declare enabled_files enabled_file
-        enabled_file=$(basename $f)
+		enabled_file="${f##*/}"
         enabled_files=$(sort <(compgen -G "${BASH_IT}/enabled/*$BASH_IT_LOAD_PRIORITY_SEPARATOR${enabled_file}") <(compgen -G "${BASH_IT}/$subdirectory/enabled/${enabled_file}") <(compgen -G "${BASH_IT}/$subdirectory/enabled/*$BASH_IT_LOAD_PRIORITY_SEPARATOR${enabled_file}") | wc -l)
 
         if [ $enabled_files -gt 0 ]; then
@@ -603,9 +603,9 @@ _disable-thing ()
               printf '%s\n' "sorry, $file_entity does not appear to be an enabled $file_type."
               return
           fi
-          rm "${BASH_IT}/$subdirectory/enabled/$(basename $plugin)"
+          rm "${BASH_IT}/$subdirectory/enabled/${plugin##*/}"
         else
-          rm "${BASH_IT}/enabled/$(basename $plugin_global)"
+          rm "${BASH_IT}/enabled/${plugin_global##*/}"
         fi
     fi
 
@@ -681,7 +681,7 @@ _enable-thing ()
             return
         fi
 
-        to_enable=$(basename $to_enable)
+		to_enable="${to_enable##*/}"
         # Check for existence of the file using a wildcard, since we don't know which priority might have been used when enabling it.
         typeset enabled_plugin=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9][0-9][0-9]$BASH_IT_LOAD_PRIORITY_SEPARATOR$to_enable,$to_enable} 2>/dev/null | head -1)
         if [ ! -z "$enabled_plugin" ] ; then

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -71,12 +71,12 @@ _bash-it-grep() {
 ###########################################################################
 
 _bash-it-component-help() {
-  local component=$(_bash-it-pluralize-component "${1}")
-  local file=$(_bash-it-component-cache-file ${component})
+  local component="$(_bash-it-pluralize-component "${1}")"
+  local file="$(_bash-it-component-cache-file "${component}")"
   if [[ ! -s "${file}" || -z $(find "${file}" -mmin -300) ]] ; then
     rm -f "${file}" 2>/dev/null
     local func="_bash-it-${component}"
-    ${func} | $(_bash-it-grep) -E '   \[' | cat > ${file}
+    "${func}" | $(_bash-it-grep) -E '   \[' | cat > "${file}"
   fi
   cat "${file}"
 }
@@ -84,7 +84,7 @@ _bash-it-component-help() {
 _bash-it-component-cache-file() {
   local component=$(_bash-it-pluralize-component "${1}")
   local file="${BASH_IT}/tmp/cache/${component}"
-  [[ -f ${file} ]] || mkdir -p $(dirname ${file})
+  [[ -f "${file}" ]] || mkdir -p "${file%/*}"
   printf "${file}"
 }
 

--- a/plugins/available/jekyll.plugin.bash
+++ b/plugins/available/jekyll.plugin.bash
@@ -16,7 +16,7 @@ editpost() {
 
   for site in ${SITES[@]}
   do
-    if [ "$(basename $site)" = "$1" ]
+    if [ "${site##*/}" = "$1" ]
     then
       SITE=$site
       break
@@ -77,7 +77,7 @@ newpost() {
 
   for site in ${SITES[@]}
   do
-    if [ "$(basename $site)" = "$1" ]
+    if [ "${site##*/}" = "$1" ]
     then
       SITE=$site
       JEKYLL_FORMATTING=${MARKUPS[$loc]}
@@ -280,7 +280,7 @@ function testsite() {
 
   for site in ${SITES[@]}
   do
-    if [ "$(basename $site)" = "$1" ]
+    if [ "${site##*/}" = "$1" ]
     then
       SITE=$site
       break
@@ -312,7 +312,7 @@ function buildsite() {
 
   for site in ${SITES[@]}
   do
-    if [ "$(basename $site)" = "$1" ]
+    if [ "${site##*/}" = "$1" ]
     then
       SITE=$site
       break
@@ -347,7 +347,7 @@ function deploysite() {
 
   for site in ${SITES[@]}
   do
-    if [ "$(basename $site)" = "$1" ]
+    if [ "${site##*/}" = "$1" ]
     then
       SITE=$site
       REMOTE=${REMOTES[$loc]}

--- a/plugins/available/osx-timemachine.plugin.bash
+++ b/plugins/available/osx-timemachine.plugin.bash
@@ -15,7 +15,7 @@ function time-machine-list-machines() {
   local tmdest="$(time-machine-destination)/Backups.backupdb"
 
   find "$tmdest" -maxdepth 1 -mindepth 1 -type d | grep -v "/\." | while read line ; do
-    echo "$(basename "$line")"
+    echo "${line##*/}"
   done
 }
 

--- a/plugins/available/virtualenv.plugin.bash
+++ b/plugins/available/virtualenv.plugin.bash
@@ -14,8 +14,8 @@ function mkvenv {
   about 'create a new virtualenv for this directory'
   group 'virtualenv'
 
-  cwd=`basename \`pwd\``
-  mkvirtualenv --distribute $cwd
+  local cwd="${PWD##*/}"
+  mkvirtualenv --distribute "$cwd"
 }
 
 
@@ -23,19 +23,21 @@ function mkvbranch {
   about 'create a new virtualenv for the current branch'
   group 'virtualenv'
 
-  mkvirtualenv --distribute "$(basename `pwd`)@$SCM_BRANCH"
+  local cwd="${PWD##*/}"
+  mkvirtualenv --distribute "${cwd}@${SCM_BRANCH}"
 }
 
 function wovbranch {
   about 'sets workon branch'
   group 'virtualenv'
 
-  workon "$(basename `pwd`)@$SCM_BRANCH"
+  local cwd="${PWD##*/}"
+  workon "${cwd}@${SCM_BRANCH}"
 }
 
 function wovenv {
   about 'works on the virtualenv for this directory'
   group 'virtualenv'
 
-  workon "$(basename `pwd`)"
+  workon "${PWD##*/}"
 }

--- a/plugins/available/z_autoenv.plugin.bash
+++ b/plugins/available/z_autoenv.plugin.bash
@@ -11,7 +11,7 @@ autoenv_init()
   typeset target home _file
   typeset -a _files
   target=$1
-  home="$(dirname "$HOME")"
+  home="${HOME%/*}"
 
   _files=( $(
     while [[ "$PWD" != "/" && "$PWD" != "$home" ]]


### PR DESCRIPTION
## Description
Reduce subshells and external commands by using _Bash_'s string processing features instead of `dirname` and `basename`. This basically uses `$PWD`, `$BASH_SOURCE`, and "${pathname%*/}" and similar constructs to avoid subshells for `$(pwd)`, `dirname`, and `basename`. 

## Motivation and Context
This is part of a set of patches to reduce usage of subshells and external binaries in _Bash It_.

The two commits here were part of #1914, but that PR went further than this one and some edge cases were identified which could lead to unintended behavior so those uses were left as-is. Both commits here operate specifically on code which specifies the full path within the same function and thus won't run in to possible issues with user-supplied strings. Merging this PR resolves #1914.

The two edge-cases are: 
1. too many `/`, and
2. not enough `/`.

Since parameter substitution is string manipulation, it lacks logic to insert `./` for an empty directory name, &c.

## How Has This Been Tested?
Tested locally, reviewed in part in #1914, and all tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
