### PR TITLE
Add command to edit start-up files based on existance

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -21,6 +21,7 @@ alias _="sudo"
 # Shortcuts to edit startup files
 alias vbrc="vim ~/.bashrc"
 alias vbpf="vim ~/.bash_profile"
+alias vbsh="([[ -f ~/.bashrc ]] && vbrc) || ([[ -f ~/.bash_profile ]] && vbpf)"
 
 # colored grep
 # Need to check an existing file for a pattern that will be found to ensure


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 Add an alias to automatically select the entry file and edit its content. 

## Motivation and Context

I recently switch to macOS from Linux and there while installing bashit, it selected bash profile without my knowledge but I have a habit of using `vbrc`. So i decided to add a general command with fallbacks

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on macOS and Linux
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
