### PR TITLE
completion/wpscan: simplify code flow (whitespace)

### DIFF
--- a/completion/available/wpscan.completion.bash
+++ b/completion/available/wpscan.completion.bash
@@ -1,15 +1,16 @@
 # shellcheck shell=bash
 
-if _command_exists wpscan; then
-	function __wpscan_completion() {
-		local OPTS=("--help --hh --version --url --ignore-main-redirect --verbose --output --format --detection-mode --scope --headers --user-agent --vhost --random-user-agent --user-agents-list --http-auth --max-threads --throttle --request-timeout --connect-timeout --disable-tlc-checks --proxy --proxy-auth --cookie-string --cookie-jar --cache-ttl --clear-cache --server --cache-dir --update --no-update --wp-content-dir --wp-plugins-dir --wp-version-detection --main-theme-detection --enumerate --exclude-content-based --plugins-list --plugins-detection --plugins-version-all --plugins-version-detection --themes-list --themes-detection --themes-version-all --themes-version-detection --timthumbs-list --timthumbs-detection --config-backups-list --config-backups-detection --db-exports-list --db-exports-detection --medias-detection --users-list --users-detection --passwords --usernames --multicall-max-passwords --password-attack --stealthy")
-		COMPREPLY=()
-		for _opt_ in "${OPTS[@]}"; do
-			if [[ "$_opt_" == "$2"* ]]; then
-				COMPREPLY+=("$_opt_")
-			fi
-		done
-	}
+_command_exists wpscan || return
 
-	complete -F __wpscan_completion wpscan
-fi
+function __wpscan_completion() {
+	local _opt_
+	local OPTS=('--help' '--hh' '--version' '--url' '--ignore-main-redirect' '--verbose' '--output' '--format' '--detection-mode' '--scope' '--headers' '--user-agent' '--vhost' '--random-user-agent' '--user-agents-list' '--http-auth' '--max-threads' '--throttle' '--request-timeout' '--connect-timeout' '--disable-tlc-checks' '--proxy' '--proxy-auth' '--cookie-string' '--cookie-jar' '--cache-ttl' '--clear-cache' '--server' '--cache-dir' '--update' '--no-update' '--wp-content-dir' '--wp-plugins-dir' '--wp-version-detection' '--main-theme-detection' '--enumerate' '--exclude-content-based' '--plugins-list' '--plugins-detection' '--plugins-version-all' '--plugins-version-detection' '--themes-list' '--themes-detection' '--themes-version-all' '--themes-version-detection' '--timthumbs-list' '--timthumbs-detection' '--config-backups-list' '--config-backups-detection' '--db-exports-list' '--db-exports-detection' '--medias-detection' '--users-list' '--users-detection' '--passwords' '--usernames' '--multicall-max-passwords' '--password-attack' '--stealthy')
+	COMPREPLY=()
+	for _opt_ in "${OPTS[@]}"; do
+		if [[ "$_opt_" == "$2"* ]]; then
+			COMPREPLY+=("$_opt_")
+		fi
+	done
+}
+
+complete -F __wpscan_completion wpscan


### PR DESCRIPTION
## Description
Convert from indented if-block to return then unindented code. This should have basically one line change at the top, one line removed at the bottom, and then all whitespace.

## Motivation and Context
Just cleaning up.

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
