### PR TITLE
Revert most of "Fix linting errors that snuck in."

### DIFF
--- a/completion/available/git.completion.bash
+++ b/completion/available/git.completion.bash
@@ -39,5 +39,4 @@ done
 if [[ "${_git_bash_completion_found}" == false ]]; then
 	_log_warning "no completion files found - please try enabling the 'system' completion instead."
 fi
-# shellcheck disable=SC2154 # ignore unknown
 unset "${!_git_bash_completion@}"

--- a/plugins/available/autojump.plugin.bash
+++ b/plugins/available/autojump.plugin.bash
@@ -4,13 +4,11 @@ about-plugin 'Autojump configuration, see https://github.com/wting/autojump for 
 
 # Only supports the Homebrew variant, Debian and Arch at the moment.
 # Feel free to provide a PR to support other install locations
-# shellcheck disable=1090
+# shellcheck disable=SC1090
 if _bash_it_homebrew_check && [[ -s "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/autojump.sh" ]]; then
 	source "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/autojump.sh"
 elif _command_exists dpkg && dpkg -s autojump &> /dev/null; then
-	# shellcheck disable=SC1090
 	source "$(dpkg-query -S autojump.sh | cut -d' ' -f2)"
 elif _command_exists pacman && pacman -Q autojump &> /dev/null; then
-	# shellcheck disable=SC1090
 	source "$(pacman -Ql autojump | grep autojump.sh | cut -d' ' -f2)"
 fi

--- a/vendor/init.d/preexec.bash
+++ b/vendor/init.d/preexec.bash
@@ -8,7 +8,7 @@
 # Disable immediate `$PROMPT_COMMAND` modification
 __bp_delay_install="delayed"
 
-# shellcheck source=SCRIPTDIR/../github.com/rcaloras/bash-preexec
+# shellcheck source-path=SCRIPTDIR/../github.com/rcaloras/bash-preexec
 source "${BASH_IT?}/vendor/github.com/rcaloras/bash-preexec/bash-preexec.sh"
 
 # Block damanaging user's `$HISTCONTROL`


### PR DESCRIPTION
## Description
This reverts most of commit 2c8ee405662d03193510f57ab44391d20628999c.

## Motivation and Context
- _Shellcheck_ documentation for the [`source-path`]( https://github.com/koalaman/shellcheck/wiki/Directive#source-path ) directive indicates this is correct usage. We're `source`ing the `bash-preexec.sh` file from inside the `vendor/github.com/rcaloras/bash-preexec` directory. If we used the [`source`]( https://github.com/koalaman/shellcheck/wiki/Directive#source ) directive, then the full complete path to the file itself would need to be specified.
- Fix `disable=1090` to `disable=SC1090` and remove duplicate lines since this `shellcheck` directive will apply to the entire if-ladder.
- Disabling `SC2154` is almost never appropriate. In this case, several `_git_bash_completion*` variables are expressly assigned in this file, so there is no "unknown" to ignore.

Aside: the `${!_git_bash_completion@}` construct will expand to all variables starting with the prefix `_git_bash_completion`, so this line is just a shorthand way to clear all our variables concisely without forgetting any.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
