### PR TITLE
lib/reloader: lint and modernize

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -18,6 +18,7 @@
 #
 docs/
 hooks/
+scripts/
 
 # root files
 #

--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -1,14 +1,6 @@
 #!/bin/bash
 BASH_IT_LOG_PREFIX="core: reloader: "
 
-function _set-prefix-based-on-path()
-{
-  filename=$(_bash-it-get-component-name-from-path "$1")
-  extension=$(_bash-it-get-component-type-from-path "$1")
-	# shellcheck disable=SC2034
-  BASH_IT_LOG_PREFIX="$extension: $filename: "
-}
-
 if [[ "$1" != "skip" ]] && [[ -d "$BASH_IT/enabled" ]]; then
   _bash_it_config_type=""
 
@@ -22,7 +14,7 @@ if [[ "$1" != "skip" ]] && [[ -d "$BASH_IT/enabled" ]]; then
 
   for _bash_it_config_file in $(sort <(compgen -G "$BASH_IT/enabled/*${_bash_it_config_type}.bash")); do
     if [ -e "${_bash_it_config_file}" ]; then
-      _set-prefix-based-on-path "${_bash_it_config_file}"
+      _bash-it-log-prefix-by-path "${_bash_it_config_file}"
       _log_debug "Loading component..."
       # shellcheck source=/dev/null
       source $_bash_it_config_file
@@ -38,7 +30,7 @@ if [[ -n "${2}" ]] && [[ -d "$BASH_IT/${2}/enabled" ]]; then
       _log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
       for _bash_it_config_file in $(sort <(compgen -G "$BASH_IT/${2}/enabled/*.bash")); do
         if [[ -e "$_bash_it_config_file" ]]; then
-          _set-prefix-based-on-path "${_bash_it_config_file}"
+          _bash-it-log-prefix-by-path "${_bash_it_config_file}"
           _log_debug "Loading component..."
           # shellcheck source=/dev/null
           source "$_bash_it_config_file"

--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -1,44 +1,53 @@
-#!/bin/bash
+# shellcheck shell=bash
+#
+# The core component loader.
+
+# shellcheck disable=SC2034
 BASH_IT_LOG_PREFIX="core: reloader: "
 
-if [[ "$1" != "skip" ]] && [[ -d "$BASH_IT/enabled" ]]; then
-  _bash_it_config_type=""
+if [[ "${1:-}" != "skip" ]] && [[ -d "${BASH_IT?}/enabled" ]]; then
+	_bash_it_config_type=""
 
-  case $1 in
-    alias|completion|plugin)
-      _bash_it_config_type=$1
-      _log_debug "Loading enabled $1 components..." ;;
-    ''|*)
-      _log_debug "Loading all enabled components..." ;;
-  esac
+	case $1 in
+		alias | completion | plugin)
+			_bash_it_config_type=$1
+			_log_debug "Loading enabled $1 components..."
+			;;
+		'' | *)
+			_log_debug "Loading all enabled components..."
+			;;
+	esac
 
