### PR TITLE
EditorConfig: set `indent_size = tab`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,16 +13,18 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 
 [.git*]
+indent_size = tab
 indent_style = tab
 
 [{**.*sh,test/run}]
+indent_size = tab
 indent_style = tab
 
 shell_variant      = bash
 binary_next_line   = true  # like -bn
 switch_case_indent = true  # like -ci
 space_redirects    = true  # like -sr
-keep_padding       = false  # like -kp
+keep_padding       = false # like -kp
 end_of_line        = lf
 charset            = utf-8
 trim_trailing_whitespace = true


### PR DESCRIPTION
## Description
Despite `indent_size` being set to `tab` by default, it turns out that we set `indent_size` to `2` for `*` at the top of this file. So, for everywhere else, explicitly set `indent_size` to the default (`tab`). This should achieve the goal of my last patch to `.editorconfig`.

## Motivation and Context
Linters and formatters are good; they make tedium easy. But, they need to be configured properly and it was my PR that removed the explicit `indent_size=4`.

This PR makes *no* formatting changes; just fixes my previous patch.

## References
[EditorConfig.org]( https://editorconfig.org/ ):
> indent_style: set to tab or space to use hard tabs or soft tabs respectively.
> indent_size: a whole number defining the number of columns used for each indentation level and the width of soft tabs (when supported). When set to tab, the value of tab_width (if specified) will be used.

## How Has This Been Tested?
Testing? Where we're going, we don't need testing!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
