### PR TITLE
Bash-it completions performance improvement

### DIFF
--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -12,9 +12,14 @@ _bash-it-comp-list-available-not-enabled()
 
   local enabled_components all_things available_things
 
-  all_things=$(compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sed 's|^.*/||')
-  enabled_components=$(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2>/dev/null | sed 's|^.*/||; s/^[0-9]*---//g')
-  available_things=$(echo "$all_things" | sort -d | grep -Fxv "$enabled_components" | sed 's/\(.*\)\..*\.bash/\1/g')
+  all_things=( $(compgen -G "${BASH_IT}/$subdirectory/available/*.bash") ); all_things=( "${all_things[@]##*/}" )
+  enabled_components=( $(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2>/dev/null) )
+  enabled_components=( "${enabled_components[@]##*/}" ); enabled_components="${enabled_components[@]#*---}"
+  available_things=( $(sort -d <(for i in ${enabled_components}
+    do
+      all_things=( "${all_things[@]//$i}" )
+    done
+    printf '%s\n' "${all_things[@]}")) ); available_things="${available_things[@]%.*.bash}"
 
   COMPREPLY=( $(compgen -W "all ${available_things}" -- "${cur}") )
 }
@@ -26,7 +31,8 @@ _bash-it-comp-list-enabled()
 
   suffix="${subdirectory/plugins/plugin}"
 
