### PR TITLE
completion/bash-it: lint and simplify

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -37,6 +37,7 @@ aliases/available/vim.aliases.bash
 #
 completion/available/apm.completion.bash
 completion/available/awless.completion.bash
+completion/available/bash-it.completion.bash
 completion/available/brew.completion.bash
 completion/available/cargo.completion.bash
 completion/available/composer.completion.bash

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -6,7 +6,7 @@ function _compreply_candidates() {
 	read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]}" -- "${cur}")
 }
 
-function _bash-it-comp() {
+function _bash-it() {
 	local cur prev verb file_type candidates suffix
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
@@ -83,9 +83,9 @@ function _bash-it-comp() {
 }
 
 # Activate completion for bash-it and its common misspellings
-complete -F _bash-it-comp bash-it
-complete -F _bash-it-comp bash-ti
-complete -F _bash-it-comp shit
-complete -F _bash-it-comp bashit
-complete -F _bash-it-comp batshit
-complete -F _bash-it-comp bash_it
+complete -F _bash-it bash-it
+complete -F _bash-it bash-ti
+complete -F _bash-it shit
+complete -F _bash-it bashit
+complete -F _bash-it batshit
+complete -F _bash-it bash_it

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -1,165 +1,165 @@
 #!/usr/bin/env bash
 
-_bash-it-comp-enable-disable()
-{
-  local enable_disable_args="alias completion plugin"
-  COMPREPLY=( $(compgen -W "${enable_disable_args}" -- "${cur}") )
+_bash-it-comp-enable-disable() {
+	local enable_disable_args="alias completion plugin"
+	COMPREPLY=($(compgen -W "${enable_disable_args}" -- "${cur}"))
 }
 
-_bash-it-comp-list-available-not-enabled()
-{
-  local subdirectory="$1"
+_bash-it-comp-list-available-not-enabled() {
+	local subdirectory="$1"
 
-  local enabled_components all_things available_things
+	local enabled_components all_things available_things
 
-  all_things=( $(compgen -G "${BASH_IT}/$subdirectory/available/*.bash") ); all_things=( "${all_things[@]##*/}" )
-  enabled_components=( $(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2>/dev/null) )
-  enabled_components=( "${enabled_components[@]##*/}" ); enabled_components="${enabled_components[@]##*---}"
-  available_things=( $(sort -d <(for i in ${enabled_components}
-    do
-      all_things=( "${all_things[@]//$i}" )
-    done
-    printf '%s\n' "${all_things[@]}")) ); available_things="${available_things[@]%.*.bash}"
+	all_things=($(compgen -G "${BASH_IT}/$subdirectory/available/*.bash"))
+	all_things=("${all_things[@]##*/}")
+	enabled_components=($(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2> /dev/null))
+	enabled_components=("${enabled_components[@]##*/}")
+	enabled_components="${enabled_components[@]##*---}"
+	available_things=($(sort -d <(
+		for i in ${enabled_components}; do
+			all_things=("${all_things[@]//$i/}")
+		done
+		printf '%s\n' "${all_things[@]}"
+	)))
+	available_things="${available_things[@]%.*.bash}"
 
-  COMPREPLY=( $(compgen -W "all ${available_things}" -- "${cur}") )
+	COMPREPLY=($(compgen -W "all ${available_things}" -- "${cur}"))
 }
 
-_bash-it-comp-list-enabled()
-{
-  local subdirectory="$1"
-  local suffix enabled_things
+_bash-it-comp-list-enabled() {
+	local subdirectory="$1"
+	local suffix enabled_things
 
-  suffix="${subdirectory/plugins/plugin}"
+	suffix="${subdirectory/plugins/plugin}"
 
-  enabled_things=( $(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")) )
-  enabled_things=( "${enabled_things[@]##*/}" ); enabled_things=( "${enabled_things[@]##*---}" ); enabled_things="${enabled_things[@]%.*.bash}"
+	enabled_things=($(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")))
+	enabled_things=("${enabled_things[@]##*/}")
+	enabled_things=("${enabled_things[@]##*---}")
+	enabled_things="${enabled_things[@]%.*.bash}"
 
-  COMPREPLY=( $(compgen -W "all ${enabled_things}" -- "${cur}") )
+	COMPREPLY=($(compgen -W "all ${enabled_things}" -- "${cur}"))
 }
 
-_bash-it-comp-list-available()
-{
-  local subdirectory="$1"
+_bash-it-comp-list-available() {
+	local subdirectory="$1"
 
-  local enabled_things
+	local enabled_things
 
-  enabled_things=( $(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash")) )
-  enabled_things=( "${enabled_things[@]##*/}" ); enabled_things="${enabled_things[@]%.*.bash}"
+	enabled_things=($(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash")))
+	enabled_things=("${enabled_things[@]##*/}")
+	enabled_things="${enabled_things[@]%.*.bash}"
 
-  COMPREPLY=( $(compgen -W "${enabled_things}" -- "${cur}") )
+	COMPREPLY=($(compgen -W "${enabled_things}" -- "${cur}"))
 }
 
-_bash-it-comp-list-profiles()
-{
-  local profiles
+_bash-it-comp-list-profiles() {
+	local profiles
 
-  profiles=$(for f in `compgen -G "${BASH_IT}/profiles/*.bash_it" | sort -d`;
-    do
-      basename $f | sed -e 's/.bash_it//g'
-    done)
+	profiles=$(for f in $(compgen -G "${BASH_IT}/profiles/*.bash_it" | sort -d); do
+		basename $f | sed -e 's/.bash_it//g'
+	done)
 
-  COMPREPLY=( $(compgen -W "${profiles}" -- ${cur}) )
+	COMPREPLY=($(compgen -W "${profiles}" -- ${cur}))
 }
 
-_bash-it-comp()
-{
-  local cur prev opts
-  COMPREPLY=()
-  cur="${COMP_WORDS[COMP_CWORD]}"
-  prev="${COMP_WORDS[COMP_CWORD-1]}"
-  chose_opt="${COMP_WORDS[1]}"
-  file_type="${COMP_WORDS[2]}"
-  opts="disable enable help migrate reload restart profile doctor search show update version"
-  case "${chose_opt}" in
-    show)
-      local show_args="aliases completions plugins"
-      COMPREPLY=( $(compgen -W "${show_args}" -- "${cur}") )
-      return 0
-      ;;
-    help)
-      if [ x"${prev}" == x"aliases" ]; then
-        _bash-it-comp-list-available aliases
-        return 0
-      else
-        local help_args="aliases completions migrate plugins update"
-        COMPREPLY=( $(compgen -W "${help_args}" -- "${cur}") )
-        return 0
-      fi
-      ;;
-    profile)
-      case "${file_type}" in
-        load)
-          if [[ "load" == "$prev" ]]; then
-            _bash-it-comp-list-profiles
-          fi
-          return 0
-          ;;
-        rm)
-          if [[ "rm" == "$prev" ]]; then
-            _bash-it-comp-list-profiles
-          fi
-          return 0
-          ;;
-        save)
-          return 0
-          ;;
-        list)
-          return 0
-          ;;
-        *)
-          local profile_args="load save list rm"
-          COMPREPLY=( $(compgen -W "${profile_args}" -- ${cur}) )
-          return 0
-          ;;
-      esac
-      ;;
-    doctor)
-      local doctor_args="errors warnings all"
-      COMPREPLY=( $(compgen -W "${doctor_args}" -- "${cur}") )
-      return 0
-      ;;
-    update)
-      if [[ "${cur}" == -* ]];then
-        local update_args="-s --silent"
-      else
-        local update_args="stable dev"
-      fi
-      COMPREPLY=( $(compgen -W "${update_args}" -- "${cur}") )
-      return 0
-      ;;
-    migrate | reload | restart | search | version)
-      return 0
-      ;;
-    enable | disable)
-      if [ x"${chose_opt}" == x"enable" ];then
-        suffix="available-not-enabled"
-      else
-        suffix="enabled"
-      fi
-      case "${file_type}" in
-        alias)
-            _bash-it-comp-list-"${suffix}" aliases
-            return 0
-            ;;
-        plugin)
-            _bash-it-comp-list-"${suffix}" plugins
-            return 0
-            ;;
-        completion)
-            _bash-it-comp-list-"${suffix}" completion
-            return 0
-            ;;
-        *)
-            _bash-it-comp-enable-disable
-            return 0
-            ;;
-      esac
-      ;;
-  esac
+_bash-it-comp() {
+	local cur prev opts
+	COMPREPLY=()
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[COMP_CWORD - 1]}"
+	chose_opt="${COMP_WORDS[1]}"
+	file_type="${COMP_WORDS[2]}"
+	opts="disable enable help migrate reload restart profile doctor search show update version"
+	case "${chose_opt}" in
+		show)
+			local show_args="aliases completions plugins"
+			COMPREPLY=($(compgen -W "${show_args}" -- "${cur}"))
+			return 0
+			;;
+		help)
+			if [ x"${prev}" == x"aliases" ]; then
+				_bash-it-comp-list-available aliases
+				return 0
+			else
+				local help_args="aliases completions migrate plugins update"
+				COMPREPLY=($(compgen -W "${help_args}" -- "${cur}"))
+				return 0
+			fi
+			;;
+		profile)
+			case "${file_type}" in
+				load)
+					if [[ "load" == "$prev" ]]; then
+						_bash-it-comp-list-profiles
+					fi
+					return 0
+					;;
+				rm)
+					if [[ "rm" == "$prev" ]]; then
+						_bash-it-comp-list-profiles
+					fi
+					return 0
+					;;
+				save)
+					return 0
+					;;
+				list)
+					return 0
+					;;
+				*)
+					local profile_args="load save list rm"
+					COMPREPLY=($(compgen -W "${profile_args}" -- ${cur}))
+					return 0
+					;;
+			esac
+			;;
+		doctor)
+			local doctor_args="errors warnings all"
+			COMPREPLY=($(compgen -W "${doctor_args}" -- "${cur}"))
+			return 0
+			;;
+		update)
+			if [[ "${cur}" == -* ]]; then
+				local update_args="-s --silent"
+			else
+				local update_args="stable dev"
+			fi
+			COMPREPLY=($(compgen -W "${update_args}" -- "${cur}"))
+			return 0
+			;;
+		migrate | reload | restart | search | version)
+			return 0
+			;;
+		enable | disable)
+			if [ x"${chose_opt}" == x"enable" ]; then
+				suffix="available-not-enabled"
+			else
+				suffix="enabled"
+			fi
+			case "${file_type}" in
+				alias)
+					_bash-it-comp-list-"${suffix}" aliases
+					return 0
+					;;
+				plugin)
+					_bash-it-comp-list-"${suffix}" plugins
+					return 0
+					;;
+				completion)
+					_bash-it-comp-list-"${suffix}" completion
+					return 0
+					;;
+				*)
+					_bash-it-comp-enable-disable
+					return 0
+					;;
+			esac
+			;;
+	esac
 
