### PR TITLE
theme/powerline: fix error `scm: parameter not defined`

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -135,7 +135,7 @@ function __powerline_scm_prompt() {
 		elif [[ "${SCM_SVN_CHAR}" == "${SCM_CHAR}" ]]; then
 			scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
 		fi
-		echo "${scm_prompt?}${scm?}|${color}"
+		echo "${scm_prompt?}|${color}"
 	fi
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix bug that powerline theme's scm feature does not work.
## Description
<!--- Describe your changes in detail -->
The commit 2991aa66ca3e3cee98d3e52399fef30cef771176 removed set +u
but still references the variable `scm` without defining it.
This commit remove the reference to `scm`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes powerline theme's scm feature work again.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
