### PR TITLE
BATS infra refactor

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -137,7 +137,6 @@ plugins/available/zoxide.plugin.bash
 test/plugins/alias-completion.plugin.bats
 test/run
 test/test_helper.bash
-test/test_helper_libs.bash
 
 # themes
 #

--- a/test/bash_it/bash_it.bats
+++ b/test/bash_it/bash_it.bats
@@ -1,19 +1,11 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup {
-  setup_test_fixture
-
+function local_setup_file() {
   # Copy the test fixture to the Bash-it folder
-  if command -v rsync &> /dev/null
-  then
-    rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
-  else
-    find "$BASH_IT/test/fixtures/bash_it" \
-      -mindepth 1 -maxdepth 1 \
-      -exec cp -r {} "$BASH_IT/" \;
-  fi
+  cp -fRP "${BASH_IT?}/test/fixtures/bash_it"/* "${BASH_IT?}/" || true
+  # don't load any libraries as the tests here test the *whole* kit
 }
 
 @test "bash-it: verify that the test fixture is available" {

--- a/test/completion/aliases.completion.bats
+++ b/test/completion/aliases.completion.bats
@@ -1,28 +1,30 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-# Load something, anything...
-load ../../completion/available/capistrano.completion
+function local_setup_file() {
+  setup_libs "helpers"
+  # Load something, anything...
+  load ../../completion/available/capistrano.completion
+}
 
 @test "alias-completion: See that aliases with double quotes and brackets do not break the plugin" {
   alias gtest="git log --graph --pretty=format:'%C(bold)%h%Creset%C(magenta)%d%Creset %s %C(yellow)<%an> %C(cyan)(%cr)%Creset' --abbrev-commit --date=relative"
-  run load ../../completion/available/aliases.completion
+  run load "${BASH_IT?}/completion/available/aliases.completion.bash"
 
   assert_success
 }
 
 @test "alias-completion: See that aliases with single quotes and brackets do not break the plugin" {
   alias gtest='git log --graph --pretty=format:"%C(bold)%h%Creset%C(magenta)%d%Creset %s %C(yellow)<%an> %C(cyan)(%cr)%Creset" --abbrev-commit --date=relative'
-  run load ../../completion/available/aliases.completion
+  run load "${BASH_IT?}/completion/available/aliases.completion.bash"
 
   assert_success
 }
 
 @test "alias-completion: See that having aliased rm command does not output unnecessary output" {
   alias rm='rm -v'
-  run load ../../completion/available/aliases.completion
+  run load "${BASH_IT?}/completion/available/aliases.completion.bash"
 
   refute_output
 }

--- a/test/completion/bash-it.completion.bats
+++ b/test/completion/bash-it.completion.bats
@@ -1,17 +1,16 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../../lib/utilities
-load ../../lib/helpers
-load ../../completion/available/bash-it.completion
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup {
-  setup_test_fixture
+function local_setup_file() {
+  setup_libs "helpers"
+  load "${BASH_IT?}/completion/available/bash-it.completion.bash"
 }
 
 @test "completion bash-it: ensure that the _bash-it function is available" {
-  type -a _bash-it &> /dev/null
+  run type -t _bash-it
   assert_success
+  assert_output "function"
 }
 
 function __check_completion () {

--- a/test/install/install.bats
+++ b/test/install/install.bats
@@ -1,19 +1,22 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-# Determine which config file to use based on OS.
-case $OSTYPE in
-  darwin*)
-    export BASH_IT_CONFIG_FILE=.bash_profile
-    ;;
-  *)
-    export BASH_IT_CONFIG_FILE=.bashrc
-    ;;
-esac
+function local_setup() {
+  export HOME="$BATS_TEST_TMPDIR"
+}
 
-function local_setup {
-  setup_test_fixture
+function local_setup_file() {
+  # Determine which config file to use based on OS.
+  case $OSTYPE in
+    darwin*)
+      export BASH_IT_CONFIG_FILE=.bash_profile
+      ;;
+    *)
+      export BASH_IT_CONFIG_FILE=.bashrc
+      ;;
+  esac
+  # don't load any libraries as the tests here test the *whole* kit
 }
 
 @test "install: verify that the install script exists" {
@@ -25,7 +28,7 @@ function local_setup {
 
   ./install.sh --silent
 
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE"
 
   assert_link_exist "$BASH_IT/enabled/150---general.aliases.bash"
   assert_link_exist "$BASH_IT/enabled/250---base.plugin.bash"
@@ -37,16 +40,16 @@ function local_setup {
 @test "install: verify that a backup file is created" {
   cd "$BASH_IT"
 
-  touch "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  echo "test file content" > "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  local md5_orig=$(md5sum "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE" | awk '{print $1}')
+  touch "$HOME/$BASH_IT_CONFIG_FILE"
+  echo "test file content" > "$HOME/$BASH_IT_CONFIG_FILE"
+  local md5_orig=$(md5sum "$HOME/$BASH_IT_CONFIG_FILE" | awk '{print $1}')
 
   ./install.sh --silent
 
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE.bak"
 
-  local md5_bak=$(md5sum "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak" | awk '{print $1}')
+  local md5_bak=$(md5sum "$HOME/$BASH_IT_CONFIG_FILE.bak" | awk '{print $1}')
 
   assert_equal "$md5_orig" "$md5_bak"
 }
@@ -70,15 +73,15 @@ function local_setup {
 @test "install: verify that the template is appended" {
   cd "$BASH_IT"
 
-  touch "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  echo "test file content" > "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
+  touch "$HOME/$BASH_IT_CONFIG_FILE"
+  echo "test file content" > "$HOME/$BASH_IT_CONFIG_FILE"
 
   ./install.sh --silent --append-to-config
 
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE.bak"
 
-  run cat $BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE
+  run cat "$HOME/$BASH_IT_CONFIG_FILE"
 
   assert_line "test file content"
   assert_line "source \"\$BASH_IT\"/bash_it.sh"

--- a/test/install/uninstall.bats
+++ b/test/install/uninstall.bats
@@ -1,19 +1,22 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-# Determine which config file to use based on OS.
-case $OSTYPE in
-  darwin*)
-    export BASH_IT_CONFIG_FILE=.bash_profile
-    ;;
-  *)
-    export BASH_IT_CONFIG_FILE=.bashrc
-    ;;
-esac
+function local_setup() {
+  export HOME="$BATS_TEST_TMPDIR"
+}
 
-function local_setup {
-  setup_test_fixture
+function local_setup_file() {
+  # Determine which config file to use based on OS.
+  case $OSTYPE in
+    darwin*)
+      export BASH_IT_CONFIG_FILE=.bash_profile
+      ;;
+    *)
+      export BASH_IT_CONFIG_FILE=.bashrc
+      ;;
+  esac
+  # don't load any libraries as the tests here test the *whole* kit
 }
 
 @test "uninstall: verify that the uninstall script exists" {
@@ -23,19 +26,18 @@ function local_setup {
 @test "uninstall: run the uninstall script with an existing backup file" {
   cd "$BASH_IT"
 
-  echo "test file content for backup" > "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak"
-  echo "test file content for original file" > "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  local md5_bak=$(md5sum "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak" | awk '{print $1}')
+  echo "test file content for backup" > "$HOME/$BASH_IT_CONFIG_FILE.bak"
+  echo "test file content for original file" > "$HOME/$BASH_IT_CONFIG_FILE"
+  local md5_bak=$(md5sum "$HOME/$BASH_IT_CONFIG_FILE.bak" | awk '{print $1}')
 
-  ./uninstall.sh
-
+  run ./uninstall.sh
   assert_success
 
-  assert_file_not_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.uninstall"
-  assert_file_not_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak"
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
+  assert_file_not_exist "$HOME/$BASH_IT_CONFIG_FILE.uninstall"
+  assert_file_not_exist "$HOME/$BASH_IT_CONFIG_FILE.bak"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE"
 
-  local md5_conf=$(md5sum "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE" | awk '{print $1}')
+  local md5_conf=$(md5sum "$HOME/$BASH_IT_CONFIG_FILE" | awk '{print $1}')
 
   assert_equal "$md5_bak" "$md5_conf"
 }
@@ -43,18 +45,17 @@ function local_setup {
 @test "uninstall: run the uninstall script without an existing backup file" {
   cd "$BASH_IT"
 
-  echo "test file content for original file" > "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
-  local md5_orig=$(md5sum "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE" | awk '{print $1}')
+  echo "test file content for original file" > "$HOME/$BASH_IT_CONFIG_FILE"
+  local md5_orig=$(md5sum "$HOME/$BASH_IT_CONFIG_FILE" | awk '{print $1}')
 
-  ./uninstall.sh
-
+  run ./uninstall.sh
   assert_success
 
-  assert_file_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.uninstall"
-  assert_file_not_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.bak"
-  assert_file_not_exist "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE"
+  assert_file_exist "$HOME/$BASH_IT_CONFIG_FILE.uninstall"
+  assert_file_not_exist "$HOME/$BASH_IT_CONFIG_FILE.bak"
+  assert_file_not_exist "$HOME/$BASH_IT_CONFIG_FILE"
 
-  local md5_uninstall=$(md5sum "$BASH_IT_TEST_HOME/$BASH_IT_CONFIG_FILE.uninstall" | awk '{print $1}')
+  local md5_uninstall=$(md5sum "$HOME/$BASH_IT_CONFIG_FILE.uninstall" | awk '{print $1}')
 
   assert_equal "$md5_orig" "$md5_uninstall"
 }

--- a/test/lib/composure.bats
+++ b/test/lib/composure.bats
@@ -1,6 +1,11 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup_file() {
+  true
+  # don't load any libraries as the tests here test the *whole* kit
+}
 
 @test "lib composure: _composure_keywords()" {
   run _composure_keywords

--- a/test/lib/helpers.bats
+++ b/test/lib/helpers.bats
@@ -1,21 +1,15 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
-load ../../plugins/available/base.plugin
-load ../../lib/colors
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup {
-  setup_test_fixture
+function local_setup_file() {
+  setup_libs "colors"
+  load "${BASH_IT?}/plugins/available/base.plugin.bash"
+}
 
+function local_setup() {
   # Copy the test fixture to the Bash-it folder
-  if command -v rsync &> /dev/null; then
-    rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
-  else
-    find "$BASH_IT/test/fixtures/bash_it" \
-      -mindepth 1 -maxdepth 1 \
-      -exec cp -r {} "$BASH_IT/" \;
-  fi
+  cp -RP "$BASH_IT/test/fixtures/bash_it"/* "$BASH_IT/"
 }
 
 # TODO Create global __is_enabled function

--- a/test/lib/log.bats
+++ b/test/lib/log.bats
@@ -1,11 +1,10 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../../lib/colors
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-load ../../lib/log
-load ../../lib/helpers
-load ../../plugins/available/base.plugin
+function local_setup_file() {
+  setup_libs "log"
+}
 
 @test "lib log: basic debug logging with BASH_IT_LOG_LEVEL_ALL" {
   BASH_IT_LOG_LEVEL=$BASH_IT_LOG_LEVEL_ALL

--- a/test/lib/preexec.bats
+++ b/test/lib/preexec.bats
@@ -111,7 +111,7 @@ function local_setup {
 
 @test "lib preexec: __check_precmd_conflict()" {
 	test_precmd_function_name="test"
-	load ../test_helper_libs
+	setup_libs "preexec"
 
 	run __check_precmd_conflict "$test_precmd_function_name"
 	assert_failure
@@ -124,7 +124,7 @@ function local_setup {
 
 @test "lib preexec: __check_preexec_conflict()" {
 	test_preexec_function_name="test"
-	load ../test_helper_libs
+	setup_libs "preexec"
 
 	run __check_preexec_conflict "$test_preexec_function_name"
 	assert_failure
@@ -137,7 +137,7 @@ function local_setup {
 
 @test "lib preexec: safe_append_prompt_command()" {
 	test_precmd_function_name="test"
-	load ../test_helper_libs
+	setup_libs "preexec"
 
 	export precmd_functions=()
 	assert_equal "${precmd_functions[*]}" ""
@@ -151,7 +151,7 @@ function local_setup {
 
 @test "lib preexec: safe_append_preexec()" {
 	test_preexec_function_name="test"
-	load ../test_helper_libs
+	setup_libs "preexec"
 
 	export preexec_functions=()
 	assert_equal "${preexec_functions[*]}" ""

--- a/test/lib/search.bats
+++ b/test/lib/search.bats
@@ -1,28 +1,14 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-load ../../plugins/available/base.plugin
-load ../../aliases/available/git.aliases
-load ../../plugins/available/ruby.plugin
-load ../../plugins/available/rails.plugin
-load ../../completion/available/bundler.completion
-load ../../completion/available/gem.completion
-load ../../completion/available/rake.completion
-
-load ../../lib/helpers
-
-function local_setup {
-  setup_test_fixture
-
-  export OLD_PATH="$PATH"
-  export PATH="/usr/bin:/bin:/usr/sbin"
+function local_setup_file() {
+  setup_libs "search"
 }
 
-function local_teardown {
-  export PATH="$OLD_PATH"
-  unset OLD_PATH
+function local_setup() {
+    # shellcheck disable=SC2034
+    BASH_IT_SEARCH_USE_COLOR=false
 }
 
 @test "search: plugin base" {

--- a/test/lib/utilities.bats
+++ b/test/lib/utilities.bats
@@ -1,10 +1,9 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup {
-  setup_test_fixture
+function local_setup_file() {
+  setup_libs "helpers"
 }
 
 @test "_bash-it-component-item-is-enabled() - for a disabled item" {

--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -1,11 +1,14 @@
 #!/usr/bin/env bats
 
-load ../test_helper
-load ../test_helper_libs
-load ../../plugins/available/base.plugin
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup() {
+  setup_libs
+  load "${BASH_IT?}/plugins/available/base.plugin.bash"
+}
 
 @test 'plugins base: ips()' {
-  if [[ $CI ]]; then
+  if [[ -n "${CI:-}" ]]; then
     skip 'ifconfig probably requires sudo on TravisCI'
   fi
 
@@ -23,7 +26,7 @@ load ../../plugins/available/base.plugin
 }
 
 @test 'plugins base: pickfrom()' {
-  stub_file="${BASH_IT_ROOT}/stub_file"
+  stub_file="${BATS_TEST_TMPDIR}/stub_file"
   printf "l1\nl2\nl3" > $stub_file
   run pickfrom $stub_file
   assert_success
@@ -31,28 +34,30 @@ load ../../plugins/available/base.plugin
 }
 
 @test 'plugins base: mkcd()' {
-  cd "${BASH_IT_ROOT}"
+  cd "${BATS_TEST_TMPDIR}"
   declare -r dir_name="-dir_with_dash"
 
   # Make sure that the directory does not exist prior to the test
-  rm -rf "${BASH_IT_ROOT}/${dir_name}"
+  rm -rf "${BATS_TEST_TMPDIR}/${dir_name}"
+
+  run mkcd "${dir_name}"
+  assert_success
+  assert_dir_exist "${BATS_TEST_TMPDIR}/${dir_name}"
 
   mkcd "${dir_name}"
-  assert_success
-  assert_dir_exist "${BASH_IT_ROOT}/${dir_name}"
-  assert_equal "${PWD}" "${BASH_IT_ROOT//\/\///}/${dir_name}"
+  assert_equal "${PWD}" "${BATS_TEST_TMPDIR//\/\///}/${dir_name}"
 }
 
 @test 'plugins base: lsgrep()' {
-  for i in 1 2 3; do mkdir -p "${BASH_IT_TEST_DIR}/${i}"; done
-  cd $BASH_IT_TEST_DIR
+  for i in 1 2 3; do mkdir -p "${BASH_IT}/${i}"; done
+  cd $BASH_IT
   run lsgrep 2
   assert_success
   assert_equal $output 2
 }
 
 @test 'plugins base: buf()' {
-  declare -r file="${BASH_IT_ROOT}/file"
+  declare -r file="${BATS_TEST_TMPDIR}/file"
   touch $file
 
   # Take one timestamp before running the `buf` function

--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -8,10 +8,6 @@ function local_setup_file() {
 }
 
 @test 'plugins base: ips()' {
-  if [[ -n "${CI:-}" ]]; then
-    skip 'ifconfig probably requires sudo on TravisCI'
-  fi
-
   declare -r localhost='127.0.0.1'
   run ips
   assert_success

--- a/test/plugins/base.plugin.bats
+++ b/test/plugins/base.plugin.bats
@@ -1,9 +1,9 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
 load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup() {
-  setup_libs
+function local_setup_file() {
+  setup_libs "helpers"
   load "${BASH_IT?}/plugins/available/base.plugin.bash"
 }
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -195,14 +195,14 @@ function setup_acpi {
 # Creates a `upower` function that simulates output like the real `upower` command.
 # The passed in parameter is used for the remaining battery percentage.
 function setup_upower {
+	trap -p PIPE | grep -q PIPE || trap '' PIPE
 	percent="$1"
 	BAT0="/org/freedesktop/UPower/devices/battery_BAT$RANDOM"
 
 	function upower {
 		case $1 in
 		'-e'|'--enumerate')
-			# don't just `echo` twice because `grep` will close the pipe after matching the first line...
-			echo "$BAT0"$'\n'"/org/freedesktop/UPower/devices/mouse_hid_${RANDOM}_battery"
+			printf '%s\n' "$BAT0" "/org/freedesktop/UPower/devices/mouse_hid_${RANDOM}_battery"
 			;;
 		'-i'|'--show-info')
 			if [[ $2 == "$BAT0" ]]

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -195,7 +195,6 @@ function setup_acpi {
 # Creates a `upower` function that simulates output like the real `upower` command.
 # The passed in parameter is used for the remaining battery percentage.
 function setup_upower {
-	trap -p PIPE | grep -q PIPE || trap '' PIPE
 	percent="$1"
 	BAT0="/org/freedesktop/UPower/devices/battery_BAT$RANDOM"
 

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -1,9 +1,11 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-load ../../plugins/available/battery.plugin
+function local_setup_file() {
+  setup_libs "helpers"
+  load "${BASH_IT?}/plugins/available/battery.plugin.bash"
+}
 
 # Sets up the `_command_exists` function so that it only responds `true` if called with
 # the name of the function that was passed in as an argument to `setup_command_exists`.

--- a/test/plugins/cmd-returned-notify.plugin.bats
+++ b/test/plugins/cmd-returned-notify.plugin.bats
@@ -1,9 +1,11 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-load ../../plugins/available/cmd-returned-notify.plugin
+function local_setup_file() {
+  setup_libs "preexec" #"command_duration"
+  load "${BASH_IT?}/plugins/available/cmd-returned-notify.plugin.bash"
+}
 
 @test "plugins cmd-returned-notify: notify after elapsed time" {
     export NOTIFY_IF_COMMAND_RETURNS_AFTER=0

--- a/test/plugins/go.plugin.bats
+++ b/test/plugins/go.plugin.bats
@@ -1,11 +1,9 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup()
-{
-  setup_test_fixture
+function local_setup_file() {
+  setup_libs "helpers"
 }
 
 function setup_go_path()

--- a/test/plugins/ruby.plugin.bats
+++ b/test/plugins/ruby.plugin.bats
@@ -1,24 +1,15 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup {
-  setup_test_fixture
-
-  _command_exists "ruby" && mkdir -p "$(ruby -e 'print Gem.user_dir')/bin"
-
-  export OLD_PATH="$PATH"
-  export PATH="/usr/bin:/bin:/usr/sbin"
-}
-
-function local_teardown {
-  export PATH="$OLD_PATH"
-  unset OLD_PATH
+function local_setup_file() {
+  setup_libs "helpers"
 }
 
 @test "plugins ruby: remove_gem is defined" {
-  load ../../plugins/available/ruby.plugin
+  run load "${BASH_IT?}/plugins/available/ruby.plugin.bash"
+  assert_success
+  load "${BASH_IT?}/plugins/available/ruby.plugin.bash"
 
   run type remove_gem
   assert_line -n 1 "remove_gem () "
@@ -31,7 +22,9 @@ function local_teardown {
 
   mkdir -p "$(ruby -e 'print Gem.user_dir')/bin"
 
-  load ../../plugins/available/ruby.plugin
+  run load "${BASH_IT?}/plugins/available/ruby.plugin.bash"
+  assert_success
+  load "${BASH_IT?}/plugins/available/ruby.plugin.bash"
 
   local last_path_entry="$(tail -1 <<<"${PATH//:/$'\n'}")"
   [[ "${last_path_entry}" == "$(ruby -e 'print Gem.user_dir')/bin" ]]

--- a/test/plugins/xterm.plugin.bats
+++ b/test/plugins/xterm.plugin.bats
@@ -1,21 +1,10 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-load ../../plugins/available/xterm.plugin
-
-function local_setup {
-  setup_test_fixture
-
-  # Copy the test fixture to the Bash-it folder
-  if _command_exists rsync; then
-    rsync -a "$BASH_IT/test/fixtures/plugin/xterm/" "$BASH_IT/"
-  else
-    find "$BASH_IT/test/fixtures/plugin/xterm" \
-      -mindepth 1 -maxdepth 1 \
-      -exec cp -r {} "$BASH_IT/" \;
-  fi
+function local_setup_file() {
+  setup_libs "helpers"
+  load "${BASH_IT?}/plugins/available/xterm.plugin.bash"
 }
 
 @test "plugins xterm: shorten command output" {

--- a/test/run
+++ b/test/run
@@ -2,17 +2,23 @@
 test_directory="$(cd "$(dirname "$0")" && pwd)"
 bats_executable="${test_directory}/../test_lib/bats-core/bin/bats"
 
+# Locate ourselves for easy reference.
+export MAIN_BASH_IT_DIR="${test_directory%/*}"
+export MAIN_BASH_IT_GITDIR="${MAIN_BASH_IT_DIR}/.git"
+
+# Make sure BATS is available:
 git submodule init && git submodule update
 
-if [[ -z "${BASH_IT}" ]]; then
-	BASH_IT="$(cd "${test_directory}" && dirname "${PWD}")"
-	export BASH_IT
+# Warn user that tests run from the current git HEAD
+if ! git diff --quiet; then
+	echo "${BASH_SOURCE##*/}: your worktree is dirty; uncommitted changes will *not* be tested!"
 fi
 
-if [[ -z "$1" ]]; then
+# Which tests do we run?
+if [[ $# -eq '0' ]]; then
 	test_dirs=("${test_directory}"/{bash_it,completion,install,lib,plugins,themes})
 else
-	test_dirs=("$1")
+	test_dirs=("$@")
 fi
 
 # Make sure that the `parallel` command is installed,
@@ -41,5 +47,5 @@ if command -v parallel &> /dev/null \
 		"${test_dirs[@]}"
 else
 	# Run `bats` in single-threaded mode.
-	exec "$bats_executable" ${CI:+--tap} "${test_dirs[@]}"
+	exec "$bats_executable" "${CI:+--tap}" "${test_dirs[@]}"
 fi

--- a/test/run
+++ b/test/run
@@ -44,7 +44,7 @@ if command -v parallel &> /dev/null \
 		fi
 	)"
 	exec "$bats_executable" "${CI:+--tap}" --jobs "${test_jobs_effective}" \
-		"${test_dirs[@]}"
+		--no-parallelize-within-files "${test_dirs[@]}"
 else
 	# Run `bats` in single-threaded mode.
 	exec "$bats_executable" "${CI:+--tap}" "${test_dirs[@]}"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,105 +1,117 @@
-#!/usr/bin/env bats
-load "${BASH_IT}/vendor/github.com/erichs/composure/composure.sh"
+# shellcheck shell=bash
 
-unset BASH_IT_THEME
-unset GIT_HOSTING
-unset NGINX_PATH
-unset IRC_CLIENT
-unset TODO
-unset SCM_CHECK
-unset BASH_IT_AUTOMATIC_RELOAD_AFTER_CONFIG_CHANGE
-
-export TEST_MAIN_DIR="${BATS_TEST_DIRNAME}/.."
-export TEST_DEPS_DIR="${TEST_DEPS_DIR-${TEST_MAIN_DIR}/../test_lib}"
-
-# be independent of git's system configuration
-export GIT_CONFIG_NOSYSTEM
-
-load "${TEST_DEPS_DIR}/bats-support/load.bash"
-load "${TEST_DEPS_DIR}/bats-assert/load.bash"
-load "${TEST_DEPS_DIR}/bats-file/load.bash"
-
-# support 'plumbing' metadata
-cite _about _param _example _group _author _version
-cite about-alias about-plugin about-completion
-
-local_setup() {
-	true
+function setup_file() {
+	common_setup_file
 }
 
-local_teardown() {
-	true
-}
+function common_setup_file() {
+	# export *everything* to subshells, needed to support tests
+	set -a
 
-# This function sets up a local test fixture, i.e. a completely
-# fresh and isolated Bash-it directory. This is done to avoid
-# messing with your own Bash-it source directory.
-# If you need this, call it in your .bats file's `local_setup` function.
-setup_test_fixture() {
-	mkdir -p "$BASH_IT"
-	lib_directory="$(cd "$(dirname "$0")" && pwd)"
-	local src_topdir="$lib_directory/../../../.."
+	# Locate ourselves for easy reference.
+	TEST_MAIN_DIR="${MAIN_BASH_IT_DIR:-${BATS_TEST_DIRNAME?}/../..}/test"
+	TEST_DEPS_DIR="${MAIN_BASH_IT_DIR:-${TEST_MAIN_DIR}/..}/test_lib"
 
-	if command -v rsync &> /dev/null; then
-		# Use rsync to copy Bash-it to the temp folder
-		rsync -qavrKL -d --delete-excluded --exclude=.git --exclude=helper.bash --exclude=enabled "$src_topdir" "$BASH_IT"
-	else
-		rm -rf "$BASH_IT"
-		mkdir -p "$BASH_IT"
+	# Load the BATS modules we use:
+	load "${TEST_DEPS_DIR}/bats-support/load.bash"
+	load "${TEST_DEPS_DIR}/bats-assert/load.bash"
+	load "${TEST_DEPS_DIR}/bats-file/load.bash"
 
-		find "$src_topdir" \
-			-mindepth 1 -maxdepth 1 \
-			-not -name .git \
-			-exec cp -r {} "$BASH_IT" \;
-	fi
-
-	rm -rf "$BASH_IT"/enabled
-	rm -rf "$BASH_IT"/aliases/enabled
-	rm -rf "$BASH_IT"/completion/enabled
-	rm -rf "$BASH_IT"/plugins/enabled
-
-	mkdir -p "$BASH_IT"/enabled
-	mkdir -p "$BASH_IT"/aliases/enabled
-	mkdir -p "$BASH_IT"/completion/enabled
-	mkdir -p "$BASH_IT"/plugins/enabled
-
-	# Some tests use the BASH_IT_TEST_HOME variable, e.g. install/uninstall
-	export BASH_IT_TEST_HOME="$TEST_TEMP_DIR"
-}
-
-setup() {
-	# The `temp_make` function from "bats-file" requires the tralston/bats-file fork,
-	# since the original ztombol/bats-file's `temp_make` does not work on macOS.
-	TEST_TEMP_DIR="$(temp_make --prefix 'bash-it-test-')"
-	export TEST_TEMP_DIR
-
-	export BASH_IT_TEST_DIR="${TEST_TEMP_DIR}/.bash_it"
-
-	export BASH_IT_ROOT="${BASH_IT_TEST_DIR}/root"
-	export BASH_IT=$BASH_IT_TEST_DIR
-
-	mkdir -p -- "${BASH_IT_ROOT}"
+	# shellcheck disable=SC2034 # Clear any inherited environment:
+	XDG_DUMMY="" BASH_IT_DUMMY=""    # avoid possible invalid reference:
+	unset "${!XDG_@}" "${!BASH_IT@}" # unset all BASH_IT* and XDG_* variables
+	unset GIT_HOSTING NGINX_PATH IRC_CLIENT TODO SCM_CHECK
 
 	# Some tools, e.g. `git` use configuration files from the $HOME directory,
-	# which interferes with our tests. The only way to keep `git` from doing this
-	# seems to set HOME explicitly to a separate location.
+	# which interferes with our tests. The only way to keep `git` from doing
+	# this seems to set HOME explicitly to a separate location.
 	# Refer to https://git-scm.com/docs/git-config#FILES.
-	unset XDG_CONFIG_HOME
-	export HOME="${TEST_TEMP_DIR}"
+	readonly HOME="${BATS_SUITE_TMPDIR?}"
 	mkdir -p "${HOME}"
 
 	# For `git` tests to run well, user name and email need to be set.
 	# Refer to https://git-scm.com/docs/git-commit#_commit_information.
 	# This goes to the test-specific config, due to the $HOME overridden above.
-	git config --global user.name "John Doe"
-	git config --global user.email "johndoe@example.com"
+	git config --global user.name "Bash It BATS Runner"
+	git config --global user.email "bats@bash.it"
+	git config --global advice.detachedHead false
+	git config --global init.defaultBranch "master"
 
+	# Locate the temporary folder, avoid double-slash.
+	BASH_IT="${BATS_FILE_TMPDIR//\/\///}/.bash_it"
+
+	# This sets up a local test fixture, i.e. a completely fresh and isolated Bash-it directory. This is done to avoid messing with your own Bash-it source directory.
+	git --git-dir="${MAIN_BASH_IT_GITDIR?}" worktree add -d "${BASH_IT}"
+
+	load "${BASH_IT?}/vendor/github.com/erichs/composure/composure.sh"
+	# support 'plumbing' metadata
+	cite _about _param _example _group _author _version
+	cite about-alias about-plugin about-completion
+
+	# Run any local test setup
+	local_setup_file
+	set +a # not needed, but symetiric!
+}
+
+# Load standard _Bash It_ libraries
+function setup_libs() {
+	local lib
+	# Use a loop to allow convenient short-circuiting for some test files
+	for lib in "log" "utilities" "helpers" "search" "preexec" "colors"; do
+		load "${BASH_IT?}/lib/${lib}.bash" || return
+		# shellcheck disable=SC2015 # short-circuit if we've reached the requested library
+		[[ "${lib}" == "${1:-}" ]] && return 0 || true
+	done
+	return 0
+}
+
+function local_setup_file() {
+	true
+}
+
+function local_setup() {
+	true
+}
+
+function local_teardown() {
+	true
+}
+
+function clean_test_fixture() {
+	rm -rf "${BASH_IT_CONFIG?}/enabled"
+	rm -rf "${BASH_IT_CONFIG?}/aliases/enabled"
+	rm -rf "${BASH_IT_CONFIG?}/completion/enabled"
+	rm -rf "${BASH_IT_CONFIG?}/plugins/enabled"
+
+	rm -rf "${BASH_IT_CONFIG?}/tmp/cache"
+	rm -rf "${BASH_IT_CONFIG?}/profiles"/test*.bash_it
+}
+
+function setup_test_fixture() {
+	mkdir -p "${BASH_IT_CONFIG?}/enabled"
+	mkdir -p "${BASH_IT_CONFIG?}/aliases/enabled"
+	mkdir -p "${BASH_IT_CONFIG?}/completion/enabled"
+	mkdir -p "${BASH_IT_CONFIG?}/plugins/enabled"
+}
+
+function setup() {
+	# be independent of git's system configuration
+	export GIT_CONFIG_NOSYSTEM
+	# Locate the temporary folder:
+	BASH_IT_CONFIG="${BASH_IT?}" #"${BATS_TEST_TMPDIR//\/\///}"
+	export XDG_CACHE_HOME="${BATS_TEST_TMPDIR?}"
+
+	setup_test_fixture
 	local_setup
 }
 
-teardown() {
+function teardown() {
+	unset GIT_CONFIG_NOSYSTEM
 	local_teardown
+	clean_test_fixture
+}
 
-	rm -rf "${BASH_IT_TEST_DIR}"
-	temp_del "${TEST_TEMP_DIR}"
+function teardown_file() {
+	# This only serves to clean metadata from the real git repo.
+	git --git-dir="${MAIN_BASH_IT_GITDIR?}" worktree remove -f "${BASH_IT?}"
 }

--- a/test/test_helper_libs.bash
+++ b/test/test_helper_libs.bash
@@ -1,8 +1,0 @@
-# shellcheck shell=bash
-
-load "${BASH_IT}/lib/log.bash"
-load "${BASH_IT}/lib/utilities.bash"
-load "${BASH_IT}/lib/helpers.bash"
-load "${BASH_IT}/lib/search.bash"
-load "${BASH_IT}/lib/preexec.bash"
-load "${BASH_IT}/lib/colors.bash"

--- a/test/themes/base.theme.bats
+++ b/test/themes/base.theme.bats
@@ -1,8 +1,11 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
-load ../../themes/base.theme
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup_file() {
+  setup_libs "colors" #"theme"
+  load "${BASH_IT?}/themes/base.theme.bash"
+}
 
 @test 'themes base: battery_percentage should not exist' {
   run type -a battery_percentage &> /dev/null
@@ -10,7 +13,7 @@ load ../../themes/base.theme
 }
 
 @test 'themes base: battery_percentage should exist if battery plugin loaded' {
-  load ../../plugins/available/battery.plugin
+  load "${BASH_IT?}/plugins/available/battery.plugin.bash"
 
   run type -a battery_percentage &> /dev/null
   assert_success
@@ -28,12 +31,12 @@ load ../../themes/base.theme
 @test 'themes base: battery_char should exist if battery plugin loaded' {
   unset -f battery_char
 
-  load ../../plugins/available/battery.plugin
+  load "${BASH_IT?}/plugins/available/battery.plugin.bash"
   run type -t battery_percentage
   assert_success
   assert_line "function"
 
-  load ../../themes/base.theme
+  load "${BASH_IT?}/themes/base.theme.bash"
   run type -t battery_char
   assert_success
   assert_line "function"
@@ -51,13 +54,13 @@ load ../../themes/base.theme
 
   run battery_charge
   assert_success
-  assert_line -n 0 ""
+  assert_output ""
 }
 
 @test 'themes base: battery_charge should exist if battery plugin loaded' {
   unset -f battery_charge
-  load ../../plugins/available/battery.plugin
-  load ../../themes/base.theme
+  load "${BASH_IT?}/plugins/available/battery.plugin.bash"
+  load "${BASH_IT?}/themes/base.theme.bash"
 
   run type -a battery_charge &> /dev/null
   assert_success

--- a/test/themes/base.theme.git.bats
+++ b/test/themes/base.theme.git.bats
@@ -1,9 +1,14 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
+# shellcheck disable=SC2034
+# shellcheck disable=SC2016
 
-load ../test_helper
-load ../test_helper_libs
-load ../../themes/githelpers.theme
-load ../../themes/base.theme
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup_file() {
+  setup_libs "colors" #"theme"
+  load "${BASH_IT?}/themes/base.theme.bash"
+  load "${BASH_IT?}/themes/githelpers.theme.bash"
+}
 
 add_commit() {
   local file_name="general-${RANDOM}"

--- a/test/themes/base.theme.svn.bats
+++ b/test/themes/base.theme.svn.bats
@@ -1,29 +1,10 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 
-load ../test_helper
-load ../test_helper_libs
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
 
-function local_setup {
-  setup_test_fixture
-
-  # Copy the test fixture to the Bash-it folder
-  if command -v rsync &> /dev/null
-  then
-    rsync -a "$BASH_IT/test/fixtures/bash_it/" "$BASH_IT/"
-  else
-    find "$BASH_IT/test/fixtures/bash_it" \
-      -mindepth 1 -maxdepth 1 \
-      -exec cp -r {} "$BASH_IT/" \;
-  fi
-
-  export OLD_PATH="$PATH"
-
-  load ../../themes/base.theme
-}
-
-function local_teardown {
-  export PATH="$OLD_PATH"
-  unset OLD_PATH
+function local_setup_file() {
+  setup_libs "colors" #"theme"
+  load "${BASH_IT?}/themes/base.theme.bash"
 }
 
 function setup_repo {


### PR DESCRIPTION
## Description
- Apply recommendations from BATS documentation to the boilerplate in the test files, 
- refactor large parts of `test_helper.bash`,
- use `git worktree` for a fast, reliable, and predictable test environment,
- remove dependency on `test_make`,
- make working tree stand up per-file, rather than per-test, so it's much faster,
- standardize test fixture staging,
- don't ever access my local `$HOME` or local `$BASH_IT`,
- update `bats-core` to tag `v1.5.0`.

I believe this closes #1821.

## Motivation and Context
This is chapter 2 of my last BATS patch. This time I understand BATS slightly better!

I disabled intra-file parallelization, but this can be reverted as soon as configuration is no longer inside the repo. 

This alsö should resolve the drive behind #1753, as the test environment is now separated from the live repository. 

## How Has This Been Tested?
Lots and lots of running `test/run`...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
