### PR TITLE
Use `_bash-it-egrep()`

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -711,8 +711,8 @@ _enable-thing ()
 
         # Load the priority from the file if it present there
         declare local_file_priority use_load_priority
-        local_file_priority=$(grep -E "^# BASH_IT_LOAD_PRIORITY:" "${BASH_IT}/$subdirectory/available/$to_enable" | awk -F': ' '{ print $2 }')
-        use_load_priority=${local_file_priority:-$load_priority}
+		local_file_priority="$(_bash-it-egrep "^# BASH_IT_LOAD_PRIORITY:" "${BASH_IT}/$subdirectory/available/$to_enable" | awk -F': ' '{ print $2 }')"
+		use_load_priority="${local_file_priority:-$load_priority}"
 
         ln -s ../$subdirectory/available/$to_enable "${BASH_IT}/enabled/${use_load_priority}${BASH_IT_LOAD_PRIORITY_SEPARATOR}${to_enable}"
     fi

--- a/lib/search.bash
+++ b/lib/search.bash
@@ -57,7 +57,6 @@ _bash-it-search() {
 
   local component
   export BASH_IT_SEARCH_USE_COLOR=true
-  export BASH_IT_GREP=${BASH_IT_GREP:-$(which egrep)}
   declare -a BASH_IT_COMPONENTS=(aliases plugins completions)
 
   if [[ -z "$*" ]] ; then
@@ -168,7 +167,7 @@ ${echo_underline_yellow}SUMMARY${echo_normal}
 _bash-it-is-partial-match() {
   local component="$1"
   local term="$2"
-  _bash-it-component-help "${component}" | $(_bash-it-grep) -E -i -q -- "${term}"
+  _bash-it-component-help "${component}" | _bash-it-egrep -i -q -- "${term}"
 }
 
 _bash-it-component-term-matches-negation() {

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -82,7 +82,7 @@ function _bash-it-component-help() {
 	file="$(_bash-it-component-cache-file "${component}")"
 	if [[ ! -s "${file}" || -z "$(find "${file}" -mmin -300)" ]]; then
 		func="_bash-it-${component}"
-		"${func}" | ${BASH_IT_GREP:-$(_bash-it-grep)} -E '   \[' >| "${file}"
+		"${func}" | _bash-it-egrep '   \[' >| "${file}"
 	fi
 	cat "${file}"
 }
@@ -130,17 +130,17 @@ function _bash-it-component-list-matching() {
 	local component="$1"
 	shift
 	local term="$1"
-	_bash-it-component-help "${component}" | ${BASH_IT_GREP:-$(_bash-it-grep)} -E -- "${term}" | awk '{print $1}' | sort -u
+	_bash-it-component-help "${component}" | _bash-it-egrep -- "${term}" | awk '{print $1}' | sort -u
 }
 
 function _bash-it-component-list-enabled() {
 	local IFS=$'\n' component="$1"
-	_bash-it-component-help "${component}" | ${BASH_IT_GREP:-$(_bash-it-grep)} -E '\[x\]' | awk '{print $1}' | sort -u
+	_bash-it-component-help "${component}" | _bash-it-egrep '\[x\]' | awk '{print $1}' | sort -u
 }
 
 function _bash-it-component-list-disabled() {
 	local IFS=$'\n' component="$1"
-	_bash-it-component-help "${component}" | ${BASH_IT_GREP:-$(_bash-it-grep)} -E -v '\[x\]' | awk '{print $1}' | sort -u
+	_bash-it-component-help "${component}" | _bash-it-egrep -v '\[x\]' | awk '{print $1}' | sort -u
 }
 
 # Checks if a given item is enabled for a particular component/file-type.
@@ -154,7 +154,7 @@ function _bash-it-component-list-disabled() {
 function _bash-it-component-item-is-enabled() {
 	local component="$1"
 	local item="$2"
-	_bash-it-component-help "${component}" | ${BASH_IT_GREP:-$(_bash-it-grep)} -E '\[x\]' | ${BASH_IT_GREP:-$(_bash-it-grep)} -E -q -- "^${item}\s"
+	_bash-it-component-help "${component}" | _bash-it-egrep '\[x\]' | _bash-it-egrep -q -- "^${item}\s"
 }
 
 # Checks if a given item is disabled for a particular component/file-type.
@@ -168,5 +168,5 @@ function _bash-it-component-item-is-enabled() {
 function _bash-it-component-item-is-disabled() {
 	local component="$1"
 	local item="$2"
-	_bash-it-component-help "${component}" | ${BASH_IT_GREP:-$(_bash-it-grep)} -E -v '\[x\]' | ${BASH_IT_GREP:-$(_bash-it-grep)} -E -q -- "^${item}\s"
+	_bash-it-component-help "${component}" | _bash-it-egrep -v '\[x\]' | _bash-it-egrep -q -- "^${item}\s"
 }


### PR DESCRIPTION
## Description
Use the new `_bash-it-egrep()` function for readability and (slight) performance.

## Motivation and Context
The new `_bash-it-egrep()` function just runs `grep -E` (using the same overcomplicated logic as `_bash-it-grep()`), as compared to just returning the *path* to the `grep` binary as `_bash-it-grep()` does. 

This should improve readability anywhere that `${BASH_IT_GREP:-$(_bash-it-grep)}` is used, and should avoid two subshells per invocation.

Result: easier to read, faster.

Aside: I have no idea why we can't just use `grep`, but that's another question entirely.

## How Has This Been Tested?
This is live in my main branch.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
