### PR TITLE
Create lib finalize hook

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -15,8 +15,11 @@ fi
 # shellcheck disable=SC1090
 source "${BASH_IT}"/vendor/github.com/erichs/composure/composure.sh
 
-# We need to load logging module first as well in order to be able to log
-# shellcheck source=./lib/log.bash
+# Declare our end-of-main finishing hook
+declare -a _bash_it_library_finalize_hook
+
+# We need to load logging module early in order to be able to log
+# shellcheck source-path=SCRIPTDIR/lib
 source "${BASH_IT}/lib/log.bash"
 
 # We can only log it now
@@ -148,3 +151,8 @@ if ! _command_exists reload && [[ -n "${BASH_IT_RELOAD_LEGACY:-}" ]]; then
 			;;
 	esac
 fi
+
+for _bash_it_library_finalize_f in "${_bash_it_library_finalize_hook[@]:-}"; do
+	eval "${_bash_it_library_finalize_f?}" # Use `eval` to achieve the same behavior as `$PROMPT_COMMAND`.
+done
+unset "${!_bash_it_library_finalize_@}"

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -147,6 +147,11 @@ Plugin Disable Callbacks
 Plugins can define a function that will be called when the plugin is being disabled.
 The callback name should be ``{PLUGIN_NAME}_on_disable``\ , you can see ``gitstatus`` for usage example.
 
+Library Finalization Callback
+-----------------------------
+
+Specifically for Bash-it library code, e.g. in the `lib` subdirectory, a hook is available to run some code at the very end of the main loader script after all other code has been loaded. For example, `lib/theme` uses `_bash_it_library_finalize_hook+=('_bash_it_appearance_scm_init')` to add a function to be called after all plugins have been loaded.
+
 Using the pre-commit hook
 -------------------------
 

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -106,7 +106,7 @@ function _bash_it_appearance_scm_init() {
 		fi
 	fi
 }
-_bash_it_appearance_scm_init
+_bash_it_library_finalize_hook+=('_bash_it_appearance_scm_init')
 
 function scm {
 	if [[ "$SCM_CHECK" = false ]]; then


### PR DESCRIPTION
## Description
Create an array `_bash_it_library_finalize_hook` and loop at the end of the main `bash_it.sh` to run each element in the array.

## Motivation and Context
The purpose here is to run some command after everything else has been loaded. For example, `lib/theme` checks for executables for SCM commands, but `$PATH` may be altered after `lib/theme` has loaded and therefore some available commands may never be discovered. To accommodate this problem, create `_bash_it_appearance_scm_init()` and add it to the hook. It will re-check at end of `bash_it.sh` just before prompt is first displayed.

## How Has This Been Tested?
This has been part of my main branch for months and all tests pass.

## Types of changes
- [x] Enhancement (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
