### PR TITLE
completion/system: load earlier than others

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -72,6 +72,7 @@ completion/available/pipenv.completion.bash
 completion/available/pipx.completion.bash
 completion/available/rustup.completion.bash
 completion/available/sdkman.completion.bash
+completion/available/system.completion.bash
 completion/available/vault.completion.bash
 completion/available/vuejs.completion.bash
 completion/available/wpscan.completion.bash

--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -6,57 +6,55 @@
 # Load before other completions
 # BASH_IT_LOAD_PRIORITY: 325
 
-if shopt -qo nounset
-then # Bash-completion is too large and complex to expect to handle unbound variables throughout the whole codebase.
+# Bash-completion is too large and complex to expect to handle unbound variables throughout the whole codebase.
+if shopt -qo nounset; then
 	__bash_it_restore_nounset=true
 	shopt -uo nounset
 else
 	__bash_it_restore_nounset=false
 fi
 
-if [[ -r "${BASH_COMPLETION:-}" ]] ; then
-  # shellcheck disable=SC1091
+if [[ -r "${BASH_COMPLETION:-}" ]]; then
+	# shellcheck disable=SC1090
 	source "${BASH_COMPLETION}"
 
-elif [[ -r /etc/bash_completion ]] ; then
-  # shellcheck disable=SC1091
-  source /etc/bash_completion
+elif [[ -r /etc/bash_completion ]]; then
+	# shellcheck disable=SC1091
+	source /etc/bash_completion
 
 # Some distribution makes use of a profile.d script to import completion.
-elif [[ -r /etc/profile.d/bash_completion.sh ]] ; then
-  # shellcheck disable=SC1091
-  source /etc/profile.d/bash_completion.sh
+elif [[ -r /etc/profile.d/bash_completion.sh ]]; then
+	# shellcheck disable=SC1091
+	source /etc/profile.d/bash_completion.sh
 
-elif _bash_it_homebrew_check
-then
-  : ${BASH_COMPLETION_COMPAT_DIR:=$BASH_IT_HOMEBREW_PREFIX/etc/bash_completion.d}
+elif _bash_it_homebrew_check; then
+	: "${BASH_COMPLETION_COMPAT_DIR:=$BASH_IT_HOMEBREW_PREFIX/etc/bash_completion.d}"
 
-  case "${BASH_VERSION}" in
-  1*|2*|3.0*|3.1*)
-    _log_warning "Cannot load completion due to version of shell. Are you using Bash 3.2+?"
-    ;;
-  3.2*|4.0*|4.1*)
-    # Import version 1.x of bash-completion, if installed.
-    BASH_COMPLETION="$BASH_IT_HOMEBREW_PREFIX/opt/bash-completion@1/etc/bash_completion"
-    if [[ -r "$BASH_COMPLETION" ]] ; then
-      # shellcheck disable=SC1090
-      source "$BASH_COMPLETION"
-    else
-      unset BASH_COMPLETION
-    fi
-    ;;
-  4.2*|5*|*)
-    # homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
-    if [[ -r "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh ]] ; then
-      # shellcheck disable=SC1090
-      source "$BASH_IT_HOMEBREW_PREFIX"/etc/profile.d/bash_completion.sh
-    fi
-    ;;
-  esac
+	case "${BASH_VERSION}" in
+		1* | 2* | 3.0* | 3.1*)
+			_log_warning "Cannot load completion due to version of shell. Are you using Bash 3.2+?"
+			;;
+		3.2* | 4.0* | 4.1*)
+			# Import version 1.x of bash-completion, if installed.
+			BASH_COMPLETION="$BASH_IT_HOMEBREW_PREFIX/opt/bash-completion@1/etc/bash_completion"
+			if [[ -r "$BASH_COMPLETION" ]]; then
+				# shellcheck disable=SC1090
+				source "$BASH_COMPLETION"
+			else
+				unset BASH_COMPLETION
+			fi
+			;;
+		4.2* | 5* | *)
+			# homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
+			if [[ -r "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
+				# shellcheck disable=SC1091
+				source "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+			fi
+			;;
+	esac
 fi
 
-if $__bash_it_restore_nounset
-then
+if [[ ${__bash_it_restore_nounset:-false} == "true" ]]; then
 	shopt -so nounset
 fi
 unset __bash_it_restore_nounset

--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -1,7 +1,10 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 #
 # Loads the system's Bash completion modules.
 # If Homebrew is installed (OS X), it's Bash completion modules are loaded.
+
+# Load before other completions
+# BASH_IT_LOAD_PRIORITY: 325
 
 if shopt -qo nounset
 then # Bash-completion is too large and complex to expect to handle unbound variables throughout the whole codebase.

--- a/test/install/install.bats
+++ b/test/install/install.bats
@@ -32,7 +32,7 @@ function local_setup {
   assert_link_exist "$BASH_IT/enabled/250---base.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/365---alias-completion.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/350---bash-it.completion.bash"
-  assert_link_exist "$BASH_IT/enabled/350---system.completion.bash"
+  assert_link_exist "$BASH_IT/enabled/325---system.completion.bash"
 }
 
 @test "install: verify that a backup file is created" {

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -303,7 +303,7 @@ function local_setup {
   assert_link_exist "$BASH_IT/enabled/250---base.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/365---alias-completion.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/350---bash-it.completion.bash"
-  assert_link_exist "$BASH_IT/enabled/350---system.completion.bash"
+  assert_link_exist "$BASH_IT/enabled/325---system.completion.bash"
 }
 
 @test "helper: profile save command sanity" {
@@ -363,7 +363,7 @@ function local_setup {
   assert_link_not_exist "$BASH_IT/enabled/250---base.plugin.bash"
   assert_link_not_exist "$BASH_IT/enabled/365---alias-completion.plugin.bash"
   assert_link_not_exist "$BASH_IT/enabled/350---bash-it.completion.bash"
-  assert_link_not_exist "$BASH_IT/enabled/350---system.completion.bash"
+  assert_link_not_exist "$BASH_IT/enabled/325---system.completion.bash"
 }
 
 @test "helper: profile save and load" {


### PR DESCRIPTION
## Description
Set BASH_IT_LOAD_PRIORITY to 325 so that the distro-provided _bash-completions_ package is loaded before any other completions packaged here.

## Motivation and Context
Several of the completions bundled in _Bash It_ test whether another completion is already installed, however `system` sorts lexicographically fairly late in the alphabet so it is unlikely that our tests are succeeding. I chose `325` so that it's still possible to deliberately place something *before* this component, if needed somehow.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