-  for _bash_it_config_file in $(sort <(compgen -G "$BASH_IT/enabled/*${_bash_it_config_type}.bash")); do
-    if [ -e "${_bash_it_config_file}" ]; then
-      _bash-it-log-prefix-by-path "${_bash_it_config_file}"
-      _log_debug "Loading component..."
-      # shellcheck source=/dev/null
-      source $_bash_it_config_file
-    else
-      echo "Unable to read ${_bash_it_config_file}" > /dev/stderr
-    fi
-  done
+	for _bash_it_config_file in "$BASH_IT/enabled"/*"${_bash_it_config_type}.bash"; do
+		if [[ -e "${_bash_it_config_file}" ]]; then
+			_bash-it-log-prefix-by-path "${_bash_it_config_file}"
+			_log_debug "Loading component..."
+			# shellcheck source=/dev/null
+			source "$_bash_it_config_file"
+			_log_debug "Loaded."
+		else
+			_log_error "Unable to read ${_bash_it_config_file}"
+		fi
+	done
 fi
 
-if [[ -n "${2}" ]] && [[ -d "$BASH_IT/${2}/enabled" ]]; then
-  case $2 in
-    aliases|completion|plugins)
-      _log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
-      for _bash_it_config_file in $(sort <(compgen -G "$BASH_IT/${2}/enabled/*.bash")); do
-        if [[ -e "$_bash_it_config_file" ]]; then
-          _bash-it-log-prefix-by-path "${_bash_it_config_file}"
-          _log_debug "Loading component..."
-          # shellcheck source=/dev/null
-          source "$_bash_it_config_file"
-        else
-          echo "Unable to locate ${_bash_it_config_file}" > /dev/stderr
-        fi
-      done ;;
-  esac
+if [[ -n "${2:-}" ]] && [[ -d "$BASH_IT/${2}/enabled" ]]; then
+	case $2 in
+		aliases | completion | plugins)
+			_log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
+			for _bash_it_config_file in "$BASH_IT/${2}/enabled"/*.bash; do
+				if [[ -e "$_bash_it_config_file" ]]; then
+					_bash-it-log-prefix-by-path "${_bash_it_config_file}"
+					_log_debug "Loading component..."
+					# shellcheck source=/dev/null
+					source "$_bash_it_config_file"
+					_log_debug "Loaded."
+				else
+					_log_error "Unable to locate ${_bash_it_config_file}"
+				fi
+			done
+			;;
+	esac
 fi
 
 unset _bash_it_config_file

--- a/scripts/reloader.bash
+++ b/scripts/reloader.bash
@@ -4,13 +4,12 @@
 
 # shellcheck disable=SC2034
 BASH_IT_LOG_PREFIX="core: reloader: "
+_bash_it_reloader_type=""
 
 if [[ "${1:-}" != "skip" ]] && [[ -d "${BASH_IT?}/enabled" ]]; then
-	_bash_it_config_type=""
-
 	case $1 in
 		alias | completion | plugin)
-			_bash_it_config_type=$1
+			_bash_it_reloader_type=$1
 			_log_debug "Loading enabled $1 components..."
 			;;
 		'' | *)
@@ -18,15 +17,15 @@ if [[ "${1:-}" != "skip" ]] && [[ -d "${BASH_IT?}/enabled" ]]; then
 			;;
 	esac
 
-	for _bash_it_config_file in "$BASH_IT/enabled"/*"${_bash_it_config_type}.bash"; do
-		if [[ -e "${_bash_it_config_file}" ]]; then
-			_bash-it-log-prefix-by-path "${_bash_it_config_file}"
+	for _bash_it_reloader_file in "$BASH_IT/enabled"/*"${_bash_it_reloader_type}.bash"; do
+		if [[ -e "${_bash_it_reloader_file}" ]]; then
+			_bash-it-log-prefix-by-path "${_bash_it_reloader_file}"
 			_log_debug "Loading component..."
 			# shellcheck source=/dev/null
-			source "$_bash_it_config_file"
+			source "$_bash_it_reloader_file"
 			_log_debug "Loaded."
 		else
-			_log_error "Unable to read ${_bash_it_config_file}"
+			_log_error "Unable to read ${_bash_it_reloader_file}"
 		fi
 	done
 fi
@@ -35,20 +34,19 @@ if [[ -n "${2:-}" ]] && [[ -d "$BASH_IT/${2}/enabled" ]]; then
 	case $2 in
 		aliases | completion | plugins)
 			_log_warning "Using legacy enabling for $2, please update your bash-it version and migrate"
-			for _bash_it_config_file in "$BASH_IT/${2}/enabled"/*.bash; do
-				if [[ -e "$_bash_it_config_file" ]]; then
-					_bash-it-log-prefix-by-path "${_bash_it_config_file}"
+			for _bash_it_reloader_file in "$BASH_IT/${2}/enabled"/*.bash; do
+				if [[ -e "$_bash_it_reloader_file" ]]; then
+					_bash-it-log-prefix-by-path "${_bash_it_reloader_file}"
 					_log_debug "Loading component..."
 					# shellcheck source=/dev/null
-					source "$_bash_it_config_file"
+					source "$_bash_it_reloader_file"
 					_log_debug "Loaded."
 				else
-					_log_error "Unable to locate ${_bash_it_config_file}"
+					_log_error "Unable to locate ${_bash_it_reloader_file}"
 				fi
 			done
 			;;
 	esac
 fi
 
-unset _bash_it_config_file
-unset _bash_it_config_type
+unset "${!_bash_it_reloader_@}"


### PR DESCRIPTION
## Description
- adopt `_bash-it-log-prefix-by-path()`,
- `shfmt`,
- `shellcheck`,
<!-- - replace the legacy loop with a call to `_bash-it-migrate()`. -->

## Motivation and Context
Trying to get this thing to run with spaces in path...

## How Has This Been Tested?
This has been part of my main branch since September...

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