-  COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+	COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
 
-  return 0
+	return 0
 }
 
 # Activate completion for bash-it and its common misspellings

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -1,31 +1,43 @@
 # shellcheck shell=bash
 
 function _bash-it-comp-list-available-not-enabled() {
-	local subdirectory="$1"
-	COMPREPLY=($(compgen -W "all $(_bash-it-component-list-disabled "${subdirectory}")" -- "${cur}"))
+	local subdirectory="$1" IFS=$'\n' REPL
+	COMPREPLY=('all')
+	while read -ra REPL; do
+		COMPREPLY+=("${REPL[@]}")
+	done < <(compgen -W "$(_bash-it-component-list-disabled "${subdirectory}")" -- "${cur}")
 }
 
 function _bash-it-comp-list-enabled() {
-	local subdirectory="$1"
-	COMPREPLY=($(compgen -W "all $(_bash-it-component-list-enabled "${subdirectory}")" -- "${cur}"))
+	local subdirectory="$1" IFS=$'\n' REPL
+	COMPREPLY=('all')
+	while read -ra REPL; do
+		COMPREPLY+=("${REPL[@]}")
+	done < <(compgen -W "$(_bash-it-component-list-enabled "${subdirectory}")" -- "${cur}")
 }
 
 function _bash-it-comp-list-available() {
-	local subdirectory="$1"
-	COMPREPLY=($(compgen -W "all $(_bash-it-component-list "${subdirectory}")" -- "${cur}"))
+	local subdirectory="$1" IFS=$'\n' REPL
+	COMPREPLY=('all')
+	while read -ra REPL; do
+		COMPREPLY+=("${REPL[@]}")
+	done < <(compgen -W "$(_bash-it-component-list "${subdirectory}")" -- "${cur}")
 }
 
 function _bash-it-comp-list-profiles() {
-	local profiles
+	local profiles IFS=$'\n' REPL
+	COMPREPLY=()
 
 	profiles=("${BASH_IT}/profiles"/*.bash_it)
 	profiles=("${profiles[@]##*/}")
 
-	COMPREPLY=($(compgen -W "${profiles[*]%%.bash_it}" -- "${cur}"))
+	while read -ra REPL; do
+		COMPREPLY+=("${REPL[@]}")
+	done < <(compgen -W "${profiles[*]%%.bash_it}" -- "${cur}")
 }
 
 function _bash-it-comp() {
-	local cur prev opts
+	local cur prev opts chose_opt file_type
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD - 1]}"

