### PR TITLE
plugin/git-subrepo: use `$HOME` instead of `~`

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -89,6 +89,7 @@ plugins/available/blesh.plugin.bash
 plugins/available/cmd-returned-notify.plugin.bash
 plugins/available/direnv.plugin.bash
 plugins/available/docker-machine.plugin.bash
+plugins/available/git-subrepo.plugin.bash
 plugins/available/git.plugin.bash
 plugins/available/go.plugin.bash
 plugins/available/goenv.plugin.bash

--- a/plugins/available/git-subrepo.plugin.bash
+++ b/plugins/available/git-subrepo.plugin.bash
@@ -3,4 +3,4 @@
 cite about-plugin
 about-plugin 'load git-subrepo if you are using it, and initialize completions'
 
-[[ -e "${GIT_SUBREPO_ROOT:=~/.git-subrepo}/init" ]] && source "$GIT_SUBREPO_ROOT/init"
+[[ -e "${GIT_SUBREPO_ROOT:=$HOME/.git-subrepo}/init" ]] && source "$GIT_SUBREPO_ROOT/init"

--- a/plugins/available/git-subrepo.plugin.bash
+++ b/plugins/available/git-subrepo.plugin.bash
@@ -1,6 +1,7 @@
-# Load git-subrepo if you are using it, and initialize completions
-
-cite about-plugin
+# shellcheck shell=bash
 about-plugin 'load git-subrepo if you are using it, and initialize completions'
 
-[[ -e "${GIT_SUBREPO_ROOT:=$HOME/.git-subrepo}/init" ]] && source "$GIT_SUBREPO_ROOT/init"
+if [[ -s "${GIT_SUBREPO_ROOT:=$HOME/.git-subrepo}/init" ]]; then
+	# shellcheck disable=SC1091
+	source "$GIT_SUBREPO_ROOT/init"
+fi


### PR DESCRIPTION
## Description
If the outer variable is double-quoted, then the default expansion when undefined does not get tilde-expanded; use `$HOME`. Alsö, fix `SC1091`

## Motivation and Context
Just cleaning up.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
