### PR TITLE
Themes: Fix doubletime_multiline scm_prompt

### DIFF
--- a/themes/doubletime_multiline/doubletime_multiline.theme.bash
+++ b/themes/doubletime_multiline/doubletime_multiline.theme.bash
@@ -8,7 +8,7 @@ function prompt_setter() {
   PS1="
 $(clock_prompt) $(scm_char) [$THEME_PROMPT_HOST_COLOR\u@${THEME_PROMPT_HOST}$reset_color] $(virtualenv_prompt)$(ruby_version_prompt)
 \w
-$(doubletime_scm_prompt)$reset_color $ "
+$(scm_prompt)$reset_color $ "
   PS2='> '
   PS4='+ '
 }

--- a/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.bash
+++ b/themes/doubletime_multiline_pyonly/doubletime_multiline_pyonly.theme.bash
@@ -8,7 +8,7 @@ function prompt_setter() {
   PS1="
 $(clock_prompt) $(scm_char) [$THEME_PROMPT_HOST_COLOR\u@${THEME_PROMPT_HOST}$reset_color] $(virtualenv_prompt)
 \w
-$(doubletime_scm_prompt)$reset_color $ "
+$(scm_prompt)$reset_color $ "
   PS2='> '
   PS4='+ '
 }


### PR DESCRIPTION
Fix errors in doubletime_multiline and doubletime_multiline_pyonly themes caused by missing `doubletime_scm_prompt` function.

## Description
Replace calls to `doubletime_scm_prompt` with `scm_prompt` within `prompt_setter`

## Motivation and Context
The `doubletime_scm_prompt` function was removed in favor of `scm_prompt` in commit dff892e0a31e3e2797d5406099cb8513b59e5eb4. This caused the doubletime_multiline and doubletime_multiline_pyonly themes to raise errors when generating prompts.

## How Has This Been Tested?
Manually tested on Ubuntu 20.04 (WSL) and on CentOS 7

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
