### PR TITLE
Look for branches that are literally the word main

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -199,7 +199,7 @@ function gdv() {
 }
 
 function get_default_branch() {
-	if git branch | grep -q '\smain\s'; then
+	if git branch | grep -q '^. main\s*$'; then
 		echo main
 	else
 		echo master

--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -199,7 +199,7 @@ function gdv() {
 }
 
 function get_default_branch() {
-	if git branch | grep -q '\main\b'; then
+	if git branch | grep -q '\smain\s'; then
 		echo main
 	else
 		echo master

--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -199,7 +199,7 @@ function gdv() {
 }
 
 function get_default_branch() {
-	if git branch | grep -q '^main$'; then
+	if git branch | grep -q '\main\b'; then
 		echo main
 	else
 		echo master

--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -199,7 +199,7 @@ function gdv() {
 }
 
 function get_default_branch() {
-	if git branch | grep -q main; then
+	if git branch | grep -q '^main$'; then
 		echo main
 	else
 		echo master


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
When finding the default git branch, use a regex that matches only the word `main`, instead of any branch that has the substring `main` in it.

## Motivation and Context
I have a repo with many other branches that contain the string `main`,
but our default branch is still `master`.  This grep was seeing those other branches
and deciding that my default branch was `main`.  

## How Has This Been Tested?
I tested this change on the repository I described above, and it correctly decided my default branch was `master` again.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
    - I didn't see any existing tests for the git aliases (or any aliases).  Should I add a new test file?   
