### PR TITLE
completion/dotnet: new completion

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -47,6 +47,7 @@ completion/available/django.completion.bash
 completion/available/dmidecode.completion.bash
 completion/available/docker-machine.completion.bash
 completion/available/docker.completion.bash
+completion/available/dotnet.completion.bash
 completion/available/gcloud.completion.bash
 completion/available/gem.completion.bash
 completion/available/git.completion.bash

--- a/completion/available/dotnet.completion.bash
+++ b/completion/available/dotnet.completion.bash
@@ -2,17 +2,13 @@
 about-completion "bash parameter completion for the dotnet CLI"
 # see https://docs.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#bash
 
-_dotnet_bash_complete()
-{
-  local word=${COMP_WORDS[COMP_CWORD]}
+function _dotnet_bash_complete() {
+	local cur="${COMP_WORDS[COMP_CWORD]}" IFS=$'\n'
+	local candidates
 
-  local completions
-  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)"
-  if [ $? -ne 0 ]; then
-    completions=""
-  fi
+	read -d '' -ra candidates < <(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2> /dev/null)
 
-  COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+	read -d '' -ra COMPREPLY < <(compgen -W "${candidates[*]:-}" -- "$cur")
 }
 
 complete -f -F _dotnet_bash_complete dotnet

--- a/completion/available/dotnet.completion.bash
+++ b/completion/available/dotnet.completion.bash
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+about-completion "bash parameter completion for the dotnet CLI"
+# see https://docs.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#bash
+
+_dotnet_bash_complete()
+{
+  local word=${COMP_WORDS[COMP_CWORD]}
+
+  local completions
+  completions="$(dotnet complete --position "${COMP_POINT}" "${COMP_LINE}" 2>/dev/null)"
+  if [ $? -ne 0 ]; then
+    completions=""
+  fi
+
+  COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+}
+
+complete -f -F _dotnet_bash_complete dotnet


### PR DESCRIPTION
## Description
This sets up `dotnet` to complete itself according to [vendor documentation]( https://docs.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#bash ).

This closes #1983.

## Motivation and Context
I'm a big fan of tools completing themselves!

## How Has This Been Tested?
I've tested this, and alsö opened an issue upstream to improve their example: dotnet/docs#27828.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