--- a/completion/available/bash-it.completion.bash
+++ b/completion/available/bash-it.completion.bash
@@ -1,74 +1,36 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
-_bash-it-comp-enable-disable() {
-	local enable_disable_args="alias completion plugin"
-	COMPREPLY=($(compgen -W "${enable_disable_args}" -- "${cur}"))
-}
-
-_bash-it-comp-list-available-not-enabled() {
+function _bash-it-comp-list-available-not-enabled() {
 	local subdirectory="$1"
-
-	local enabled_components all_things available_things
-
-	all_things=($(compgen -G "${BASH_IT}/$subdirectory/available/*.bash"))
-	all_things=("${all_things[@]##*/}")
-	enabled_components=($(command ls "${BASH_IT}"/{"$subdirectory"/,}enabled/*.bash 2> /dev/null))
-	enabled_components=("${enabled_components[@]##*/}")
-	enabled_components="${enabled_components[@]##*---}"
-	available_things=($(sort -d <(
-		for i in ${enabled_components}; do
-			all_things=("${all_things[@]//$i/}")
-		done
-		printf '%s\n' "${all_things[@]}"
-	)))
-	available_things="${available_things[@]%.*.bash}"
-
-	COMPREPLY=($(compgen -W "all ${available_things}" -- "${cur}"))
+	COMPREPLY=($(compgen -W "all $(_bash-it-component-list-disabled "${subdirectory}")" -- "${cur}"))
 }
 
-_bash-it-comp-list-enabled() {
+function _bash-it-comp-list-enabled() {
 	local subdirectory="$1"
-	local suffix enabled_things
-
-	suffix="${subdirectory/plugins/plugin}"
-
-	enabled_things=($(sort -d <(compgen -G "${BASH_IT}/$subdirectory/enabled/*.${suffix}.bash") <(compgen -G "${BASH_IT}/enabled/*.${suffix}.bash")))
-	enabled_things=("${enabled_things[@]##*/}")
-	enabled_things=("${enabled_things[@]##*---}")
-	enabled_things="${enabled_things[@]%.*.bash}"
-
-	COMPREPLY=($(compgen -W "all ${enabled_things}" -- "${cur}"))
+	COMPREPLY=($(compgen -W "all $(_bash-it-component-list-enabled "${subdirectory}")" -- "${cur}"))
 }
 
-_bash-it-comp-list-available() {
+function _bash-it-comp-list-available() {
 	local subdirectory="$1"
-
-	local enabled_things
-
-	enabled_things=($(sort -d <(compgen -G "${BASH_IT}/$subdirectory/available/*.bash")))
-	enabled_things=("${enabled_things[@]##*/}")
-	enabled_things="${enabled_things[@]%.*.bash}"
-
-	COMPREPLY=($(compgen -W "${enabled_things}" -- "${cur}"))
+	COMPREPLY=($(compgen -W "all $(_bash-it-component-list "${subdirectory}")" -- "${cur}"))
 }
 
-_bash-it-comp-list-profiles() {
+function _bash-it-comp-list-profiles() {
 	local profiles
 
-	profiles=$(for f in $(compgen -G "${BASH_IT}/profiles/*.bash_it" | sort -d); do
-		basename $f | sed -e 's/.bash_it//g'
-	done)
+	profiles=("${BASH_IT}/profiles"/*.bash_it)
+	profiles=("${profiles[@]##*/}")
 
-	COMPREPLY=($(compgen -W "${profiles}" -- ${cur}))
+	COMPREPLY=($(compgen -W "${profiles[*]%%.bash_it}" -- "${cur}"))
 }
 
-_bash-it-comp() {
+function _bash-it-comp() {
 	local cur prev opts
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD - 1]}"
 	chose_opt="${COMP_WORDS[1]}"
-	file_type="${COMP_WORDS[2]}"
+	file_type="${COMP_WORDS[2]:-}"
 	opts="disable enable help migrate reload restart profile doctor search show update version"
 	case "${chose_opt}" in
 		show)
@@ -77,7 +39,7 @@ _bash-it-comp() {
 			return 0
 			;;
 		help)
-			if [ x"${prev}" == x"aliases" ]; then
+			if [[ "${prev}" == "aliases" ]]; then
 				_bash-it-comp-list-available aliases
 				return 0
 			else
@@ -108,7 +70,7 @@ _bash-it-comp() {
 					;;
 				*)
 					local profile_args="load save list rm"
-					COMPREPLY=($(compgen -W "${profile_args}" -- ${cur}))
+					COMPREPLY=($(compgen -W "${profile_args}" -- "${cur}"))
 					return 0
 					;;
 			esac
@@ -131,26 +93,19 @@ _bash-it-comp() {
 			return 0
 			;;
 		enable | disable)
-			if [ x"${chose_opt}" == x"enable" ]; then
+			if [[ "${chose_opt}" == "enable" ]]; then
 				suffix="available-not-enabled"
 			else
 				suffix="enabled"
 			fi
 			case "${file_type}" in
-				alias)
-					_bash-it-comp-list-"${suffix}" aliases
-					return 0
-					;;
-				plugin)
-					_bash-it-comp-list-"${suffix}" plugins
-					return 0
-					;;
-				completion)
-					_bash-it-comp-list-"${suffix}" completion
+				alias | completion | plugin)
+					_bash-it-comp-list-"${suffix}" "${file_type}"
 					return 0
 					;;
 				*)
