### PR TITLE
CI: fix version of OSX runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,13 @@
 name: CI
 
 # Triggers the workflow on push or pull request events
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   bats-test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11.0]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-10.15, macos-11]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Description
Now that Mac OS X is "version 11", the "minor" version is no longer relevant.

Alsö, clean up the run conditions.

## Motivation and Context
We've been running on the initial-release version for months.

## How Has This Been Tested?
All tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
