### PR TITLE
lib/appearance: export `$CLICOLOR` instead of `$LSCOLOR`

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -76,6 +76,7 @@ completion/available/vuejs.completion.bash
 completion/available/wpscan.completion.bash
 
 # libraries
+lib/appearance.bash
 lib/colors.bash
 lib/helpers.bash
 lib/history.bash

--- a/lib/appearance.bash
+++ b/lib/appearance.bash
@@ -1,19 +1,18 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 # colored ls
 export LSCOLORS='Gxfxcxdxdxegedabagacad'
 
-if [[ -z "$CUSTOM_THEME_DIR" ]]; then
-    CUSTOM_THEME_DIR="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/themes"
-fi
+: "${CUSTOM_THEME_DIR:="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/themes"}"
 
 # Load the theme
-if [[ $BASH_IT_THEME ]]; then
-    if [[ -f $BASH_IT_THEME ]]; then
-        source $BASH_IT_THEME
-    elif [[ -f "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash" ]]; then
-        source "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
-    else
-        source "$BASH_IT/themes/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
-    fi
+# shellcheck disable=SC1090
+if [[ -n "${BASH_IT_THEME:-}" ]]; then
+	if [[ -f "${BASH_IT_THEME}" ]]; then
+		source "${BASH_IT_THEME}"
+	elif [[ -f "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash" ]]; then
+		source "$CUSTOM_THEME_DIR/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
+	else
+		source "$BASH_IT/themes/$BASH_IT_THEME/$BASH_IT_THEME.theme.bash"
+	fi
 fi

--- a/lib/appearance.bash
+++ b/lib/appearance.bash
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 
-# colored ls
-export LSCOLORS='Gxfxcxdxdxegedabagacad'
+: "${CLICOLOR:=$(tput colors)}"
+export CLICOLOR
 
 : "${CUSTOM_THEME_DIR:="${BASH_IT_CUSTOM:=${BASH_IT}/custom}/themes"}"
 

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -45,7 +45,7 @@ function _bash-it-log-prefix-by-path() {
 
 function _has_colors() {
 	# Check that stdout is a terminal, and that it has at least 8 colors.
-	[[ -t 1 && "${_bash_it_available_colors:=$(tput colors 2> /dev/null)}" -ge 8 ]]
+	[[ -t 1 && "${CLICOLOR:=$(tput colors 2> /dev/null)}" -ge 8 ]]
 }
 
 function _bash-it-log-message() {

--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -1,6 +1,10 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034 # Expected behavior for themes.
 
+# Colors for listing files, using default color scheme.
+# To customize color scheme by theme, check out https://geoff.greer.fm/lscolors/
+export CLICOLOR LSCOLORS LS_COLORS
+
 CLOCK_CHAR_THEME_PROMPT_PREFIX=''
 CLOCK_CHAR_THEME_PROMPT_SUFFIX=''
 CLOCK_THEME_PROMPT_PREFIX=''


### PR DESCRIPTION
## Description
- Export `$CLICOLOR`, instead of `$LSCOLORS`, and add a comment to the base theme to help theme authors;
- `shellcheck`;
- Alsö, since the *value* of `$CLICOLOR` is not used anywhere, overload it to count the number of colors available for use elsewhere.

## Motivation and Context
Exporting `$LSCOLOR` from `lib/appearance` has always been weird to me and it took me a few rounds to figure out why: it's not useful. BSD `ls` enables color output if `$CLICOLOR` is set (to any value, even blank), and GNU `ls` doesn't use any variable to enable color listings. (GNU `ls` requires `--color=auto` or similar.) The `$LSCOLORS` (BSD) and `$LS_COLORS` (GNU) variables do *not* enable color listings; they just specify which color scheme to use (with incompatible formats).

Themes can and should customize `$LSCOLORS`/`$LS_COLORS`, but this should not be hard-coded by the main files. Both GNU and BSD `ls` have default colors they use when these variables are not set.

Alsö resolves #2082.

## How Has This Been Tested?
This is part of my main branch, and I've tested to make sure it loads, and the test suite passes. 

## Types of changes
- [x] Weird fix (non-breaking change which calms the brain worms)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
