### PR TITLE
Plugin/jekyll: lint and stuff

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -137,13 +137,6 @@ elif [ -s /Applications/Preview.app ]; then
 	PREVIEW="/Applications/Preview.app"
 fi
 
-# Load all the Jekyll stuff
-
-if [ -e "$HOME/.jekyllconfig" ]; then
-	# shellcheck disable=SC1090
-	. "$HOME/.jekyllconfig"
-fi
-
 # BASH_IT_RELOAD_LEGACY is set.
 if ! _command_exists reload && [[ -n "${BASH_IT_RELOAD_LEGACY:-}" ]]; then
 	case $OSTYPE in

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -97,6 +97,7 @@ plugins/available/history-search.plugin.bash
 plugins/available/history-substring-search.plugin.bash
 plugins/available/history.plugin.bash
 plugins/available/hub.plugin.bash
+plugins/available/jekyll.plugin.bash
 plugins/available/jump.plugin.bash
 plugins/available/less-pretty-cat.plugin.bash
 plugins/available/node.plugin.bash

--- a/plugins/available/jekyll.plugin.bash
+++ b/plugins/available/jekyll.plugin.bash
@@ -315,3 +315,8 @@ function deploysite() {
 	builtin cd "${SITE}" || return
 	rsync -rz "${REMOTE?}"
 }
+
+# Load the Jekyll config
+if [[ -s "$HOME/.jekyllconfig" ]]; then
+	source "$HOME/.jekyllconfig"
+fi