-					_bash-it-comp-enable-disable
+					local enable_disable_args="alias completion plugin"
+					COMPREPLY=($(compgen -W "${enable_disable_args}" -- "${cur}"))
 					return 0
 					;;
 			esac

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -9,8 +9,8 @@ function local_setup {
   setup_test_fixture
 }
 
-@test "completion bash-it: ensure that the _bash-it-comp function is available" {
-  type -a _bash-it-comp &> /dev/null
+@test "completion bash-it: ensure that the _bash-it function is available" {
+  type -a _bash-it &> /dev/null
   assert_success
 }
 
@@ -38,7 +38,7 @@ function __check_completion () {
   COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 ))
 
   # Run the Bash-it completion function
-  _bash-it-comp
+  _bash-it
 
   # Return the completion output
   echo "${COMPREPLY[@]}"

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -155,10 +155,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the a* aliases when atom is enabled with the old location and name" {
-  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/atom.aliases.bash
+  ln -s "$BASH_IT/aliases/available/atom.aliases.bash" "$BASH_IT/aliases/enabled/atom.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/atom.aliases.bash"
 
-  ln -s $BASH_IT/completion/available/apm.completion.bash $BASH_IT/completion/enabled/apm.completion.bash
+  ln -s "$BASH_IT/completion/available/apm.completion.bash" "$BASH_IT/completion/enabled/apm.completion.bash"
   assert_link_exist "$BASH_IT/completion/enabled/apm.completion.bash"
 
   run __check_completion 'bash-it disable alias a'
