### PR TITLE
README: Display latest build status from default branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ![logo](https://github.com/Bash-it/media/raw/master/media/Bash-it.png)
 
-![Build Status](https://github.com/Bash-it/bash-it/workflows/CI/badge.svg?branch=master)
+![Build Status](../../../workflows/CI/badge.svg?event=push)
 ![Docs Status](https://readthedocs.org/projects/bash-it/badge/)
 ![License](https://img.shields.io/github/license/Bash-it/bash-it)
 ![shell](https://img.shields.io/badge/Shell-Bash-blue)


### PR DESCRIPTION
## Description
This displays the build/test status of the latest commit the default branch, not neccessarily `master` branch, from whichever fork it's read from.

## Motivation and Context
The test suite on my fork is broken (due to my not merging all my branches cleanly for my own main branch), but on the rare occasion I clicked on my own repo online it would show a clean build! This fixes it so that the badge is displayed from the *current* repository, and from the default branch.

## How Has This Been Tested?
Works for me!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
