### PR TITLE
plugins: Fix shellcheck warnings on already linted files

### DIFF
--- a/plugins/available/alias-completion.plugin.bash
+++ b/plugins/available/alias-completion.plugin.bash
@@ -70,7 +70,7 @@ function alias_completion {
 			local compl_func="${new_completion/#* -F /}"
 			compl_func="${compl_func%% *}"
 			# avoid recursive call loops by ignoring our own functions
-			if [[ "${compl_func#_$namespace::}" == "$compl_func" ]]; then
+			if [[ "${compl_func#_"$namespace"::}" == "$compl_func" ]]; then
 				local compl_wrapper="_${namespace}::${alias_name}"
 				echo "function $compl_wrapper {
                         local compl_word=\$2

--- a/plugins/available/git.plugin.bash
+++ b/plugins/available/git.plugin.bash
@@ -309,7 +309,7 @@ function git-changelog() {
 		# shellcheck disable=SC2162
 		git log "$1" --no-merges --format="%cd" --date=short | sort -u -r | while read DATE; do
 			echo
-			echo [$DATE]
+			echo "[$DATE]"
 			git log --no-merges --format=" * (%h) %s by %an <%ae>" --since="$DATE 00:00:00" --until="$DATE 24:00:00"
 			NEXT=$DATE
 		done


### PR DESCRIPTION
For some reason, running `lint_clean_files.sh` locally resulted in some errors for me, although it is ran on every PR...

## Description
Fix small shellcheck quoting warnings

## Motivation and Context
Clears up `lint_clean_files.sh` to not error out

## How Has This Been Tested?
lint ran, tests as well

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
