### PR TITLE
plugin/python: OS detection & `shfmt`

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -106,6 +106,7 @@ plugins/available/nodenv.plugin.bash
 plugins/available/percol.plugin.bash
 plugins/available/plenv.plugin.bash
 plugins/available/pyenv.plugin.bash
+plugins/available/python.plugin.bash
 plugins/available/rbenv.plugin.bash
 plugins/available/ruby.plugin.bash
 plugins/available/textmate.plugin.bash

--- a/plugins/available/python.plugin.bash
+++ b/plugins/available/python.plugin.bash
@@ -1,11 +1,12 @@
 # shellcheck shell=bash
 about-plugin 'alias "shttp" to SimpleHTTPServer'
 
-if _command_exists python2; then
-	alias shttp='python2 -m SimpleHTTPServer'
+if _command_exists python3; then
+	alias shttp='python3 -m http.server'
 elif _command_exists python; then
-	alias shttp='python -m SimpleHTTPServer'
+	alias shttp='python -m http.server'
 else
+	_log_warning "Unable to load 'plugin/python' due to being unable to find a working 'python'"
 	return 1
 fi
 

--- a/plugins/available/python.plugin.bash
+++ b/plugins/available/python.plugin.bash
@@ -1,32 +1,31 @@
-cite about-plugin
+# shellcheck shell=bash
 about-plugin 'alias "shttp" to SimpleHTTPServer'
 
 if _command_exists python2; then
 	alias shttp='python2 -m SimpleHTTPServer'
-elif _command_exists python
+elif _command_exists python; then
 	alias shttp='python -m SimpleHTTPServer'
 else
 	return 1
 fi
 
 function pyedit() {
-    about 'opens python module in your EDITOR'
-    param '1: python module to open'
-    example '$ pyedit requests'
-    group 'python'
+	about 'opens python module in your EDITOR'
+	param '1: python module to open'
+	example '$ pyedit requests'
+	group 'python'
 
-    xpyc="$(python -c "import os, sys; f = open(os.devnull, 'w'); sys.stderr = f; module = __import__('$1'); sys.stdout.write(module.__file__)")"
+	xpyc="$(python -c "import os, sys; f = open(os.devnull, 'w'); sys.stderr = f; module = __import__('$1'); sys.stdout.write(module.__file__)")"
 
-    if [[ "$xpyc" == "" ]]; then
-        echo "Python module $1 not found"
-        return -1
-
-    elif [[ "$xpyc" == *__init__.py* ]]; then
-        xpydir="${xpyc%/*}";
-        echo "$EDITOR $xpydir";
-        ${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}} "$xpydir";
-    else
-        echo "$EDITOR ${xpyc%.*}.py";
-        ${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}} "${xpyc%.*}.py";
-    fi
+	if [[ "$xpyc" == "" ]]; then
+		echo "Python module $1 not found"
+		return 1
+	elif [[ "$xpyc" == *__init__.py* ]]; then
+		xpydir="${xpyc%/*}"
+		echo "$EDITOR $xpydir"
+		${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}} "$xpydir"
+	else
+		echo "$EDITOR ${xpyc%.*}.py"
+		${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}} "${xpyc%.*}.py"
+	fi
 }

--- a/plugins/available/python.plugin.bash
+++ b/plugins/available/python.plugin.bash
@@ -1,11 +1,12 @@
 cite about-plugin
 about-plugin 'alias "shttp" to SimpleHTTPServer'
 
-if [[ "$OSTYPE" == 'linux'* ]]
-then
-  alias shttp='python2 -m SimpleHTTPServer'
+if _command_exists python2; then
+	alias shttp='python2 -m SimpleHTTPServer'
+elif _command_exists python
+	alias shttp='python -m SimpleHTTPServer'
 else
-  alias shttp='python -m SimpleHTTPServer'
+	return 1
 fi
 
 function pyedit() {
@@ -14,18 +15,18 @@ function pyedit() {
     example '$ pyedit requests'
     group 'python'
 
-    xpyc=`python -c "import os, sys; f = open(os.devnull, 'w'); sys.stderr = f; module = __import__('$1'); sys.stdout.write(module.__file__)"`
+    xpyc="$(python -c "import os, sys; f = open(os.devnull, 'w'); sys.stderr = f; module = __import__('$1'); sys.stdout.write(module.__file__)")"
 
     if [[ "$xpyc" == "" ]]; then
         echo "Python module $1 not found"
         return -1
 
-    elif [[ $xpyc == *__init__.py* ]]; then
-        xpydir=`dirname $xpyc`;
+    elif [[ "$xpyc" == *__init__.py* ]]; then
+        xpydir="${xpyc%/*}";
         echo "$EDITOR $xpydir";
-        $EDITOR "$xpydir";
+        ${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}} "$xpydir";
     else
         echo "$EDITOR ${xpyc%.*}.py";
-        $EDITOR "${xpyc%.*}.py";
+        ${VISUAL:-${EDITOR:-${ALTERNATE_EDITOR:-nano}}} "${xpyc%.*}.py";
     fi
 }


### PR DESCRIPTION
## Description
Don't check for `$OSTYPE` in order to determine which version of `python` to use... Alsö, use some `$EDITOR`s, and finally `shfmt`.

## Motivation and Context
Just cleaning up.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
