### PR TITLE
Plugin/todo: cleanup and simplify

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -109,6 +109,7 @@ plugins/available/pyenv.plugin.bash
 plugins/available/rbenv.plugin.bash
 plugins/available/ruby.plugin.bash
 plugins/available/textmate.plugin.bash
+plugins/available/todo.plugin.bash
 plugins/available/xterm.plugin.bash
 plugins/available/zoxide.plugin.bash
 

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -67,7 +67,7 @@ function passgen() {
 
 # Create alias pass to passgen when pass isn't installed or
 # BASH_IT_LEGACY_PASS is true.
-if ! _command_exists pass || [[ "${BASH_IT_LEGACY_PASS:-}" = true ]]; then
+if ! _command_exists pass || [[ "${BASH_IT_LEGACY_PASS:-}" == true ]]; then
 	alias pass=passgen
 fi
 
@@ -120,19 +120,26 @@ function usage() {
 	esac
 }
 
-if ! _bash-it-component-item-is-enabled plugin todo; then
-	# if user has installed todo plugin, skip this...
-	function t() {
-		about 'one thing todo'
-		param 'if not set, display todo item'
-		param '1: todo text'
-		if [[ "$*" == "" ]]; then
-			cat ~/.t
-		else
-			echo "$*" > ~/.t
-		fi
-	}
-fi
+function t() {
+	about 'todo.sh if available, otherwise one thing todo'
+	param 'if not set, display todo item'
+	param '1: todo text'
+
+	local todotxt="${XDG_STATE_HOME:-~/.local/state}/bash_it/todo.txt"
+
+	if _bash-it-component-item-is-enabled plugin todo; then
+		todo.sh "$@"
+		return
+	elif [[ ! -f "${todotxt}" && -f ~/.t ]]; then
+		mv -vn ~/.t "${todotxt}" # Verbose, so the user knows. Don't overwrite, just in case.
+	fi
+
+	if [[ "$#" -eq 0 ]]; then
+		cat "${todotxt}"
+	else
+		echo "$@" >| "${todotxt}"
+	fi
+}
 
 if _command_exists mkisofs; then
 	function mkiso() {

--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -120,8 +120,7 @@ function usage() {
 	esac
 }
 
-# shellcheck disable=SC2144 # the glob matches only one file
-if [[ ! -e "${BASH_IT?}/plugins/enabled/todo.plugin.bash" && ! -e "${BASH_IT?}/plugins/enabled"/*"${BASH_IT_LOAD_PRIORITY_SEPARATOR-}todo.plugin.bash" ]]; then
+if ! _bash-it-component-item-is-enabled plugin todo; then
 	# if user has installed todo plugin, skip this...
 	function t() {
 		about 'one thing todo'

--- a/plugins/available/todo.plugin.bash
+++ b/plugins/available/todo.plugin.bash
@@ -4,5 +4,3 @@ about-plugin 'Todo.txt integration'
 # you may override any of the exported variables below in your .bash_profile
 : "${TODOTXT_DEFAULT_ACTION:=ls}"
 export TODOTXT_DEFAULT_ACTION
-
-alias t='todo.sh'

--- a/plugins/available/todo.plugin.bash
+++ b/plugins/available/todo.plugin.bash
@@ -1,12 +1,8 @@
-#!/bin/bash
-cite about-plugin
+# shellcheck shell=bash
 about-plugin 'Todo.txt integration'
 
 # you may override any of the exported variables below in your .bash_profile
-
-if [ -z "$TODOTXT_DEFAULT_ACTION" ]; then
-  # typing 't' by itself will list current todos
-  export TODOTXT_DEFAULT_ACTION=ls
-fi
+: "${TODOTXT_DEFAULT_ACTION:=ls}"
+export TODOTXT_DEFAULT_ACTION
 
 alias t='todo.sh'


### PR DESCRIPTION
## Description
Clean up `plugin/todo`, add to `clean_files.txt`, and use `_bash-it-component-item-is-enabled()` in `plugin/base`.

## Motivation and Context
Mostly just cleaning up, but alsö getting rid of that abomination in `plugin/base`.

## How Has This Been Tested?
Tests pass locally and in CI.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
