### PR TITLE
Wholesale cleanup of all history plugins

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -92,6 +92,7 @@ plugins/available/docker-machine.plugin.bash
 plugins/available/git.plugin.bash
 plugins/available/go.plugin.bash
 plugins/available/goenv.plugin.bash
+plugins/available/history-eternal.plugin.bash
 plugins/available/history-search.plugin.bash
 plugins/available/history-substring-search.plugin.bash
 plugins/available/history.plugin.bash

--- a/completion/available/git.completion.bash
+++ b/completion/available/git.completion.bash
@@ -39,4 +39,5 @@ done
 if [[ "${_git_bash_completion_found}" == false ]]; then
 	_log_warning "no completion files found - please try enabling the 'system' completion instead."
 fi
+# shellcheck disable=SC2154 # ignore unknown
 unset "${!_git_bash_completion@}"

--- a/plugins/available/autojump.plugin.bash
+++ b/plugins/available/autojump.plugin.bash
@@ -4,6 +4,7 @@ about-plugin 'Autojump configuration, see https://github.com/wting/autojump for 
 
 # Only supports the Homebrew variant, Debian and Arch at the moment.
 # Feel free to provide a PR to support other install locations
+# shellcheck disable=1090
 if _bash_it_homebrew_check && [[ -s "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/autojump.sh" ]]; then
 	source "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/autojump.sh"
 elif _command_exists dpkg && dpkg -s autojump &> /dev/null; then

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -121,8 +121,7 @@ function usage() {
 }
 
 # shellcheck disable=SC2144 # the glob matches only one file
-if [[ ! -e "${BASH_IT?}/plugins/enabled/todo.plugin.bash" &&
-	! -e "${BASH_IT?}/plugins/enabled"/*"${BASH_IT_LOAD_PRIORITY_SEPARATOR-}todo.plugin.bash" ]]; then
+if [[ ! -e "${BASH_IT?}/plugins/enabled/todo.plugin.bash" && ! -e "${BASH_IT?}/plugins/enabled"/*"${BASH_IT_LOAD_PRIORITY_SEPARATOR-}todo.plugin.bash" ]]; then
 	# if user has installed todo plugin, skip this...
 	function t() {
 		about 'one thing todo'

--- a/plugins/available/history-eternal.plugin.bash
+++ b/plugins/available/history-eternal.plugin.bash
@@ -1,0 +1,20 @@
+# shellcheck shell=bash
+about-plugin 'eternal bash history'
+
+# Load after the history plugin
+# BASH_IT_LOAD_PRIORITY: 375
+
+# Modify history sizes before changing location to avoid unintentionally
+# truncating the history file early.
+
+# "Numeric values less than zero result in every command being saved on the history list (there is no limit)"
+export HISTSIZE=-1
+
+# "Non-numeric values and numeric values less than zero inhibit truncation"
+export HISTFILESIZE='unlimited'
+
+# Use a custom history file location so history is not truncated
+# if the environment ever loses this "eternal" configuration.
+HISTDIR="${XDG_STATE_HOME:-${HOME?}/.local/state}/bash"
+[[ -d ${HISTDIR?} ]] || mkdir -p "${HISTDIR?}"
+export HISTFILE="${HISTDIR?}/history"

--- a/plugins/available/history-search.plugin.bash
+++ b/plugins/available/history-search.plugin.bash
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
-cite about-plugin
 about-plugin 'search history using the prefix already entered'
+
+# Load after the history plugin
+# BASH_IT_LOAD_PRIORITY: 375
 
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history

--- a/plugins/available/history-substring-search.plugin.bash
+++ b/plugins/available/history-substring-search.plugin.bash
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
-cite about-plugin
 about-plugin 'search history using the substring already entered'
+
+# Load after the history plugin
+# BASH_IT_LOAD_PRIORITY: 375
 
 # enter a few characters and press UpArrow/DownArrow
 # to search backwards/forwards through the history

--- a/plugins/available/history.plugin.bash
+++ b/plugins/available/history.plugin.bash
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
-cite about-plugin
 about-plugin 'improve history handling with sane defaults'
 
-# append to bash_history if Terminal.app quits
+# Append the history list to the file named by the value of the HISTFILE
+# variable when the shell exits, rather than overwriting the file.
 shopt -s histappend
 
 # erase duplicates; alternative option: export HISTCONTROL=ignoredups
@@ -11,19 +11,17 @@ export HISTCONTROL=${HISTCONTROL:-ignorespace:erasedups}
 # resize history to 100x the default (500)
 export HISTSIZE=${HISTSIZE:-50000}
 
-top-history() {
+# Flush history to disk after each command.
+export PROMPT_COMMAND="history -a;${PROMPT_COMMAND}"
+
+function top-history() {
 	about 'print the name and count of the most commonly run tools'
 
-	if [[ -n $HISTTIMEFORMAT ]]; then
-		# To parse history we need a predictable format, which HISTTIMEFORMAT
-		# gets in the way of. So we unset it and set a trap to guarantee the
-		# user's environment returns to normal even if the pipeline below fails.
-		# shellcheck disable=SC2064
-		trap "export HISTTIMEFORMAT='$HISTTIMEFORMAT'" RETURN
-		unset HISTTIMEFORMAT
-	fi
-
-	history \
+	# - Make sure formatting doesn't interfer with our parsing
+	# - Use awk to count how many times the first command on each line has been called
+	# - Truncate to 10 lines
+	# - Print in column format
+	HISTTIMEFORMAT='' history \
 		| awk '{
 				a[$2]++
 			}END{

--- a/vendor/init.d/preexec.bash
+++ b/vendor/init.d/preexec.bash
@@ -8,7 +8,7 @@
 # Disable immediate `$PROMPT_COMMAND` modification
 __bp_delay_install="delayed"
 
-# shellcheck source-path=SCRIPTDIR/../github.com/rcaloras/bash-preexec
+# shellcheck source=SCRIPTDIR/../github.com/rcaloras/bash-preexec
 source "${BASH_IT?}/vendor/github.com/rcaloras/bash-preexec/bash-preexec.sh"
 
 # Block damanaging user's `$HISTCONTROL`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- remove the use of redundant cite
- minor cleanups to history.plugin.bash
- set explicit load orders for history-search and history-substring-search
- add new plugin history-eternal

## Motivation and Context
history plugins needed some love now that we have dealt with preexec

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
