### PR TITLE
lib/utilities: refactor `_bash-it-pluralize-component()` & other improvements

### DIFF
--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -47,9 +47,10 @@ function _bash-it-get-component-type-from-path() {
 #
 #
 function _bash-it-array-contains-element() {
-	local e
-	for e in "${@:2}"; do
-		[[ "$e" == "$1" ]] && return 0
+	local e element="${1?}"
+	shift
+	for e in "$@"; do
+		[[ "$e" == "${element}" ]] && return 0
 	done
 	return 1
 }
@@ -82,7 +83,7 @@ function _bash-it-component-help() {
 	file="$(_bash-it-component-cache-file "${component}")"
 	if [[ ! -s "${file}" || -z "$(find "${file}" -mmin -300)" ]]; then
 		func="_bash-it-${component}"
-		"${func}" | _bash-it-egrep '   \[' >| "${file}"
+		"${func}" | _bash-it-egrep '\[[x ]\]' >| "${file}"
 	fi
 	cat "${file}"
 }

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -81,7 +81,8 @@ function _bash-it-component-help() {
 	local component file func
 	_bash-it-component-pluralize "${1}"
 	component="${_bash_it_component_pluralized_name?}"
-	file="$(_bash-it-component-cache-file "${component}")"
+	_bash-it-component-cache-file "${component}"
+	file="${_bash_it_component_cache_filename?}"
 	if [[ ! -s "${file}" || -z "$(find "${file}" -mmin -300)" ]]; then
 		func="_bash-it-${component}"
 		"${func}" | _bash-it-egrep '\[[x ]\]' >| "${file}"
@@ -95,7 +96,7 @@ function _bash-it-component-cache-file() {
 	component="${_bash_it_component_pluralized_name?}"
 	file="${XDG_CACHE_HOME:-${BASH_IT?}/tmp/cache}${XDG_CACHE_HOME:+/bash_it}/${component}"
 	[[ -f "${file}" ]] || mkdir -p "${file%/*}"
-	printf '%s' "${file}"
+	printf -v _bash_it_component_cache_filename '%s' "${file}"
 }
 
 function _bash-it-component-singularize() {
@@ -132,7 +133,8 @@ function _bash-it-clean-component-cache() {
 			_bash-it-clean-component-cache "${component}"
 		done
 	else
-		cache="$(_bash-it-component-cache-file "${component}")"
+		_bash-it-component-cache-file "${component}"
+		cache="${_bash_it_component_cache_filename?}"
 		if [[ -f "${cache}" ]]; then
 			rm -f "${cache}"
 		fi

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -79,49 +79,46 @@ function _bash-it-egrep() {
 
 function _bash-it-component-help() {
 	local component file func
-	_bash-it-component-pluralize "${1}"
-	component="${_bash_it_component_pluralized_name?}"
-	_bash-it-component-cache-file "${component}"
-	file="${_bash_it_component_cache_filename?}"
-	if [[ ! -s "${file}" || -z "$(find "${file}" -mmin -300)" ]]; then
-		func="_bash-it-${component}"
+	_bash-it-component-pluralize "${1}" component
+	_bash-it-component-cache-file "${component}" file
+	if [[ ! -s "${file?}" || -z "$(find "${file}" -mmin -300)" ]]; then
+		func="_bash-it-${component?}"
 		"${func}" | _bash-it-egrep '\[[x ]\]' >| "${file}"
 	fi
 	cat "${file}"
 }
 
 function _bash-it-component-cache-file() {
-	local component file
-	_bash-it-component-pluralize "${1?${FUNCNAME[0]}: component name required}"
-	component="${_bash_it_component_pluralized_name?}"
-	file="${XDG_CACHE_HOME:-${BASH_IT?}/tmp/cache}${XDG_CACHE_HOME:+/bash_it}/${component}"
-	[[ -f "${file}" ]] || mkdir -p "${file%/*}"
-	printf -v _bash_it_component_cache_filename '%s' "${file}"
+	local _component_to_cache _file_path _result="${2:-${FUNCNAME[0]//-/_}}"
+	_bash-it-component-pluralize "${1?${FUNCNAME[0]}: component name required}" _component_to_cache
+	_file_path="${XDG_CACHE_HOME:-${BASH_IT?}/tmp/cache}${XDG_CACHE_HOME:+/bash_it}/${_component_to_cache?}"
+	[[ -f "${_file_path}" ]] || mkdir -p "${_file_path%/*}"
+	printf -v "${_result?}" '%s' "${_file_path}"
 }
 
 function _bash-it-component-singularize() {
-	[[ -n "${2:-}" ]] && local -n _bash_it_component_singularized_name="${2?}"
-	local component="${1?${FUNCNAME[0]}: component name required}"
-	local -i len="$((${#component} - 2))"
-	if [[ "${component:${len}:2}" == 'ns' ]]; then
-		component="${component%s}"
-	elif [[ "${component}" == "aliases" ]]; then
-		component="${component%es}"
+	local _result="${2:-${FUNCNAME[0]//-/_}}"
+	local _component_to_single="${1?${FUNCNAME[0]}: component name required}"
+	local -i len="$((${#_component_to_single} - 2))"
+	if [[ "${_component_to_single:${len}:2}" == 'ns' ]]; then
+		_component_to_single="${_component_to_single%s}"
+	elif [[ "${_component_to_single}" == "aliases" ]]; then
+		_component_to_single="${_component_to_single%es}"
 	fi
-	printf -v _bash_it_component_singularized_name '%s' "${component}"
+	printf -v "${_result?}" '%s' "${_component_to_single}"
 }
 
 function _bash-it-component-pluralize() {
-	[[ -n "${2:-}" ]] && local -n _bash_it_component_pluralized_name="${2?}"
-	local component="${1?${FUNCNAME[0]}: component name required}"
-	local -i len="$((${#component} - 1))"
+	local _result="${2:-${FUNCNAME[0]//-/_}}"
+	local _component_to_plural="${1?${FUNCNAME[0]}: component name required}"
+	local -i len="$((${#_component_to_plural} - 1))"
 	# pluralize component name for consistency
-	if [[ "${component:${len}:1}" != 's' ]]; then
-		component="${component}s"
-	elif [[ "${component}" == "alias" ]]; then
-		component="${component}es"
+	if [[ "${_component_to_plural:${len}:1}" != 's' ]]; then
+		_component_to_plural="${_component_to_plural}s"
+	elif [[ "${_component_to_plural}" == "alias" ]]; then
+		_component_to_plural="${_component_to_plural}es"
 	fi
-	printf -v _bash_it_component_pluralized_name '%s' "${component}"
+	printf -v "${_result?}" '%s' "${_component_to_plural}"
 }
 
 function _bash-it-clean-component-cache() {
@@ -133,8 +130,7 @@ function _bash-it-clean-component-cache() {
 			_bash-it-clean-component-cache "${component}"
 		done
 	else
-		_bash-it-component-cache-file "${component}"
-		cache="${_bash_it_component_cache_filename?}"
+		_bash-it-component-cache-file "${component}" cache
 		if [[ -f "${cache}" ]]; then
 			rm -f "${cache}"
 		fi

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -144,7 +144,6 @@ function _bash-it-component-list-disabled() {
 }
 
 # Checks if a given item is enabled for a particular component/file-type.
-# Uses the component cache if available.
 #
 # Returns:
 #    0 if an item of the component is enabled, 1 otherwise.
@@ -152,13 +151,17 @@ function _bash-it-component-list-disabled() {
 # Examples:
 #    _bash-it-component-item-is-enabled alias git && echo "git alias is enabled"
 function _bash-it-component-item-is-enabled() {
-	local component="$1"
-	local item="$2"
-	_bash-it-component-help "${component}" | _bash-it-egrep '\[x\]' | _bash-it-egrep -q -- "^${item}\s"
+	local component="$1" item="$2"
+	local each_file
+
+	for each_file in "${BASH_IT}/enabled"/*"${BASH_IT_LOAD_PRIORITY_SEPARATOR?}${item}.${component}"*."bash" \
+		"${BASH_IT}/${component}"*/"enabled/${item}.${component}"*."bash" \
+		"${BASH_IT}/${component}"*/"enabled"/*"${BASH_IT_LOAD_PRIORITY_SEPARATOR?}${item}.${component}"*."bash"; do
+		[[ -f "${each_file}" ]] && return
+	done
 }
 
 # Checks if a given item is disabled for a particular component/file-type.
-# Uses the component cache if available.
 #
 # Returns:
 #    0 if an item of the component is enabled, 1 otherwise.
@@ -166,7 +169,5 @@ function _bash-it-component-item-is-enabled() {
 # Examples:
 #    _bash-it-component-item-is-disabled alias git && echo "git aliases are disabled"
 function _bash-it-component-item-is-disabled() {
-	local component="$1"
-	local item="$2"
-	_bash-it-component-help "${component}" | _bash-it-egrep -v '\[x\]' | _bash-it-egrep -q -- "^${item}\s"
+	! _bash-it-component-item-is-enabled "$@"
 }


### PR DESCRIPTION
Please review commit notes as appropriate.

## Description
- Refactor function `_bash-it-pluralize-component()`;
- Remove dependencies from `_bash-it-component-item-is-enabled()` (so it's much faster);
- Fix `_bash-it-component-help()` for long component names;
- Clean up tests a little.

## Motivation and Context
Refactoring `_bash-it-pluralize-component()` started by accident while fiddling with `bash-it search` and resulted in:
- renaming the function so it better matches it's siblings,
- adding a matching `_bash-it-component-singularize()` which can be used when logging and other places,
- using `printf`'s `-v` flag to store to a variable, rather than echoing to `stdout` to reduce subshells,
- updating `_bash-it-component-cache-file()` and `_bash-it-component-help()` to use the variable,
- updating `_bash-it-component-cache-file()` to use `printf -v` too.

Alsö, misc fixes to `lib/utilities` that came along with the branch and deobfuscation of `tests/utilities`.

## How Has This Been Tested?
These fixes have long been part of my main branch and my `shellcheck` branch(es), and all automated tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