@@ -166,10 +166,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the a* aliases when atom is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/150---atom.aliases.bash
+  ln -s "$BASH_IT/aliases/available/atom.aliases.bash" "$BASH_IT/aliases/enabled/150---atom.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/150---atom.aliases.bash"
 
-  ln -s $BASH_IT/completion/available/apm.completion.bash $BASH_IT/completion/enabled/350---apm.completion.bash
+  ln -s "$BASH_IT/completion/available/apm.completion.bash" "$BASH_IT/completion/enabled/350---apm.completion.bash"
   assert_link_exist "$BASH_IT/completion/enabled/350---apm.completion.bash"
 
   run __check_completion 'bash-it disable alias a'
@@ -177,10 +177,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the a* aliases when atom is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/enabled/150---atom.aliases.bash
+  ln -s "$BASH_IT/aliases/available/atom.aliases.bash" "$BASH_IT/enabled/150---atom.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/150---atom.aliases.bash"
 
-  ln -s $BASH_IT/completion/available/apm.completion.bash $BASH_IT/enabled/350---apm.completion.bash
+  ln -s "$BASH_IT/completion/available/apm.completion.bash" "$BASH_IT/enabled/350---apm.completion.bash"
   assert_link_exist "$BASH_IT/enabled/350---apm.completion.bash"
 
   run __check_completion 'bash-it disable alias a'