-  enabled_things=$(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash") | sed 's|^.*/||; s/\(.*\)\..*\.bash/\1/g; s/^[0-9]*---//g')
+  enabled_things=( $(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")) )
+  enabled_things=( "${enabled_things[@]##*/}" ); enabled_things=( "${enabled_things[@]#*---}" ); enabled_things="${enabled_things[@]%.*.bash}"
 
   COMPREPLY=( $(compgen -W "all ${enabled_things}" -- "${cur}") )
 }
@@ -37,7 +43,8 @@ _bash-it-comp-list-available()
 
   local enabled_things
 
-  enabled_things=$(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash") | sed 's|^.*/||; s/\(.*\)\..*\.bash/\1/g')
+  enabled_things=( $(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash")) )
+  enabled_things=( "${enabled_things[@]##*/}" ); enabled_things="${enabled_things[@]%.*.bash}"
 
   COMPREPLY=( $(compgen -W "${enabled_things}" -- "${cur}") )
 }

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -10,20 +10,11 @@ _bash-it-comp-list-available-not-enabled()
 {
   subdirectory="$1"
 
-  local available_things
+  local enabled_components all_things available_things
 
-  available_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort -d`;
-    do
-      file_entity=$(basename $f)
-
-      typeset enabled_component=$(command ls "${BASH_IT}/$subdirectory/enabled/"{[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity,$file_entity} 2>/dev/null | head -1)
-      typeset enabled_component_global=$(command ls "${BASH_IT}/enabled/"[0-9]*$BASH_IT_LOAD_PRIORITY_SEPARATOR$file_entity 2>/dev/null | head -1)
-
-      if [ -z "$enabled_component" ] && [ -z "$enabled_component_global" ]
-      then
-        basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g'
-      fi
-    done)
+  all_things=$(compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sed 's|^.*/||')
+  enabled_components=$(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2>/dev/null | sed 's|^.*/||; s/^[0-9]*---//g')
+  available_things=$(echo "$all_things" | sort -d | grep -Fxv "$enabled_components" | sed 's/\(.*\)\..*\.bash/\1/g')
 
   COMPREPLY=( $(compgen -W "all ${available_things}" -- ${cur}) )
 }
@@ -107,15 +98,15 @@ _bash-it-comp()
       fi
       case "${file_type}" in
         alias)
-            _bash-it-comp-list-${suffix} aliases
+            _bash-it-comp-list-"${suffix}" aliases
             return 0
             ;;
         plugin)
-            _bash-it-comp-list-${suffix} plugins
+            _bash-it-comp-list-"${suffix}" plugins
             return 0
             ;;
         completion)
-            _bash-it-comp-list-${suffix} completion
+            _bash-it-comp-list-"${suffix}" completion
             return 0
             ;;
         *)

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -24,12 +24,9 @@ _bash-it-comp-list-enabled()
   local subdirectory="$1"
   local suffix enabled_things
 
-  suffix=$(echo "$subdirectory" | sed -e 's/plugins/plugin/g')
+  suffix="${subdirectory/plugins/plugin}"
 
-  enabled_things=$(for f in `sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")`;
-    do
-      basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g' | sed -e "s/^[0-9]*---//g"
-    done)
+  enabled_things=$(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash") | sed 's|^.*/||; s/\(.*\)\..*\.bash/\1/g; s/^[0-9]*---//g')
 
   COMPREPLY=( $(compgen -W "all ${enabled_things}" -- ${cur}) )
 }
@@ -40,10 +37,7 @@ _bash-it-comp-list-available()
 
   local enabled_things
 
-  enabled_things=$(for f in `compgen -G "${BASH_IT}/$subdirectory/available/*.bash" | sort -d`;
-    do
-      basename $f | sed -e 's/\(.*\)\..*\.bash/\1/g'
-    done)
+  enabled_things=$(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash") | sed 's|^.*/||; s/\(.*\)\..*\.bash/\1/g')
 
   COMPREPLY=( $(compgen -W "${enabled_things}" -- ${cur}) )
 }

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -14,7 +14,7 @@ _bash-it-comp-list-available-not-enabled()
 
   all_things=( $(compgen -G "${BASH_IT}/$subdirectory/available/*.bash") ); all_things=( "${all_things[@]##*/}" )
   enabled_components=( $(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2>/dev/null) )
-  enabled_components=( "${enabled_components[@]##*/}" ); enabled_components="${enabled_components[@]#*---}"
+  enabled_components=( "${enabled_components[@]##*/}" ); enabled_components="${enabled_components[@]##*---}"
   available_things=( $(sort -d <(for i in ${enabled_components}
     do
       all_things=( "${all_things[@]//$i}" )
@@ -32,7 +32,7 @@ _bash-it-comp-list-enabled()
   suffix="${subdirectory/plugins/plugin}"
 
   enabled_things=( $(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")) )
-  enabled_things=( "${enabled_things[@]##*/}" ); enabled_things=( "${enabled_things[@]#*---}" ); enabled_things="${enabled_things[@]%.*.bash}"
+  enabled_things=( "${enabled_things[@]##*/}" ); enabled_things=( "${enabled_things[@]##*---}" ); enabled_things="${enabled_things[@]%.*.bash}"
 
   COMPREPLY=( $(compgen -W "all ${enabled_things}" -- "${cur}") )
 }

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -3,7 +3,7 @@
 _bash-it-comp-enable-disable()
 {
   local enable_disable_args="alias completion plugin"
-  COMPREPLY=( $(compgen -W "${enable_disable_args}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "${enable_disable_args}" -- "${cur}") )
 }
 
 _bash-it-comp-list-available-not-enabled()
@@ -16,7 +16,7 @@ _bash-it-comp-list-available-not-enabled()
   enabled_components=$(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2>/dev/null | sed 's|^.*/||; s/^[0-9]*---//g')
   available_things=$(echo "$all_things" | sort -d | grep -Fxv "$enabled_components" | sed 's/\(.*\)\..*\.bash/\1/g')
 
-  COMPREPLY=( $(compgen -W "all ${available_things}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "all ${available_things}" -- "${cur}") )
 }
 
 _bash-it-comp-list-enabled()
@@ -28,7 +28,7 @@ _bash-it-comp-list-enabled()
 
   enabled_things=$(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash") | sed 's|^.*/||; s/\(.*\)\..*\.bash/\1/g; s/^[0-9]*---//g')
 
-  COMPREPLY=( $(compgen -W "all ${enabled_things}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "all ${enabled_things}" -- "${cur}") )
 }
 
 _bash-it-comp-list-available()
@@ -39,7 +39,7 @@ _bash-it-comp-list-available()
 
   enabled_things=$(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash") | sed 's|^.*/||; s/\(.*\)\..*\.bash/\1/g')
 
-  COMPREPLY=( $(compgen -W "${enabled_things}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "${enabled_things}" -- "${cur}") )
 }
 
 _bash-it-comp()
@@ -54,7 +54,7 @@ _bash-it-comp()
   case "${chose_opt}" in
     show)
       local show_args="aliases completions plugins"
-      COMPREPLY=( $(compgen -W "${show_args}" -- ${cur}) )
+      COMPREPLY=( $(compgen -W "${show_args}" -- "${cur}") )
       return 0
       ;;
     help)
@@ -63,22 +63,22 @@ _bash-it-comp()
         return 0
       else
         local help_args="aliases completions migrate plugins update"
-        COMPREPLY=( $(compgen -W "${help_args}" -- ${cur}) )
+        COMPREPLY=( $(compgen -W "${help_args}" -- "${cur}") )
         return 0
       fi
       ;;
     doctor)
       local doctor_args="errors warnings all"
-      COMPREPLY=( $(compgen -W "${doctor_args}" -- ${cur}) )
+      COMPREPLY=( $(compgen -W "${doctor_args}" -- "${cur}") )
       return 0
       ;;
     update)
-      if [[ ${cur} == -* ]];then
+      if [[ "${cur}" == -* ]];then
         local update_args="-s --silent"
       else
         local update_args="stable dev"
       fi
-      COMPREPLY=( $(compgen -W "${update_args}" -- ${cur}) )
+      COMPREPLY=( $(compgen -W "${update_args}" -- "${cur}") )
       return 0
       ;;
     migrate | reload | search | version)
@@ -111,7 +111,7 @@ _bash-it-comp()
       ;;
   esac
 
-  COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
 
   return 0
 }

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -8,7 +8,7 @@ _bash-it-comp-enable-disable()
 
 _bash-it-comp-list-available-not-enabled()
 {
-  subdirectory="$1"
+  local subdirectory="$1"
 
   local enabled_components all_things available_things
 
@@ -33,7 +33,7 @@ _bash-it-comp-list-enabled()
 
 _bash-it-comp-list-available()
 {
-  subdirectory="$1"
+  local subdirectory="$1"
 
   local enabled_things
 

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -88,7 +88,7 @@ _bash-it-comp()
       COMPREPLY=( $(compgen -W "${update_args}" -- "${cur}") )
       return 0
       ;;
-    migrate | reload | search | version)
+    migrate | reload | restart | search | version)
       return 0
       ;;
     enable | disable)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I went on and removed the usage of loops from the bash-it completions, and arranged the functions to essentially perform the same acts, but process the file lists after having accumulated them, instead of performing tests etc for each and every one of the files. While I'm at it, I also double quoted some variables to avoid having the interpreter spend time trying to perform splitting on them (a bit of nitpick, but why not), made a couple of variables local, since they seemed to have gotten unnoticed and replaced a usage of sed with the pattern substitution parameter of parameter expansion. I was also thinking of eliminating the usage of pipes by using process substitution, thus eliminating spawned subshells and having the rest of process substitution performance benefits, but I don't know if this would go too far and make the code a bit hard to read with all the nested parentheses and redirections.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> As mentioned in the linked issue, the performance of bash-it completions generation, end especially for the `enable` option is rather poor, which is a significant problem for me, as I relatively regularly use them. This PR massively improves this aspect, to the point where I'd say completions for `bash-it` are now very fast.
<!--- If it fixes an open issue, please link to the issue here. --> 
Closes #1988

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> Apart from using the very completions to notice the performance difference and passing the tests, I kind of benchmarked them by exporting the `__check_completion` function from the completions test, and running tests like `time __check_completion 'bash-it enable completion docker'`.
<!--- Include details of your testing environment, and the tests you ran to --> I ran tests on my phone, laptop and gcp server which use Android 12, Manjaro 21.2.0 and Ubuntu 21.10 respectively. On my phone, from and average duration of 4s, it dropped to ≈100ms when files aren't cached and ≈60ms after they are, on my dual core laptop from an average of ≈1s it dropped to ≈80ms when files aren't cached and ≈25ms when they are, and on my 8 core server from ≈700ms to ≈10ms (always). In every case, very fast I think.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
 