### PR TITLE
preexec: work around upstream mangling of `$HISTCONTROL`

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -155,6 +155,3 @@ if ! _command_exists reload && [[ -n "${BASH_IT_RELOAD_LEGACY:-}" ]]; then
 			;;
 	esac
 fi
-
-# Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
-set +T

--- a/plugins/available/xterm.plugin.bash
+++ b/plugins/available/xterm.plugin.bash
@@ -30,7 +30,11 @@ precmd_xterm_title() {
 }
 
 preexec_xterm_title() {
-	set_xterm_title "$(_short-command "${1:-}") {$(_short-dirname)} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
+	local command_line="${BASH_COMMAND:-${1:-}}"
+	local directory_name short_command
+	directory_name="$(_short-dirname)"
+	short_command="$(_short-command "${command_line}")"
+	set_xterm_title "${short_command} {${directory_name}} (${SHORT_USER:-${USER}}@${SHORT_HOSTNAME:-${HOSTNAME}})"
 }
 
 case "${TERM:-dumb}" in

--- a/vendor/init.d/preexec.bash
+++ b/vendor/init.d/preexec.bash
@@ -1,3 +1,25 @@
 # shellcheck shell=bash
-# shellcheck disable=1090
-source "${BASH_IT}"/vendor/github.com/rcaloras/bash-preexec/bash-preexec.sh
+# shellcheck disable=SC2034
+#
+# Load the `bash-preexec.sh` library, and define helper functions
+
+## Prepare, load, fix, and install `bash-preexec.sh`
+
+# Disable immediate `$PROMPT_COMMAND` modification
+__bp_delay_install="delayed"
+
+# shellcheck source-path=SCRIPTDIR/../github.com/rcaloras/bash-preexec
+source "${BASH_IT?}/vendor/github.com/rcaloras/bash-preexec/bash-preexec.sh"
+
+# Block damanaging user's `$HISTCONTROL`
+function __bp_adjust_histcontrol() { :; }
+
+# Don't fail on readonly variables
+function __bp_require_not_readonly() { :; }
+
+# Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
+__bp_enable_subshells= # blank
+set +T
+
+# Modify `$PROMPT_COMMAND` now
+__bp_install_after_session_init


### PR DESCRIPTION
## Description
This is a work around for the refusal of `bash-preexec` upstream to fix their mangling of user's `$HISTCONTROL`. See upstream PR 119 for a complete, working patch which maintains their desired behavior, while alsö allowing the user to choose their own settings including fall-back code to emulate user intent, *and* fall-back code for close-enough when the user forces `$HISTCONTROL`, *and* compatibility with Bash 3.2–5.x.

## Motivation and Context
This workaround is intended to avoid the need to patch upstream (see #1966). We could of course just patch upstream and carry the patch ourselves, but that would introduce additional friction for updates in the future. 

Basically, this asks the `bash-preexec` lib to not run it's initializer when we load it, then we overwrite the problematic function, then we call the initializer ourselves. Result: no patch, no mangling.

## How Has This Been Tested?
Tested? Where we're going, we don't need testing. (@cornfeedhobo tested this on his system, and a version of this has been live in my main branch for months.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
