### PR TITLE
theme/powerline: fix an oops in the last patch

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -142,7 +142,7 @@ function __powerline_scm_prompt() {
 }
 
 function __powerline_cwd_prompt() {
-	local cwd="${PWD/$HOME/\~}"
+	local cwd="${PWD/$HOME/~}"
 
 	echo "${cwd}|${CWD_THEME_PROMPT_COLOR}"
 }


### PR DESCRIPTION
## Description
The tilde should not have been escaped, and in fact I did not have it escaped in my main branch, but the PR I submitted did have it escaped and...now it shows up in the prompt line for all the PowerLine themes... oops.

## How Has This Been Tested?
Locally. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
