### PR TITLE
Use `$PWD` instead of `$(pwd)`

### DIFF
--- a/completion/available/gradle.completion.bash
+++ b/completion/available/gradle.completion.bash
@@ -23,8 +23,8 @@
 COMP_WORDBREAKS=$(echo "$COMP_WORDBREAKS" | sed -e 's/://g')
 
 __gradle-set-project-root-dir() {
-    local dir=`pwd`
-    project_root_dir=`pwd`
+    local dir="${PWD}"
+    project_root_dir="${PWD}"
     while [[ $dir != '/' ]]; do
         if [[ -f "$dir/settings.gradle" || -f "$dir/gradlew" ]]; then
             project_root_dir=$dir

--- a/completion/available/hub.completion.bash
+++ b/completion/available/hub.completion.bash
@@ -227,7 +227,7 @@ EOF
       ((c++))
     done
     if [ -z "$name" ]; then
-      repo=$(basename "$(pwd)")
+      repo="$(basename "${PWD}")"
     fi
     case "$prev" in
       -d|-h)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -449,7 +449,7 @@ _bash-it-restart() {
   _about 'restarts the shell in order to fully reload it'
   _group 'lib'
 
-  saved_pwd=$(pwd)
+  saved_pwd="${PWD}"
 
   case $OSTYPE in
     darwin*)

--- a/plugins/available/dirs.plugin.bash
+++ b/plugins/available/dirs.plugin.bash
@@ -86,7 +86,7 @@ S () {
 
     sed "/$@/d" ~/.dirs > ~/.dirs1;
     \mv ~/.dirs1 ~/.dirs;
-    echo "$@"=\"`pwd`\" >> ~/.dirs;
+    echo "$@"=\""${PWD}"\" >> ~/.dirs;
     source ~/.dirs ;
 }
 

--- a/plugins/available/dirs.plugin.bash
+++ b/plugins/available/dirs.plugin.bash
@@ -23,7 +23,7 @@ alias 8="pushd +8"
 alias 9="pushd +9"
 
 # Clone this location
-alias pc="pushd \$(pwd)"
+alias pc='pushd "${PWD}"'
 
 # Push new location
 alias pu="pushd"
@@ -73,7 +73,7 @@ G () {
     example '$ G ..'
     group 'dirs'
 
-    cd "${1:-$(pwd)}" ;
+    cd "${1:-${PWD}}" ;
 }
 
 S () {

--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -40,7 +40,7 @@ load ../../plugins/available/base.plugin
   mkcd "${dir_name}"
   assert_success
   assert_dir_exist "${BASH_IT_ROOT}/${dir_name}"
-  assert_equal $(pwd) "${BASH_IT_ROOT}/${dir_name}"
+  assert_equal "${PWD}" "${BASH_IT_ROOT}/${dir_name}"
 }
 
 @test 'plugins base: lsgrep()' {

--- a/test/run
+++ b/test/run
@@ -6,7 +6,7 @@ git submodule init && git submodule update
 
 if [ -z "${BASH_IT}" ]; then
   declare BASH_IT
-  BASH_IT=$(cd ${test_directory} && dirname "$(pwd)")
+  BASH_IT="$(cd "${test_directory}" && dirname "${PWD}")"
   export BASH_IT
 fi
 

--- a/themes/powerturk/powerturk.theme.bash
+++ b/themes/powerturk/powerturk.theme.bash
@@ -43,7 +43,7 @@ _swd(){
     begin="" # The unshortened beginning of the path.
     shortbegin="" # The shortened beginning of the path.
     current="" # The section of the path we're currently working on.
-    end="${2:-$(pwd)}/" # The unmodified rest of the path.
+    end="${2:-${PWD}}/" # The unmodified rest of the path.
 
     if [[ "$end" =~ "$HOME" ]]; then
         INHOME=1


### PR DESCRIPTION
NOTE: This PR assumes that my `basenamed` branch has already been merged (#1926)! This PR does not do anything with `basename`/`dirname`; it's just based off that branch.

## Description
_Bash_ maintains the `$PWD` shell parameter with the current and correct full path to the present working directory. The shell builtin `pwd` returns the value of `$PWD`, so just skip the subshell and use the parameter directly.

## Motivation and Context
This is part of a patch set to reduce the use of subshells.

## How Has This Been Tested?
Tested locally, and all tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
...more of an optimization.

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
