### PR TITLE
"pipenv --completion" is obsoleted

### DIFF
--- a/completion/available/pipenv.completion.bash
+++ b/completion/available/pipenv.completion.bash
@@ -1,4 +1,4 @@
 # shellcheck shell=bash
 if _command_exists pipenv; then
-	eval "$(pipenv --completion)"
+	eval "$(_PIPENV_COMPLETE=bash_source pipenv)"
 fi


### PR DESCRIPTION
Reference: https://buildmedia.readthedocs.org/media/pdf/pipenv/latest/pipenv.pdf 4.2.18 Shell Completion

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
change to `_PIPENV_COMPLETE=bash_source pipenv`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fix the problem:
```
Usage: pipenv [OPTIONS] COMMAND [ARGS]...
Try 'pipenv -h' for help.

Error: No such option: --completion Did you mean --python?
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes. It fixes the problem.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.

---

Fixes #1993