@@ -188,10 +188,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the docker-machine plugin when docker-machine is enabled with the old location and name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/docker-compose.aliases.bash
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
 
-  ln -s $BASH_IT/plugins/available/docker-machine.plugin.bash $BASH_IT/plugins/enabled/docker-machine.plugin.bash
+  ln -s "$BASH_IT/plugins/available/docker-machine.plugin.bash" "$BASH_IT/plugins/enabled/docker-machine.plugin.bash"
   assert_link_exist "$BASH_IT/plugins/enabled/docker-machine.plugin.bash"
 
   run __check_completion 'bash-it disable plugin docker'
@@ -199,10 +199,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the docker-machine plugin when docker-machine is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
 
-  ln -s $BASH_IT/plugins/available/docker-machine.plugin.bash $BASH_IT/plugins/enabled/350---docker-machine.plugin.bash
+  ln -s "$BASH_IT/plugins/available/docker-machine.plugin.bash" "$BASH_IT/plugins/enabled/350---docker-machine.plugin.bash"
   assert_link_exist "$BASH_IT/plugins/enabled/350---docker-machine.plugin.bash"
 
   run __check_completion 'bash-it disable plugin docker'
@@ -210,10 +210,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the docker-machine plugin when docker-machine is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/enabled/150---docker-compose.aliases.bash
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/enabled/150---docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/150---docker-compose.aliases.bash"
 
-  ln -s $BASH_IT/plugins/available/docker-machine.plugin.bash $BASH_IT/enabled/350---docker-machine.plugin.bash
+  ln -s "$BASH_IT/plugins/available/docker-machine.plugin.bash" "$BASH_IT/enabled/350---docker-machine.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/350---docker-machine.plugin.bash"
 
   run __check_completion 'bash-it disable plugin docker'
@@ -221,10 +221,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and name" {
-  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash
+  ln -s "$BASH_IT/aliases/available/todo.txt-cli.aliases.bash" "$BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/todo.txt-cli.aliases.bash"
 
-  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/todo.plugin.bash
+  ln -s "$BASH_IT/plugins/available/todo.plugin.bash" "$BASH_IT/plugins/enabled/todo.plugin.bash"
   assert_link_exist "$BASH_IT/plugins/enabled/todo.plugin.bash"
 
   run __check_completion 'bash-it disable alias to'
