### PR TITLE
docs: Pin docutils to 0.17.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx==3.2.1
 sphinx-rtd-theme==0.5.0
 sphinxemoji==0.1.8
+docutils==0.17.1


### PR DESCRIPTION
Seems like docutils 0.18 has some problems and it is breaking our docs build (https://issues.apache.org/jira/browse/FLINK-24662)

Lets use 0.17.1 for now :)

## Description
Use docutils pinned to 0.17.1

## Motivation and Context
Avoiding bogus docs build failure

## How Has This Been Tested?
Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
