### PR TITLE
completion/pip: simplify control flow

### DIFF
--- a/completion/available/pip.completion.bash
+++ b/completion/available/pip.completion.bash
@@ -6,14 +6,15 @@
 # If the pip package is installed within virtual environments, say, python managed by pyenv,
 # you should first initialize the corresponding environment.
 # So that pip is in the system's path.
-if _command_exists pip; then
-	function __bash_it_complete_pip() {
-		if _command_exists _pip_completion; then
-			_pip_completion "$@"
-		else
-			eval "$(pip completion --bash)"
-			_pip_completion "$@"
-		fi
-	}
-	complete -o default -F __bash_it_complete_pip pip
-fi
+_command_exists pip || return
+
+function __bash_it_complete_pip() {
+	if _command_exists _pip_completion; then
+		complete -o default -F _pip_completion pip
+		_pip_completion "$@"
+	else
+		eval "$(pip completion --bash)"
+		_pip_completion "$@"
+	fi
+}
+complete -o default -F __bash_it_complete_pip pip

--- a/completion/available/pip3.completion.bash
+++ b/completion/available/pip3.completion.bash
@@ -6,14 +6,15 @@
 # If the pip package is installed within virtual environments, say, python managed by pyenv,
 # you should first initialize the corresponding environment.
 # So that pip3 is in the system's path.
-if _command_exists pip3; then
-	function __bash_it_complete_pip3() {
-		if _command_exists _pip_completion; then
-			_pip_completion "$@"
-		else
-			eval "$(pip3 completion --bash)"
-			_pip_completion "$@"
-		fi
-	}
-	complete -o default -F __bash_it_complete_pip3 pip3
-fi
+_command_exists pip3 || return
+
+function __bash_it_complete_pip3() {
+	if _command_exists _pip_completion; then
+		complete -o default -F _pip_completion pip3
+		_pip_completion "$@"
+	else
+		eval "$(pip3 completion --bash)"
+		_pip_completion "$@"
+	fi
+}
+complete -o default -F __bash_it_complete_pip3 pip3


### PR DESCRIPTION
## Description
Short-circuit the loader rather than indenting nearly the whole file.

Alsö, assign the `_pip_completion()` handler directly once it's loaded so that we get out of the way once we load it.

## Motivation and Context
Indenting the entirety of the logic of the file just weirds me out...it alsö makes future diff's weird, and makes any whitespace changes look like the whole file was replaced.

Alsö, this function doesn't need to run ever once the real completion is loaded.

Alsö alsö, I feel like the `_command_exists _pip_completion` branch of the if statement will *never* be taken, no matter what else is loaded already. Won't `eval "$(pip completion --bash)"` register the full handler itself and then we never run?

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
