### PR TITLE
lib/helpers: new function `_bash-it-find-in-ancestor()`

### DIFF
--- a/completion/available/gradle.completion.bash
+++ b/completion/available/gradle.completion.bash
@@ -22,17 +22,9 @@
 # Avoid inaccurate completions for subproject tasks
 COMP_WORDBREAKS=$(echo "$COMP_WORDBREAKS" | sed -e 's/://g')
 
-__gradle-set-project-root-dir() {
-    local dir="${PWD}"
-    project_root_dir="${PWD}"
-    while [[ $dir != '/' ]]; do
-        if [[ -f "$dir/settings.gradle" || -f "$dir/gradlew" ]]; then
-            project_root_dir=$dir
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    return 1
+function __gradle-set-project-root-dir() {
+    project_root_dir="$(_bash-it-find-in-ancestor "settings.gradle" "gradlew")"
+    return "$?"
 }
 
 __gradle-init-cache-dir() {

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -849,3 +849,21 @@ then
     fi
   }
 fi
+
+function _bash-it-find-in-ancestor() (
+	# We're deliberately using a subshell for this entire function for simplicity.
+	# By using a subshell, we can use ${PWD} without special handling, and can
+	#  just `cd ..` to move up the directory heirarchy.
+	# Let the shell do the work.
+	local kin
+	while [[ "${PWD}" != '/' ]]; do
+		for kin in "$@"; do
+			if [[ -r "${PWD}/${kin}" ]]; then
+				printf '%s' "${PWD}"
+				return "$?"
+			fi
+		done
+		command cd .. || return "$?"
+	done
+	return 1
+)

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -850,12 +850,21 @@ then
   }
 fi
 
+# `_bash-it-find-in-ancestor` uses the shell's ability to run a function in
+# a subshell to simplify our search to a simple `cd ..` and `[[ -r $1 ]]`
+# without any external dependencies. Let the shell do what it's good at.
 function _bash-it-find-in-ancestor() (
-	# We're deliberately using a subshell for this entire function for simplicity.
-	# By using a subshell, we can use ${PWD} without special handling, and can
-	#  just `cd ..` to move up the directory heirarchy.
-	# Let the shell do the work.
+	about 'searches parents of the current directory for any of the specified file names'
+	group 'helpers'
+	param '*: names of files or folders to search for'
+	returns '0: prints path of closest matching ancestor directory to stdout'
+	returns '1: no match found'
+	returns '2: improper usage of shell builtin' # uncommon
+	example '_bash-it-find-in-ancestor .git .hg'
+	example '_bash-it-find-in-ancestor GNUmakefile Makefile makefile'
+
 	local kin
+	# To keep things simple, we do not search the root dir.
 	while [[ "${PWD}" != '/' ]]; do
 		for kin in "$@"; do
 			if [[ -r "${PWD}/${kin}" ]]; then

--- a/plugins/available/gradle.plugin.bash
+++ b/plugins/available/gradle.plugin.bash
@@ -3,19 +3,10 @@ about-plugin 'Add a gw command to use gradle wrapper if present, else use system
 
 function gw() {
   local file="gradlew"
-  local curr_path="${PWD}"
-  local result="gradle"
+  local result
 
-  # Search recursively upwards for file.
-  until [[ "${curr_path}" == "/" ]]; do
-    if [[ -e "${curr_path}/${file}" ]]; then
-      result="${curr_path}/${file}"
-      break
-    else
-      curr_path=$(dirname "${curr_path}")
-    fi
-  done
+  result="$(_bash-it-find-in-ancestor "${file}")"
 
   # Call gradle
-  "${result}" $*
+  "${result:-gradle}" $*
 }


### PR DESCRIPTION
## Description
New function to do a search looking for a sibling to a parent of the current directory, for example to find `../../.git` to indicate that `$PWD` is inside a git repository.

## Motivation and Context
This removes the remaining path traversal logic in the `gradle` plugin and completion, and I suspect may be useful for SCM stuff in themes.

Suggestions for a better function name welcome!!

## How Has This Been Tested?
All tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
