### PR TITLE
plugin(dirs): remove shopt -s cdable_vars

### DIFF
--- a/plugins/available/dirs.plugin.bash
+++ b/plugins/available/dirs.plugin.bash
@@ -103,5 +103,3 @@ R () {
 }
 
 alias U='source ~/.dirs' 	# Update bookmark stack
-# Set the Bash option so that no '$' is required when using the above facility
-shopt -s cdable_vars


### PR DESCRIPTION
Removes `shopt` setings from `dirs` plugin

## Description
Remove thes `shopt -s cdable_vars` setting from the `dirs` plugin.

## Motivation and Context

I decided that I no-longer wanted `cdable_vars` enabled as I have too many environment variables and they were constantly getting in the way of tab-completing `cd`.

After removing the option from the my local bash config (I had it explicitly enabled), I discovered that it was **STILL** enabled when launching a new terminal.

I tracked it down to this plugin.

As much as possible, `shopt` settings should be left to the user.

Additionally, this plugin does not require the cdable_vars be enabled.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Marking as Breaking Change since some users may have picked up the setting from this plugin and may not realize why its missing after their next update.
