### PR TITLE
Plugin/man: Add `R` to `$LESS`

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -101,6 +101,7 @@ plugins/available/java.plugin.bash
 plugins/available/jekyll.plugin.bash
 plugins/available/jump.plugin.bash
 plugins/available/less-pretty-cat.plugin.bash
+plugins/available/man.plugin.bash
 plugins/available/node.plugin.bash
 plugins/available/nodenv.plugin.bash
 plugins/available/percol.plugin.bash

--- a/plugins/available/man.plugin.bash
+++ b/plugins/available/man.plugin.bash
@@ -1,12 +1,14 @@
 # shellcheck shell=bash
 about-plugin 'colorize man pages for better readability'
 
-export LESS_TERMCAP_mb=$'\e[1;32m'
-export LESS_TERMCAP_md=$'\e[1;32m'
-export LESS_TERMCAP_me=$'\e[0m'
-export LESS_TERMCAP_se=$'\e[0m'
-export LESS_TERMCAP_so=$'\e[01;33m'
-export LESS_TERMCAP_ue=$'\e[0m'
-export LESS_TERMCAP_us=$'\e[1;4;31m'
+: "${LESS_TERMCAP_mb:=$'\e[1;32m'}"
+: "${LESS_TERMCAP_md:=$'\e[1;32m'}"
+: "${LESS_TERMCAP_me:=$'\e[0m'}"
+: "${LESS_TERMCAP_se:=$'\e[0m'}"
+: "${LESS_TERMCAP_so:=$'\e[01;33m'}"
+: "${LESS_TERMCAP_ue:=$'\e[0m'}"
+: "${LESS_TERMCAP_us:=$'\e[1;4;31m'}"
 
+: "${LESS:=}"
+export "${!LESS_TERMCAP@}"
 export LESS="R${LESS#-}"

--- a/plugins/available/man.plugin.bash
+++ b/plugins/available/man.plugin.bash
@@ -1,4 +1,4 @@
-cite about-plugin
+# shellcheck shell=bash
 about-plugin 'colorize man pages for better readability'
 
 export LESS_TERMCAP_mb=$'\e[1;32m'
@@ -8,3 +8,5 @@ export LESS_TERMCAP_se=$'\e[0m'
 export LESS_TERMCAP_so=$'\e[01;33m'
 export LESS_TERMCAP_ue=$'\e[0m'
 export LESS_TERMCAP_us=$'\e[1;4;31m'
+
+export LESS="R${LESS#-}"


### PR DESCRIPTION
## Description
Add `R` to `$LESS`, which is interpreted as flags on the command line. Alsö, don't clobber user-set variables.

## Motivation and Context
Otherwise, `-R` must be added on the command line or colors just won't be rendered and these variables will be ignored. Usually, `less` gets aliased or wrapped in a function, but if it's not then we'd like to use our settings. This alsö reduces the need to alias or wrap `less` and is much less likely to break.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