@@ -232,10 +232,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash
+  ln -s "$BASH_IT/aliases/available/todo.txt-cli.aliases.bash" "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/150---todo.txt-cli.aliases.bash"
 
-  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/350---todo.plugin.bash
+  ln -s "$BASH_IT/plugins/available/todo.plugin.bash" "$BASH_IT/plugins/enabled/350---todo.plugin.bash"
   assert_link_exist "$BASH_IT/plugins/enabled/350---todo.plugin.bash"
 
   run __check_completion 'bash-it disable alias to'
@@ -243,10 +243,10 @@ function __check_completion () {
 }
 
 @test "completion bash-it: disable - provide the todo.txt-cli aliases when todo plugin is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/todo.txt-cli.aliases.bash $BASH_IT/enabled/150---todo.txt-cli.aliases.bash
+  ln -s "$BASH_IT/aliases/available/todo.txt-cli.aliases.bash" "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/150---todo.txt-cli.aliases.bash"
 
-  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/enabled/350---todo.plugin.bash
+  ln -s "$BASH_IT/plugins/available/todo.plugin.bash" "$BASH_IT/enabled/350---todo.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/350---todo.plugin.bash"
 
   run __check_completion 'bash-it disable alias to'
@@ -264,7 +264,7 @@ function __check_completion () {
 }
 
 @test "completion bash-it: enable - provide the a* aliases when atom is enabled with the old location and name" {
-  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/atom.aliases.bash
+  ln -s "$BASH_IT/aliases/available/atom.aliases.bash" "$BASH_IT/aliases/enabled/atom.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/atom.aliases.bash"
 
   run __check_completion 'bash-it enable alias a'
@@ -272,7 +272,7 @@ function __check_completion () {
 }
 
 @test "completion bash-it: enable - provide the a* aliases when atom is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/aliases/enabled/150---atom.aliases.bash
+  ln -s "$BASH_IT/aliases/available/atom.aliases.bash" "$BASH_IT/aliases/enabled/150---atom.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/150---atom.aliases.bash"
 
   run __check_completion 'bash-it enable alias a'
@@ -280,55 +280,55 @@ function __check_completion () {
 }
 
 @test "completion bash-it: enable - provide the a* aliases when atom is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/atom.aliases.bash $BASH_IT/enabled/150---atom.aliases.bash
+  ln -s "$BASH_IT/aliases/available/atom.aliases.bash" "$BASH_IT/enabled/150---atom.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/150---atom.aliases.bash"
 
   run __check_completion 'bash-it enable alias a'
   assert_line -n 0 "all ag ansible apt"
 }
 
-@test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the old location and name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/docker-compose.aliases.bash
+@test "completion bash-it: enable - provide the docker* plugins when docker-compose is enabled with the old location and name" {
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable plugin docker'
   assert_line -n 0 "docker docker-compose docker-machine"
 }
 
-@test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+@test "completion bash-it: enable - provide the docker-* plugins when docker-compose is enabled with the old location and priority-based name" {
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable plugin docker'
   assert_line -n 0 "docker docker-compose docker-machine"
 }
 
-@test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/enabled/150---docker-compose.aliases.bash
+@test "completion bash-it: enable - provide the docker-* plugins when docker-compose is enabled with the new location and priority-based name" {
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/enabled/150---docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/150---docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable plugin docker'
   assert_line -n 0 "docker docker-compose docker-machine"
 }
 
-@test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the old location and name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/docker-compose.aliases.bash
+@test "completion bash-it: enable - provide the docker* completions when docker-compose is enabled with the old location and name" {
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable completion docker'
   assert_line -n 0 "docker docker-compose docker-machine"
 }
 
-@test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/aliases/enabled/150---docker-compose.aliases.bash
+@test "completion bash-it: enable - provide the docker* completions when docker-compose is enabled with the old location and priority-based name" {
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable completion docker'
   assert_line -n 0 "docker docker-compose docker-machine"
 }
 
