### PR TITLE
Plugin/LaTeX: 2009 was thirteen years ago

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -102,6 +102,7 @@ plugins/available/hub.plugin.bash
 plugins/available/java.plugin.bash
 plugins/available/jekyll.plugin.bash
 plugins/available/jump.plugin.bash
+plugins/available/latex.plugin.bash
 plugins/available/less-pretty-cat.plugin.bash
 plugins/available/man.plugin.bash
 plugins/available/node.plugin.bash

--- a/plugins/available/latex.plugin.bash
+++ b/plugins/available/latex.plugin.bash
@@ -1,9 +1,19 @@
-cite about-plugin
-about-plugin 'use mactex'
+# shellcheck shell=bash
+about-plugin 'add MacTeX to PATH'
+
+_bash_it_plugin_latex_paths=(
+	# Standard locations
+	/usr/local/texbin
+	# MacOS locations
+	/Library/TeX/texbin
+)
 
 # add mactex to the path if its present
-MACTEX_PATH=/usr/local/texlive/2009/bin/universal-darwin
-if [[ -d  $MACTEX_PATH ]]; then
-  pathmunge $MACTEX_PATH after
-fi
-unset MACTEX_PATH
+for _bash_it_plugin_latex_path in "${_bash_it_plugin_latex_paths[@]}"; do
+	if [[ -d "$_bash_it_plugin_latex_path/" ]]; then
+		pathmunge "$_bash_it_plugin_latex_path" after && break
+	fi
+done
+
+# Cleanup
+unset "${!_bash_it_plugin_latex_@}"


### PR DESCRIPTION
## Description
This plugin was hard-coded for the 2009 edition of MacTeX. I am 99.999999% sure literally zero people use this plugin, since it hasn't done anything in over a decade.

## Motivation and Context
Now, it will attempt to locate the currently installed edition of MacTeX and add it to the path.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
