### PR TITLE
Feature: automatic history management

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -83,6 +83,7 @@ completion/available/wpscan.completion.bash
 # libraries
 lib/colors.bash
 lib/helpers.bash
+lib/history.bash
 lib/log.bash
 lib/preexec.bash
 lib/search.bash

--- a/lib/history.bash
+++ b/lib/history.bash
@@ -1,0 +1,49 @@
+# shellcheck shell=bash
+#
+# Functions for working with Bash's command history.
+
+function _bash-it-history-init() {
+	safe_append_preexec '_bash-it-history-auto-save'
+	safe_append_prompt_command '_bash-it-history-auto-load'
+}
+
+function _bash-it-history-auto-save() {
+	case $HISTCONTROL in
+		*'noauto'* | *'autoload'*)
+			: # Do nothing, as configured.
+			;;
+		*'auto'*)
+			# Append new history from this session to the $HISTFILE
+			history -a
+			;;
+		*)
+			# Append *only* if shell option `histappend` has been enabled.
+			shopt -q histappend && history -a && return
+			;;
+	esac
+}
+
+function _bash-it-history-auto-load() {
+	case $HISTCONTROL in
+		*'noauto'*)
+			: # Do nothing, as configured.
+			;;
+		*'autosave'*)
+			# Append new history from this session to the $HISTFILE
+			history -a
+			;;
+		*'autoloadnew'*)
+			# Read new entries from $HISTFILE
+			history -n
+			;;
+		*'auto'*)
+			# Blank in-memory history, then read entire $HISTFILE fresh from disk.
+			history -a && history -c && history -r
+			;;
+		*)
+			: # Do nothing, default.
+			;;
+	esac
+}
+
+_bash_it_library_finalize_hook+=('_bash-it-history-init')

--- a/plugins/available/history-eternal.plugin.bash
+++ b/plugins/available/history-eternal.plugin.bash
@@ -1,20 +1,22 @@
 # shellcheck shell=bash
 about-plugin 'eternal bash history'
 
-# Load after the history plugin
-# BASH_IT_LOAD_PRIORITY: 375
+if [[ ${BASH_VERSINFO[0]} -lt 4 ]] || [[ ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 3 ]]; then
+	_log_warning "Bash version 4.3 introduced the 'unlimited' history size capability."
+	return 1
+fi
 
 # Modify history sizes before changing location to avoid unintentionally
 # truncating the history file early.
 
 # "Numeric values less than zero result in every command being saved on the history list (there is no limit)"
-export HISTSIZE=-1
+readonly HISTSIZE=-1 2> /dev/null || true
 
 # "Non-numeric values and numeric values less than zero inhibit truncation"
-export HISTFILESIZE='unlimited'
+readonly HISTFILESIZE='unlimited' 2> /dev/null || true
 
 # Use a custom history file location so history is not truncated
 # if the environment ever loses this "eternal" configuration.
 HISTDIR="${XDG_STATE_HOME:-${HOME?}/.local/state}/bash"
 [[ -d ${HISTDIR?} ]] || mkdir -p "${HISTDIR?}"
-export HISTFILE="${HISTDIR?}/history"
+readonly HISTFILE="${HISTDIR?}/history" 2> /dev/null || true

--- a/plugins/available/history-search.plugin.bash
+++ b/plugins/available/history-search.plugin.bash
@@ -1,9 +1,6 @@
 # shellcheck shell=bash
 about-plugin 'search history using the prefix already entered'
 
-# Load after the history plugin
-# BASH_IT_LOAD_PRIORITY: 375
-
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history
 if [[ ${SHELLOPTS} =~ (vi|emacs) ]]; then

--- a/plugins/available/history-substring-search.plugin.bash
+++ b/plugins/available/history-substring-search.plugin.bash
@@ -1,9 +1,6 @@
 # shellcheck shell=bash
 about-plugin 'search history using the substring already entered'
 
-# Load after the history plugin
-# BASH_IT_LOAD_PRIORITY: 375
-
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history
 if [[ ${SHELLOPTS} =~ (vi|emacs) ]]; then

--- a/plugins/available/history.plugin.bash
+++ b/plugins/available/history.plugin.bash
@@ -5,11 +5,11 @@ about-plugin 'improve history handling with sane defaults'
 # variable when the shell exits, rather than overwriting the file.
 shopt -s histappend
 
-# erase duplicates; alternative option: export HISTCONTROL=ignoredups
-export HISTCONTROL=${HISTCONTROL:-ignorespace:erasedups}
+# erase duplicates; alternative option: HISTCONTROL=ignoredups
+: "${HISTCONTROL:=ignorespace:erasedups}"
 
 # resize history to 100x the default (500)