-@test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/aliases/available/docker-compose.aliases.bash $BASH_IT/enabled/150---docker-compose.aliases.bash
+@test "completion bash-it: enable - provide the docker* completions when docker-compose is enabled with the new location and priority-based name" {
+  ln -s "$BASH_IT/aliases/available/docker-compose.aliases.bash" "$BASH_IT/enabled/150---docker-compose.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/150---docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable completion docker'
@@ -336,7 +336,7 @@ function __check_completion () {
 }
 
 @test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and name" {
-  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/todo.plugin.bash
+  ln -s "$BASH_IT/plugins/available/todo.plugin.bash" "$BASH_IT/plugins/enabled/todo.plugin.bash"
   assert_link_exist "$BASH_IT/plugins/enabled/todo.plugin.bash"
 
   run __check_completion 'bash-it enable alias to'
@@ -344,7 +344,7 @@ function __check_completion () {
 }
 
 @test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the old location and priority-based name" {
-  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/plugins/enabled/350---todo.plugin.bash
+  ln -s "$BASH_IT/plugins/available/todo.plugin.bash" "$BASH_IT/plugins/enabled/350---todo.plugin.bash"
   assert_link_exist "$BASH_IT/plugins/enabled/350---todo.plugin.bash"
 
   run __check_completion 'bash-it enable alias to'
@@ -352,7 +352,7 @@ function __check_completion () {
 }
 
 @test "completion bash-it: enable - provide the todo.txt-cli aliases when todo plugin is enabled with the new location and priority-based name" {
-  ln -s $BASH_IT/plugins/available/todo.plugin.bash $BASH_IT/enabled/350---todo.plugin.bash
+  ln -s "$BASH_IT/plugins/available/todo.plugin.bash" "$BASH_IT/enabled/350---todo.plugin.bash"
   assert_link_exist "$BASH_IT/enabled/350---todo.plugin.bash"
 
   run __check_completion 'bash-it enable alias to'

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 
 load ../test_helper
+load ../../lib/utilities
+load ../../lib/helpers
 load ../../completion/available/bash-it.completion
 
 function local_setup {
@@ -290,7 +292,7 @@ function __check_completion () {
   assert_link_exist "$BASH_IT/aliases/enabled/docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable plugin docker'
-  assert_line -n 0 "docker-compose docker-machine docker"
+  assert_line -n 0 "docker docker-compose docker-machine"
 }
 
 @test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the old location and priority-based name" {
@@ -298,7 +300,7 @@ function __check_completion () {
   assert_link_exist "$BASH_IT/aliases/enabled/150---docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable plugin docker'
-  assert_line -n 0 "docker-compose docker-machine docker"
+  assert_line -n 0 "docker docker-compose docker-machine"
 }
 
 @test "completion bash-it: enable - provide the docker-* plugins when nothing is enabled with the new location and priority-based name" {
@@ -306,7 +308,7 @@ function __check_completion () {
   assert_link_exist "$BASH_IT/enabled/150---docker-compose.aliases.bash"
 
   run __check_completion 'bash-it enable plugin docker'
-  assert_line -n 0 "docker-compose docker-machine docker"
+  assert_line -n 0 "docker docker-compose docker-machine"
 }
 
 @test "completion bash-it: enable - provide the docker-* completions when nothing is enabled with the old location and name" {


### PR DESCRIPTION
## Description
- `shfmt`
- `shellcheck`
- Use `_bash-it-component-list-enabled()` and `_bash-it-component-list-disabled()` instead of reinventing the wheel.
- Use `read -ra` to populate `$COMPREPLY`, instead of unquoted word separation.
- New function `_compreply_candidates()` to simplify the loop for `read -ra`.

## Motivation and Context
After the recent performance upgrades for this completion, I took a look at what was bogging it down before and decided to lint the file. I then fell down the rabbit hole and accidentally refactored it again. I preserved the structure and speed, but deleted quite a lot by using existing functions as well as ensuring we handle spaces and International/unicode characters properly.

## How Has This Been Tested?
Manual testing at the command line, `test/completion/bash-it.completion.bats`, and the full test suite.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