--- a/plugins/available/jekyll.plugin.bash
+++ b/plugins/available/jekyll.plugin.bash
@@ -7,8 +7,8 @@ function editpost() {
 	param '1: site directory'
 	group 'jekyll'
 
-	local SITE site POST DATE TITLE POSTS TMPFILE POST_TO_EDIT
-	local -i COUNTER
+	local SITE site POST DATE TITLE POSTS
+	local -i COUNTER=1 POST_TO_EDIT
 	if [[ -z "${1:-}" ]]; then
 		echo "Error: no site specified."
 		echo "The site is the name of the directory your project is in."
@@ -29,20 +29,16 @@ function editpost() {
 
 	builtin cd "${SITE}/_posts" || return
 
-	COUNTER=1
-	TMPFILE="/tmp/editpost-$RANDOM"
-
 	for POST in *; do
 		DATE="$(echo "${POST}" | grep -oE "[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}")"
 		TITLE="$(grep -oE "title: (.+)" < "${POST}")"
 		TITLE="${TITLE/title: /}"
-		echo "${COUNTER}) 	${DATE}	${TITLE}" >> "${TMPFILE}"
+		echo "${COUNTER}) 	${DATE}	${TITLE}"
 		POSTS[COUNTER]="$POST"
 		COUNTER="$((COUNTER + 1))"
-	done
-	less "${TMPFILE}"
+	done | less
 	read -rp "Number of post to edit: " POST_TO_EDIT
-	"${JEKYLL_EDITOR:-${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}}}" "${POSTS[$POST_TO_EDIT]}"
+	"${JEKYLL_EDITOR:-${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}}}" "${POSTS[POST_TO_EDIT]}"
 }
 
 function newpost() {
@@ -52,23 +48,22 @@ function newpost() {
 
 	local SITE site FNAME_POST_TITLE FNAME YAML_DATE
 	local JEKYLL_FORMATTING FNAME_DATE OPTIONS OPTION POST_TYPE POST_TITLE
-	if [ -z "$1" ]; then
+	local -i loc=0
+	if [[ -z "${1:-}" ]]; then
 		echo "Error: no site specified."
 		echo "The site is the name of the directory your project is in."
 		return 1
 	fi
 
-	if [ -z "$SITE" ]; then
+	if [[ -z "${SITE}" ]]; then
 		echo "No such site."
 		return 1
 	fi
 
-	loc=0
-
 	for site in "${SITES[@]}"; do
-		if [ "${site##*/}" = "$1" ]; then
-			SITE=$site
-			JEKYLL_FORMATTING=${MARKUPS[$loc]}
+		if [[ "${site##*/}" == "$1" ]]; then
+			SITE="$site"
+			JEKYLL_FORMATTING="${MARKUPS[loc]}"
 			break
 		fi
 		loc=$((loc + 1))
@@ -88,32 +83,32 @@ function newpost() {
 
 	if [[ $JEKYLL_FORMATTING == "markdown" || $JEKYLL_FORMATTING == "textile" ]]; then
 		select OPTION in "${OPTIONS[@]}"; do
-			if [[ $OPTION = "Text" ]]; then
+			if [[ $OPTION == "Text" ]]; then
 				POST_TYPE="Text"
 				break
 			fi
 
-			if [[ $OPTION = "Quote" ]]; then
+			if [[ $OPTION == "Quote" ]]; then
 				POST_TYPE="Quote"
 				break
 			fi
 
-			if [[ $OPTION = "Image" ]]; then
+			if [[ $OPTION == "Image" ]]; then
 				POST_TYPE="Image"
 				break
 			fi
 
-			if [[ $OPTION = "Audio" ]]; then
+			if [[ $OPTION == "Audio" ]]; then
 				POST_TYPE="Audio"
 				break
 			fi
 
-			if [[ $OPTION = "Video" ]]; then
+			if [[ $OPTION == "Video" ]]; then
 				POST_TYPE="Video"
 				break
 			fi
 
-			if [[ $OPTION = "Link" ]]; then
+			if [[ $OPTION == "Link" ]]; then
 				POST_TYPE="Link"
 				break
 			fi
@@ -133,31 +128,27 @@ function newpost() {
 	FNAME="$FNAME_DATE-$FNAME_POST_TITLE.$JEKYLL_FORMATTING"
 
 	# And, finally, create the actual post file. But we're not done yet...
-	# Write a little stuff to the file for the YAML Front Matter
+	{
+		# Write a little stuff to the file for the YAML Front Matter
+		echo "---"
 
-	echo "---" >> "${FNAME}"
+		# Now we have to get the date, again. But this time for in the header (YAML Front Matter) of the file
+		YAML_DATE="$(date "+%B %d %Y %X")"
 
-	# Now we have to get the date, again. But this time for in the header (YAML Front Matter) of
-	# the file
+		# Echo the YAML Formatted date to the post file
+		echo "date: $YAML_DATE"
 
-	YAML_DATE="$(date "+%B %d %Y %X")"
+		# Echo the original post title to the YAML Front Matter header
+		echo "title: $POST_TITLE"
 
-	# Echo the YAML Formatted date to the post file
+		# And, now, echo the "post" layout to the YAML Front Matter header
+		echo "layout: post"
 
-	echo "date: $YAML_DATE" >> "${FNAME}"
+		# Close the YAML Front Matter Header
+		echo "---"
 
-	# Echo the original post title to the YAML Front Matter header
-
-	echo "title: $POST_TITLE" >> "${FNAME}"
-
-	# And, now, echo the "post" layout to the YAML Front Matter header
-
-	echo "layout: post" >> "${FNAME}"
-
-	# Close the YAML Front Matter Header
-
-	echo "---" >> "${FNAME}"
-	echo >> "${FNAME}"
+		echo
+	} > "${FNAME}"
 
 	# Generate template text based on the post type
 
@@ -167,31 +158,31 @@ function newpost() {
 		fi
 
 		if [[ $POST_TYPE == "Quote" ]]; then
-			echo "> Quote" >> "${FNAME}"
-			echo >> "${FNAME}"
-			echo "&mdash; Author" >> "${FNAME}"
+			echo "> Quote"
+			echo
+			echo "&mdash; Author"
 		fi
 
 		if [[ $POST_TYPE == "Image" ]]; then
-			echo "![Alternate Text](/path/to/image/or/url)" >> "${FNAME}"
+			echo "![Alternate Text](/path/to/image/or/url)"
 		fi
 
 		if [[ $POST_TYPE == "Audio" ]]; then
-			echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>" >> "${FNAME}"
+			echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>"
 		fi
 
 		if [[ $POST_TYPE == "Video" ]]; then
-			echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>" >> "${FNAME}"
+			echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>"
 		fi
 
 		if [[ $POST_TYPE == "Link" ]]; then
-			echo "[link][1]" >> "${FNAME}"
-			echo >> "${FNAME}"
-			echo "> Quote" >> "${FNAME}"
-			echo >> "${FNAME}"
-			echo "[1]: url" >> "${FNAME}"
+			echo "[link][1]"
+			echo
+			echo "> Quote"
+			echo
+			echo "[1]: url"
 		fi
-	fi
+	fi >> "${FNAME}"
 
 	if [[ $JEKYLL_FORMATTING == "textile" ]]; then
 		if [[ $POST_TYPE == "Text" ]]; then
@@ -199,29 +190,29 @@ function newpost() {
 		fi
 
 		if [[ $POST_TYPE == "Quote" ]]; then
-			echo "bq. Quote" >> "${FNAME}"
-			echo >> "${FNAME}"
-			echo "&mdash; Author" >> "${FNAME}"
+			echo "bq. Quote"
+			echo
+			echo "&mdash; Author"
 		fi
 
 		if [[ $POST_TYPE == "Image" ]]; then
-			echo "!url(alt text)" >> "${FNAME}"
+			echo "!url(alt text)"
 		fi
 
 		if [[ $POST_TYPE == "Audio" ]]; then
-			echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>" >> "${FNAME}"
+			echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>"
 		fi
 
 		if [[ $POST_TYPE == "Video" ]]; then
-			echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>" >> "${FNAME}"
+			echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>"
 		fi
 
 		if [[ $POST_TYPE == "Link" ]]; then
-			echo "\"Site\":url" >> "${FNAME}"
-			echo >> "${FNAME}"
-			echo "bq. Quote" >> "${FNAME}"
+			echo "\"Site\":url"
+			echo
+			echo "bq. Quote"
 		fi
-	fi
+	fi >> "${FNAME}"
 
 	# Open the file in your favorite editor
 
@@ -299,7 +290,7 @@ function deploysite() {
 	fi
 
 	for site in "${SITES[@]}"; do
-		if [ "${site##*/}" == "$1" ]; then
+		if [[ "${site##*/}" == "$1" ]]; then
 			SITE="$site"
 			REMOTE="${REMOTES[loc]}"
 			break

--- a/plugins/available/jekyll.plugin.bash
+++ b/plugins/available/jekyll.plugin.bash
@@ -1,367 +1,317 @@
+# shellcheck shell=bash
 cite about-plugin
 about-plugin 'manage your jekyll site'
 
-editpost() {
-  about 'edit a post'
-  param '1: site directory'
-  group 'jekyll'
+function editpost() {
+	about 'edit a post'
+	param '1: site directory'
+	group 'jekyll'
 
-  unset SITE
-  if [ -z "$1" ]
-  then
-    echo "Error: no site specified."
-    echo "The site is the name of the directory your project is in."
-    return 1
-  fi
+	local SITE site POST DATE TITLE POSTS TMPFILE POST_TO_EDIT
+	local -i COUNTER
+	if [[ -z "${1:-}" ]]; then
+		echo "Error: no site specified."
+		echo "The site is the name of the directory your project is in."
+		return 1
+	fi
 
-  for site in ${SITES[@]}
-  do
-    if [ "${site##*/}" = "$1" ]
-    then
-      SITE=$site
-      break
-    fi
-  done
+	for site in "${SITES[@]:-}"; do
+		if [[ "${site##*/}" == "$1" ]]; then
+			SITE="${site}"
+			break
+		fi
+	done
 
-  if [ -z "$SITE" ]
-  then
-    echo "No such site."
-    return 1
-  fi
+	if [[ -z "${SITE:-}" ]]; then
+		echo "No such site."
+		return 1
+	fi
 
-  builtin cd "$SITE/_posts"
+	builtin cd "${SITE}/_posts" || return
 
-  COUNTER=1
-  NUMBER="$RANDOM"
-  TMPFILE="/tmp/editpost-$NUMBER"
+	COUNTER=1
+	TMPFILE="/tmp/editpost-$RANDOM"
 
-  for POST in *
-  do
-    DATE=`echo $POST | grep -oE "[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}"`
-    TITLE=`cat $POST | grep -oE "title: (.+)"`
-    TITLE=`echo $TITLE | sed 's/title: //'`
-    echo "$COUNTER) 	$DATE	$TITLE" >> "$TMPFILE"
-    POSTS[$COUNTER]=$POST
-    COUNTER=`expr $COUNTER + 1`
-  done
-  less $TMPFILE
-  read -p "Number of post to edit: " POST_TO_EDIT
-  if [ -z "$JEKYLL_EDITOR" ]
-  then
-    nano "${POSTS[$POST_TO_EDIT]}"
-  else
-    "$JEKYLL_EDITOR" "${POSTS[$POST_TO_EDIT]}"
-  fi
+	for POST in *; do
+		DATE="$(echo "${POST}" | grep -oE "[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}")"
+		TITLE="$(grep -oE "title: (.+)" < "${POST}")"
+		TITLE="${TITLE/title: /}"
+		echo "${COUNTER}) 	${DATE}	${TITLE}" >> "${TMPFILE}"
+		POSTS[COUNTER]="$POST"
+		COUNTER="$((COUNTER + 1))"
+	done
+	less "${TMPFILE}"
+	read -rp "Number of post to edit: " POST_TO_EDIT
+	"${JEKYLL_EDITOR:-${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}}}" "${POSTS[$POST_TO_EDIT]}"
 }
 
-newpost() {
-  about 'create a new post'
-  param '1: site directory'
-  group 'jekyll'
+function newpost() {
+	about 'create a new post'
+	param '1: site directory'
+	group 'jekyll'
 
-  unset SITE
-  if [ -z "$1" ]
-  then
-    echo "Error: no site specified."
-    echo "The site is the name of the directory your project is in."
-    return 1
-  fi
+	local SITE site FNAME_POST_TITLE FNAME YAML_DATE
+	local JEKYLL_FORMATTING FNAME_DATE OPTIONS OPTION POST_TYPE POST_TITLE
+	if [ -z "$1" ]; then
+		echo "Error: no site specified."
+		echo "The site is the name of the directory your project is in."
+		return 1
+	fi
 
-  if [ -z "$SITE" ]
-  then
-    echo "No such site."
-    return 1
-  fi
+	if [ -z "$SITE" ]; then
+		echo "No such site."
+		return 1
+	fi
 
-  loc=0
+	loc=0
 
-  for site in ${SITES[@]}
-  do
-    if [ "${site##*/}" = "$1" ]
-    then
-      SITE=$site
-      JEKYLL_FORMATTING=${MARKUPS[$loc]}
-      break
-    fi
-    loc=$(($loc+1))
-  done
+	for site in "${SITES[@]}"; do
+		if [ "${site##*/}" = "$1" ]; then
+			SITE=$site
+			JEKYLL_FORMATTING=${MARKUPS[$loc]}
+			break
+		fi
+		loc=$((loc + 1))
+	done
 
-  # 'builtin cd' into the local jekyll root
+	# 'builtin cd' into the local jekyll root
 
-  builtin cd "$SITE/_posts"
+	builtin cd "${SITE}/_posts" || return
 
-  # Get the date for the new post's filename
+	# Get the date for the new post's filename
 
-  FNAME_DATE=$(date "+%Y-%m-%d")
+	FNAME_DATE="$(date "+%Y-%m-%d")"
 
-  # If the user is using markdown or textile formatting, let them choose what type of post they want. Sort of like Tumblr.
+	# If the user is using markdown or textile formatting, let them choose what type of post they want. Sort of like Tumblr.
 
-  OPTIONS="Text Quote Image Audio Video Link"
+	OPTIONS=('Text' 'Quote' 'Image' 'Audio' 'Video' 'Link')
 
-  if [ $JEKYLL_FORMATTING = "markdown" -o $JEKYLL_FORMATTING = "textile" ]
-  then
-    select OPTION in $OPTIONS
-    do
-      if [[ $OPTION = "Text" ]]
-      then
-        POST_TYPE="Text"
-        break
-      fi
+	if [[ $JEKYLL_FORMATTING == "markdown" || $JEKYLL_FORMATTING == "textile" ]]; then
+		select OPTION in "${OPTIONS[@]}"; do
+			if [[ $OPTION = "Text" ]]; then
+				POST_TYPE="Text"
+				break
+			fi
 
-      if [[ $OPTION = "Quote" ]]
-      then
-        POST_TYPE="Quote"
-        break
-      fi
+			if [[ $OPTION = "Quote" ]]; then
+				POST_TYPE="Quote"
+				break
+			fi
 
-      if [[ $OPTION = "Image" ]]
-      then
-        POST_TYPE="Image"
-        break
-      fi
+			if [[ $OPTION = "Image" ]]; then
+				POST_TYPE="Image"
+				break
+			fi
 
-      if [[ $OPTION = "Audio" ]]
-      then
-        POST_TYPE="Audio"
-        break
-      fi
+			if [[ $OPTION = "Audio" ]]; then
+				POST_TYPE="Audio"
+				break
+			fi
 
-      if [[ $OPTION = "Video" ]]
-      then
-        POST_TYPE="Video"
-        break
-      fi
+			if [[ $OPTION = "Video" ]]; then
+				POST_TYPE="Video"
+				break
+			fi
 
-      if [[ $OPTION = "Link" ]]
-      then
-        POST_TYPE="Link"
-        break
-      fi
-    done
-  fi
+			if [[ $OPTION = "Link" ]]; then
+				POST_TYPE="Link"
+				break
+			fi
+		done
+	fi
 
-  # Get the title for the new post
+	# Get the title for the new post
 
-  read -p "Enter title of the new post: " POST_TITLE
+	read -rp "Enter title of the new post: " POST_TITLE
 
-  # Convert the spaces in the title to hyphens for use in the filename
+	# Convert the spaces in the title to hyphens for use in the filename
 
-  FNAME_POST_TITLE=`echo $POST_TITLE | tr ' ' "-"`
+	FNAME_POST_TITLE="${POST_TITLE/ /-}"
 
-  # Now, put it all together for the full filename
+	# Now, put it all together for the full filename
 
-  FNAME="$FNAME_DATE-$FNAME_POST_TITLE.$JEKYLL_FORMATTING"
+	FNAME="$FNAME_DATE-$FNAME_POST_TITLE.$JEKYLL_FORMATTING"
 
-  # And, finally, create the actual post file. But we're not done yet...
+	# And, finally, create the actual post file. But we're not done yet...
+	# Write a little stuff to the file for the YAML Front Matter
 
-  touch "$FNAME"
+	echo "---" >> "${FNAME}"
 
-  # Write a little stuff to the file for the YAML Front Matter
+	# Now we have to get the date, again. But this time for in the header (YAML Front Matter) of
+	# the file
 
-  echo "---" >> $FNAME
+	YAML_DATE="$(date "+%B %d %Y %X")"
 
-  # Now we have to get the date, again. But this time for in the header (YAML Front Matter) of
-  # the file
+	# Echo the YAML Formatted date to the post file
 
-  YAML_DATE=$(date "+%B %d %Y %X")
+	echo "date: $YAML_DATE" >> "${FNAME}"
 
-  # Echo the YAML Formatted date to the post file
+	# Echo the original post title to the YAML Front Matter header
 
-  echo "date: $YAML_DATE" >> $FNAME
+	echo "title: $POST_TITLE" >> "${FNAME}"
 
-  # Echo the original post title to the YAML Front Matter header
+	# And, now, echo the "post" layout to the YAML Front Matter header
 
-  echo "title: $POST_TITLE" >> $FNAME
+	echo "layout: post" >> "${FNAME}"
 
-  # And, now, echo the "post" layout to the YAML Front Matter header
+	# Close the YAML Front Matter Header
 
-  echo "layout: post" >> $FNAME
+	echo "---" >> "${FNAME}"
+	echo >> "${FNAME}"
 
-  # Close the YAML Front Matter Header
+	# Generate template text based on the post type
 
-  echo "---" >> $FNAME
-  echo >> $FNAME
+	if [[ $JEKYLL_FORMATTING == "markdown" ]]; then
+		if [[ $POST_TYPE == "Text" ]]; then
+			true
+		fi
 
-  # Generate template text based on the post type
+		if [[ $POST_TYPE == "Quote" ]]; then
+			echo "> Quote" >> "${FNAME}"
+			echo >> "${FNAME}"
+			echo "&mdash; Author" >> "${FNAME}"
+		fi
 
-  if [[ $JEKYLL_FORMATTING = "markdown" ]]
-  then
-    if [[ $POST_TYPE = "Text" ]]
-    then
-      true
-    fi
+		if [[ $POST_TYPE == "Image" ]]; then
+			echo "![Alternate Text](/path/to/image/or/url)" >> "${FNAME}"
+		fi
 
-    if [[ $POST_TYPE = "Quote" ]]
-    then
-      echo "> Quote" >> $FNAME
-      echo >> $FNAME
-      echo "&mdash; Author" >> $FNAME
-    fi
+		if [[ $POST_TYPE == "Audio" ]]; then
+			echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>" >> "${FNAME}"
+		fi
 
-    if [[ $POST_TYPE = "Image" ]]
-    then
-      echo "![Alternate Text](/path/to/image/or/url)" >> $FNAME
-    fi
+		if [[ $POST_TYPE == "Video" ]]; then
+			echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>" >> "${FNAME}"
+		fi
 
-    if [[ $POST_TYPE = "Audio" ]]
-    then
-      echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>" >> $FNAME
-    fi
+		if [[ $POST_TYPE == "Link" ]]; then
+			echo "[link][1]" >> "${FNAME}"
+			echo >> "${FNAME}"
+			echo "> Quote" >> "${FNAME}"
+			echo >> "${FNAME}"
+			echo "[1]: url" >> "${FNAME}"
+		fi
+	fi
 
-    if [[ $POST_TYPE = "Video" ]]
-    then
-      echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>" >> $FNAME
-    fi
+	if [[ $JEKYLL_FORMATTING == "textile" ]]; then
+		if [[ $POST_TYPE == "Text" ]]; then
+			true
+		fi
 
-    if [[ $POST_TYPE = "Link" ]]
-    then
-      echo "[link][1]" >> $FNAME
-      echo >> $FNAME
-      echo "> Quote" >> $FNAME
-      echo >> $FNAME
-      echo "[1]: url" >> $FNAME
-    fi
-  fi
+		if [[ $POST_TYPE == "Quote" ]]; then
+			echo "bq. Quote" >> "${FNAME}"
+			echo >> "${FNAME}"
+			echo "&mdash; Author" >> "${FNAME}"
+		fi
 
-  if [[ $JEKYLL_FORMATTING = "textile" ]]
-  then
-    if [[ $POST_TYPE = "Text" ]]
-    then
-      true
-    fi
+		if [[ $POST_TYPE == "Image" ]]; then
+			echo "!url(alt text)" >> "${FNAME}"
+		fi
 
-    if [[ $POST_TYPE = "Quote" ]]
-    then
-      echo "bq. Quote" >> $FNAME
-      echo >> $FNAME
-      echo "&mdash; Author" >> $FNAME
-    fi
+		if [[ $POST_TYPE == "Audio" ]]; then
+			echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>" >> "${FNAME}"
+		fi
 
-    if [[ $POST_TYPE = "Image" ]]
-    then
-      echo "!url(alt text)" >> $FNAME
-    fi
+		if [[ $POST_TYPE == "Video" ]]; then
+			echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>" >> "${FNAME}"
+		fi
 
-    if [[ $POST_TYPE = "Audio" ]]
-    then
-      echo "<html><audio src=\"/path/to/audio/file\" controls=\"controls\"></audio></html>" >> $FNAME
-    fi
+		if [[ $POST_TYPE == "Link" ]]; then
+			echo "\"Site\":url" >> "${FNAME}"
+			echo >> "${FNAME}"
+			echo "bq. Quote" >> "${FNAME}"
+		fi
+	fi
 
-    if [[ $POST_TYPE = "Video" ]]
-    then
-      echo "<html><video src=\"/path/to/video\" controls=\"controls\"></video></html>" >> $FNAME
-    fi
+	# Open the file in your favorite editor
 
-    if [[ $POST_TYPE = "Link" ]]
-    then
-      echo "\"Site\":url" >> $FNAME
-      echo >> $FNAME
-      echo "bq. Quote" >> $FNAME
-    fi
-  fi
-
-  # Open the file in your favorite editor
-
-  "$JEKYLL_EDITOR" $FNAME
+	"${JEKYLL_EDITOR:-${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}}}" "${FNAME}"
 }
 
 function testsite() {
-  about 'launches local jekyll server'
-  param '1: site directory'
-  group 'jekyll'
+	about 'launches local jekyll server'
+	param '1: site directory'
+	group 'jekyll'
 
-  unset SITE
-  if [ -z "$1" ]
-  then
-    echo "Error: no site specified."
-    echo "The site is the name of the directory your project is in."
-    return 1
-  fi
+	local SITE site
+	if [[ -z "${1:-}" ]]; then
+		echo "Error: no site specified."
+		echo "The site is the name of the directory your project is in."
+		return 1
+	fi
 
-  for site in ${SITES[@]}
-  do
-    if [ "${site##*/}" = "$1" ]
-    then
-      SITE=$site
-      break
-    fi
-  done
+	for site in "${SITES[@]}"; do
+		if [[ "${site##*/}" == "$1" ]]; then
+			SITE="$site"
+			break
+		fi
+	done
 
-  if [ -z "$SITE" ]
-  then
-    echo "No such site."
-    return 1
-  fi
+	if [[ -z "${SITE}" ]]; then
+		echo "No such site."
+		return 1
+	fi
 
-  builtin cd $SITE
-  jekyll --server --auto
+	builtin cd "${SITE}" || return
+	jekyll --server --auto
 }
 
 function buildsite() {
-  about 'builds site'
-  param '1: site directory'
-  group 'jekyll'
+	about 'builds site'
+	param '1: site directory'
+	group 'jekyll'
 
-  unset SITE
-  if [ -z "$1" ]
-  then
-    echo "Error: no site specified."
-    echo "The site is the name of the directory your project is in."
-    return 1
-  fi
+	local SITE site
+	if [[ -z "${1:-}" ]]; then
+		echo "Error: no site specified."
+		echo "The site is the name of the directory your project is in."
+		return 1
+	fi
 
-  for site in ${SITES[@]}
-  do
-    if [ "${site##*/}" = "$1" ]
-    then
-      SITE=$site
-      break
-    fi
-  done
+	for site in "${SITES[@]}"; do
+		if [[ "${site##*/}" == "$1" ]]; then
+			SITE="$site"
+			break
+		fi
+	done
 
-  if [ -z "$SITE" ]
-  then
-    echo "No such site."
-    return 1
-  fi
+	if [[ -z "${SITE}" ]]; then
+		echo "No such site."
+		return 1
+	fi
 
-  builtin cd $SITE
-  rm -rf _site
-  jekyll --no-server
+	builtin cd "${SITE}" || return
+	rm -rf _site
+	jekyll --no-server
 }
 
 function deploysite() {
-  about 'rsyncs site to remote host'
-  param '1: site directory'
-  group 'jekyll'
+	about 'rsyncs site to remote host'
+	param '1: site directory'
+	group 'jekyll'
 
-  unset SITE
-  if [ -z "$1" ]
-  then
-    echo "Error: no site specified."
-    echo "The site is the name of the directory your project is in."
-    return 1
-  fi
+	local SITE site REMOTE
+	local -i loc=0
+	if [[ -z "${1:-}" ]]; then
+		echo "Error: no site specified."
+		echo "The site is the name of the directory your project is in."
+		return 1
+	fi
 
-  loc=0
+	for site in "${SITES[@]}"; do
+		if [ "${site##*/}" == "$1" ]; then
+			SITE="$site"
+			REMOTE="${REMOTES[loc]}"
+			break
+		fi
+		loc=$((loc + 1))
+	done
 
-  for site in ${SITES[@]}
-  do
-    if [ "${site##*/}" = "$1" ]
-    then
-      SITE=$site
-      REMOTE=${REMOTES[$loc]}
-      break
-    fi
-    loc=$(($loc+1))
-  done
+	if [[ -z "${SITE}" ]]; then
+		echo "No such site."
+		return 1
+	fi
 
-  if [ -z "$SITE" ]
-  then
-    echo "No such site."
-    return 1
-  fi
-
-  builtin cd $SITE
-  rsync -rz $REMOTE
+	builtin cd "${SITE}" || return
+	rsync -rz "${REMOTE?}"
 }


### PR DESCRIPTION
## Description
Run `shellcheck`, `shfmt`, and then try to clean up a bit. 

## Motivation and Context
No behavior changes intended with one exception: `source ~/.jekyllconfig` is moved from main to the Jekyll plugin.

## How Has This Been Tested?
Tested?

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
