### PR TITLE
theme/pete: `shellcheck` && `shfmt`

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -150,6 +150,7 @@ themes/command_duration.theme.bash
 themes/easy
 themes/essential
 themes/modern
+themes/pete
 themes/powerline
 themes/pure
 themes/purity

--- a/themes/pete/pete.theme.bash
+++ b/themes/pete/pete.theme.bash
@@ -1,11 +1,16 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2034 # Expected behavior for themes.
 
-prompt_setter() {
-  # Save history
-  _save-and-reload-history 1
-  PS1="($(clock_prompt)) $(scm_char) [$blue\u$reset_color@$green\H$reset_color] $yellow\w${reset_color}$(scm_prompt_info)$(ruby_version_prompt) $reset_color "
-  PS2='> '
-  PS4='+ '
+function prompt_setter() {
+	local clock_prompt scm_char scm_prompt_info ruby_version_prompt
+	clock_prompt="$(clock_prompt)"
+	scm_char="$(scm_char)"
+	scm_prompt_info="$(scm_prompt_info)"
+	ruby_version_prompt="$(ruby_version_prompt)"
+	_save-and-reload-history 1 # Save history
+	PS1="(${clock_prompt}) ${scm_char} [${blue?}\u${reset_color?}@${green?}\H${reset_color?}] ${yellow?}\w${reset_color?}${scm_prompt_info}${ruby_version_prompt} ${reset_color?} "
+	PS2='> '
+	PS4='+ '
 }
 
 safe_append_prompt_command prompt_setter


### PR DESCRIPTION
## Description
Simplify Pete's `prompt_setter()` a little. It's more verbose, but it's clearer what's what.

## Motivation and Context
Simplicity, clarity, and #1696.

## How Has This Been Tested?
`bash-it preview pete`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
