### PR TITLE
lib/helpers: fix `_command_exists()`

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -1039,14 +1039,7 @@ all_groups ()
     about 'displays all unique metadata groups'
     group 'lib'
 
-    typeset func
-    typeset file=$(mktemp -t composure.XXXX)
-    for func in $(_typeset_functions)
-    do
-        typeset -f $func | metafor group >> $file
-    done
-    cat $file | sort | uniq
-    rm $file
+	declare -f | metafor group | sort -u
 }
 
 if ! type pathmunge > /dev/null 2>&1

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -15,49 +15,49 @@ case "$OSTYPE" in
   'darwin'*) BASH_IT_SED_I_PARAMETERS=(-i "")
 esac
 
-function _command_exists ()
-{
-  _about 'checks for existence of a command'
-  _param '1: command to check'
-  _param '2: (optional) log message to include when command not found'
-  _example '$ _command_exists ls && echo exists'
-  _group 'lib'
-  local msg="${2:-Command '$1' does not exist!}"
-  if type -t "$1" &> /dev/null
-  then
-	  return 0
-  else
-	  _log_warning "$msg"
-	  return 1
-  fi
+function _command_exists() {
+	_about 'checks for existence of a command'
+	_param '1: command to check'
+	_param '2: (optional) log message to include when command not found'
+	_example '$ _command_exists ls && echo exists'
+	_group 'lib'
+	local msg="${2:-Command '$1' does not exist}"
+	if type -t "$1" > /dev/null; then
+		return 0
+	else
+		_log_debug "$msg"
+		return 1
+	fi
 }
 
-function _binary_exists ()
-{
-  _about 'checks for existence of a binary'
-  _param '1: binary to check'
-  _param '2: (optional) log message to include when binary not found'
-  _example '$ _binary_exists ls && echo exists'
-  _group 'lib'
-  local msg="${2:-Binary '$1' does not exist!}"
-  if type -P "$1" &> /dev/null
-  then
-	return 0
-  else
-	_log_warning "$msg"
-	return 1
-  fi
+function _binary_exists() {
+	_about 'checks for existence of a binary'
+	_param '1: binary to check'
+	_param '2: (optional) log message to include when binary not found'
+	_example '$ _binary_exists ls && echo exists'
+	_group 'lib'
+	local msg="${2:-Binary '$1' does not exist}"
+	if type -P "$1" > /dev/null; then
+		return 0
+	else
+		_log_debug "$msg"
+		return 1
+	fi
 }
 
-function _completion_exists ()
-{
-  _about 'checks for existence of a completion'
-  _param '1: command to check'
-  _param '2: (optional) log message to include when completion is found'
-  _example '$ _completion_exists gh && echo exists'
-  _group 'lib'
-  local msg="${2:-Completion for '$1' already exists!}"
-  complete -p "$1" &> /dev/null && _log_warning "$msg" ;
+function _completion_exists() {
+	_about 'checks for existence of a completion'
+	_param '1: command to check'
+	_param '2: (optional) log message to include when completion is found'
+	_example '$ _completion_exists gh && echo exists'
+	_group 'lib'
+	local msg="${2:-Completion for '$1' already exists}"
+	if complete -p "$1" &> /dev/null; then
+		_log_debug "$msg"
+		return 0
+	else
+		return 1
+	fi
 }
 
 function _bash_it_homebrew_check()
@@ -179,12 +179,20 @@ bash-it ()
     fi
 }
 
-_is_function ()
-{
-    _about 'sets $? to true if parameter is the name of a function'
-    _param '1: name of alleged function'
-    _group 'lib'
-    [ -n "$(LANG=C type -t $1 2>/dev/null | grep 'function')" ]
+function _is_function() {
+	_about 'sets $? to true if parameter is the name of a function'
+	_param '1: name of alleged function'
+	_param '2: (optional) log message to include when function not found'
+	_group 'lib'
+	_example '$ _is_function ls && echo exists'
+	_group 'lib'
+	local msg="${2:-Function '$1' does not exist}"
+	if LC_ALL=C type -t "$1" | _bash-it-egrep -q 'function'; then
+		return 0
+	else
+		_log_debug "$msg"
+		return 1
+	fi
 }
 
 _bash-it-aliases ()


### PR DESCRIPTION
This is a *tiny* PR since I'm having trouble rebasing my `helpers` PR (#1934). This change was in the middle and just much easier to pull it aside 😃 

## Description
The weird subshell is weird AF. Just do a normal `if`. Ditto `_binary_exists()`, `_completion_exists()`, and `_is_function()`! Alsö, make `all_groups()` literally 100x faster.


## Motivation and Context
Simplicity, consistency, and #1696! And `git rebase` is hard sometimes.

## How Has This Been Tested?
Locale and all tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