-export HISTSIZE=${HISTSIZE:-50000}
+: "${HISTSIZE:=50000}"
 
 # Flush history to disk after each command.
 export PROMPT_COMMAND="history -a;${PROMPT_COMMAND}"

--- a/plugins/available/history.plugin.bash
+++ b/plugins/available/history.plugin.bash
@@ -5,14 +5,13 @@ about-plugin 'improve history handling with sane defaults'
 # variable when the shell exits, rather than overwriting the file.
 shopt -s histappend
 
-# erase duplicates; alternative option: HISTCONTROL=ignoredups
-: "${HISTCONTROL:=ignorespace:erasedups}"
+# 'ignorespace': don't save command lines which begin with a space to history
+# 'erasedups' (alternative 'ignoredups'): don't save duplicates to history
+# 'autoshare': automatically share history between multiple running shells
+: "${HISTCONTROL:=ignorespace:erasedups:autoshare}"
 
 # resize history to 100x the default (500)
 : "${HISTSIZE:=50000}"
-
-# Flush history to disk after each command.
-export PROMPT_COMMAND="history -a;${PROMPT_COMMAND}"
 
 function top-history() {
 	about 'print the name and count of the most commonly run tools'

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -584,6 +584,7 @@ function aws_profile {
 }
 
 function _save-and-reload-history() {
-	local autosave=${1:-0}
-	[[ $autosave -eq 1 ]] && history -a && history -c && history -r
+	local autosave="${1:-${HISTORY_AUTOSAVE:-0}}"
+	[[ ${autosave} -eq 1 ]] && local HISTCONTROL="${HISTCONTROL:-}${HISTCONTROL:+:}autoshare"
+	_bash-it-history-auto-save && _bash-it-history-auto-load
 }


### PR DESCRIPTION
## Description
Two new functions `_bash_it_history_auto_save()` and `_bash_it_history_auto_load()`, which append new history to disk and load new history from disk, respectively.

These functions operate based on four modes configured in `$HISTCONTROL`:
1. `autoshare`: append to `$HISTFILE` when `_bash_it_history_auto_save()` called, and read from `$HISTFILE` when `_bash_it_history_auto_load()` called.
2. `autosave`: append to `$HISTFILE` when `_bash_it_history_auto_save()` called, but do not do anything when `_bash_it_history_auto_load()` called.
3. `autoload`: do not do anything when `_bash_it_history_auto_save()` called, but do read from `$HISTFILE` when `_bash_it_history_auto_load()` called.
4. `noauto` (default): don't do anything.

## Motivation and Context
This PR is based on @davidpfarrell's suggestions in and fixes #1595. 

`_bash_it_history_auto_save()` should be added to `preexec` hook and `_bash_it_history_auto_load()` should be added to `precmd` hook, so history is saved immediately and loaded on the next prompt.

Ok, I've refactored slightly. There's four commits. The first three just do a little cleanup on the existing plugins, and the last one adds the "automatic history management" feature. 

A few minor notes:
- Don't use `export` as it exports the variable to the environment of external binaries, which both adds clutter and alsö can *occasionally* (`ksh`?) cause very unexpected weirds including potential loss of the history file. We don't want a newly executed `bash` or `ksh` to inherit `$HISTFILE` but then otherwise set `$HISTFILESIZE` to anything shorter. `readonly` only survives the *current* shell, so make sure not to `export`.
- Do use `readonly` in `plugin/history-eternal` so that all three variables (`$HISTSIZE`, `$HISTFILESIZE`, and `$HISTFILE`) are all set simultaneously and aren't mis-matched by some clumsy script or plugin somewhere else. This combination ensures that the user's eternal history file is only touched with proper settings configured (or by hand).
- The two new history management functions *both* save history (`history -a`) on every run (unless configured not to). This is due to the fact that the `preexec` hook sometimes doesn't run due to weirds relating to emulating using the `DEBUG` hook, so just I save history twice. The cases where the `preexec` hook doesn't run are nearly instantaneous, so no functionality is lost. This doesn't have a performance penalty as _Bash_ doesn't actually save twice; it doesn't do anything when asked to append to an up-to-date history file. This combination maximizes the synchronicity of multiple shells writing to the file. Both running shells should see and update the file immediately, before and after user input.

I don't think that history management should be handled by the theme. We can set some defaults in `plugins/history` and let the user customize further. Maybe add to the template?

## How Has This Been Tested?
Tested locally, and all tests pass.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
