### PR TITLE
Fix save-and-reload-history command not found

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -275,7 +275,7 @@ function __powerline_prompt_command() {
 	SEGMENTS_AT_LEFT=0
 	LAST_SEGMENT_COLOR=""
 
-	save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
+	_save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 
 	if [[ -n "${POWERLINE_PROMPT_DISTRO_LOGO}" ]]; then
 		LEFT_PROMPT+="$(set_color "${PROMPT_DISTRO_LOGO_COLOR}" "${PROMPT_DISTRO_LOGO_COLORBG}")${PROMPT_DISTRO_LOGO}$(set_color - -)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The function `save-and-reload-history` is not exists.
Use `_save-and-reload-history` instead of `save-and-reload-history`.

## Description

When I set `BASH_IT_THEME='powerline'`,
it will show `save-and-reload-history: command not found` every time after starting a new command.
I found that other scripts use `_save-and-reload-history` instead of `save-and-reload-history`,
so I replace it with `_save-and-reload-history`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fixes "command not found."

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Set `export BASH_IT_THEME='powerline` in `~/.bashrc`.
2. `source ~/.bashrc`
3. Press enter or some command.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
