### PR TITLE
fix wrong function name call  in `helpers.bash`

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -814,7 +814,7 @@ _disable-thing ()
     _bash-it-clean-component-cache "${file_type}"
 
     if [ "$file_entity" = "all" ]; then
-      printf '%s\n' "$file_entity $(_bash-it-pluralize-component "$file_type") disabled."
+      printf '%s\n' "$file_entity $(_bash-it-component-pluralize "$file_type") disabled."
     else
       printf '%s\n' "$file_entity disabled."
     fi


### PR DESCRIPTION
when i tried to install, i got a message `_bash-it-pluralize-component` command not found; after checking `utilities.bash` the correct function name was `_bash-it-component-pluralize`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
