### PR TITLE
Fix checking whether fzf is already in PATH

### DIFF
--- a/plugins/available/fzf.plugin.bash
+++ b/plugins/available/fzf.plugin.bash
@@ -4,13 +4,14 @@
 cite about-plugin
 about-plugin 'load fzf, if you are using it'
 
-_command_exists fzf || return
-
 if [ -r ~/.fzf.bash ] ; then
   source ~/.fzf.bash
 elif [ -r "${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf.bash ] ; then
   source "${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf.bash
 fi
+
+# No need to continue if the command is not present
+_command_exists fzf || return
 
 if [ -z ${FZF_DEFAULT_COMMAND+x}  ] && _command_exists fd ; then
   export FZF_DEFAULT_COMMAND='fd --type f'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The check in fzf plugin for whether it's sourced already was inverted. Let's correct it. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
