### PR TITLE
theme/powerline base: cleanup and incorporate defaults

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -286,7 +286,8 @@ function __powerline_prompt_command() {
 	fi
 
 	## left prompt ##
-	for segment in ${POWERLINE_PROMPT-"user_info" "scm" "python_venv" "ruby" "node" "cwd"}; do
+	# shellcheck disable=SC2068 # intended behavior
+	for segment in ${POWERLINE_PROMPT[@]-"user_info" "scm" "python_venv" "ruby" "node" "cwd"}; do
 		info="$("__powerline_${segment}_prompt")"
 		[[ -n "${info}" ]] && __powerline_left_segment "${info}"
 	done

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -9,14 +9,16 @@ function set_color() {
 	fi
 	if [[ "${2:-}" != "-" ]]; then
 		bg="48;5;${2}"
-		[[ -n "${fg}" ]] && bg=";${bg}"
+		if [[ -n "${fg}" ]]; then
+			bg=";${bg}"
+		fi
 	fi
-	echo -e "\[\033[${fg}${bg}m\]"
+	printf '\[\\e[%s%sm\]' "${fg}" "${bg}"
 }
 
 #Customising User Info Segment
 function __powerline_user_info_prompt() {
-	local user_info="${SHORT_USER:-${USER}}"
+	local user_info='\u'
 	local color=${USER_INFO_THEME_PROMPT_COLOR-${POWERLINE_USER_INFO_COLOR-"32"}}
 
 	if [[ "${THEME_CHECK_SUDO:-false}" == true ]]; then
@@ -32,12 +34,12 @@ function __powerline_user_info_prompt() {
 			fi
 			;;
 		*)
-			if [[ -n "${SSH_CLIENT:-}" ]] || [[ -n "${SSH_CONNECTION:-}" ]]; then
-				user_info="${USER_INFO_SSH_CHAR-${POWERLINE_USER_INFO_SSH_CHAR-"⌁ "}}${user_info}"
+			if [[ -n "${SSH_CLIENT:-}" || -n "${SSH_CONNECTION:-}" ]]; then
+				user_info="${USER_INFO_SSH_CHAR-${POWERLINE_USER_INFO_SSH_CHAR-"⌁"}}${user_info}"
 			fi
 			;;
 	esac
-	echo "${user_info}|${color}"
+	printf '%s|%s' "${user_info}" "${color}"
 }
 
 function __powerline_terraform_prompt() {
@@ -45,7 +47,9 @@ function __powerline_terraform_prompt() {
 
 	if [[ -d .terraform ]]; then
 		terraform_workspace="$(terraform_workspace_prompt)"
-		[[ -n "${terraform_workspace}" ]] && echo "${TERRAFORM_CHAR-${POWERLINE_TERRAFORM_CHAR-"❲t❳ "}}${terraform_workspace}|${TERRAFORM_THEME_PROMPT_COLOR-${POWERLINE_TERRAFORM_COLOR-"161"}}"
+		if [[ -n "${terraform_workspace}" ]]; then
+			printf '%s%s|%s' "${TERRAFORM_CHAR-${POWERLINE_TERRAFORM_CHAR-"❲t❳"}}" "${terraform_workspace}" "${TERRAFORM_THEME_PROMPT_COLOR-${POWERLINE_TERRAFORM_COLOR-"161"}}"
+		fi
 	fi
 }
 
@@ -53,14 +57,18 @@ function __powerline_gcloud_prompt() {
 	local active_gcloud_account=""
 
 	active_gcloud_account="$(active_gcloud_account_prompt)"
-	[[ -n "${active_gcloud_account}" ]] && echo "${GCLOUD_CHAR-${POWERLINE_GCLOUD_CHAR-"❲G❳ "}}${active_gcloud_account}|${GCLOUD_THEME_PROMPT_COLOR-${POWERLINE_GCLOUD_COLOR-"161"}}"
+	if [[ -n "${active_gcloud_account}" ]]; then
+		printf '%s%s|%s' "${GCLOUD_CHAR-${POWERLINE_GCLOUD_CHAR-"❲G❳"}}" "${active_gcloud_account}" "${GCLOUD_THEME_PROMPT_COLOR-${POWERLINE_GCLOUD_COLOR-"161"}}"
+	fi
 }
 
 function __powerline_node_prompt() {
 	local node_version=""
 
 	node_version="$(node_version_prompt)"
-	[[ -n "${node_version}" ]] && echo "${NODE_CHAR-${POWERLINE_NODE_CHAR-="❲n❳ "}}${node_version}|${NODE_THEME_PROMPT_COLOR-${POWERLINE_NODE_COLOR-"22"}}"
+	if [[ -n "${node_version}" ]]; then
+		printf '%s%s|%s' "${NODE_CHAR-${POWERLINE_NODE_CHAR-="❲n❳"}}" "${node_version}" "${NODE_THEME_PROMPT_COLOR-${POWERLINE_NODE_COLOR-"22"}}"
+	fi
 }
 
 #Customising Ruby Prompt
@@ -74,7 +82,7 @@ function __powerline_ruby_prompt() {
 	fi
 
 	if [[ -n "${ruby_version:-}" ]]; then
-		echo "${RUBY_CHAR-${POWERLINE_RUBY_CHAR-"💎 "}}${ruby_version}|${RUBY_THEME_PROMPT_COLOR-${POWERLINE_RUBY_COLOR-"161"}}"
+		printf '%s%s|%s' "${RUBY_CHAR-${POWERLINE_RUBY_CHAR-"💎"}}" "${ruby_version}" "${RUBY_THEME_PROMPT_COLOR-${POWERLINE_RUBY_COLOR-"161"}}"
 	fi
 }
 
@@ -85,7 +93,9 @@ function __powerline_k8s_context_prompt() {
 		kubernetes_context="$(k8s_context_prompt)"
 	fi
 
-	[[ -n "${kubernetes_context}" ]] && echo "${KUBERNETES_CONTEXT_THEME_CHAR-${POWERLINE_KUBERNETES_CONTEXT_CHAR-"⎈ "}}${kubernetes_context}|${KUBERNETES_CONTEXT_THEME_PROMPT_COLOR-${POWERLINE_KUBERNETES_CONTEXT_COLOR-"26"}}"
+	if [[ -n "${kubernetes_context}" ]]; then
+		printf '%s%s|%s' "${KUBERNETES_CONTEXT_THEME_CHAR-${POWERLINE_KUBERNETES_CONTEXT_CHAR-"⎈"}}" "${kubernetes_context}" "${KUBERNETES_CONTEXT_THEME_PROMPT_COLOR-${POWERLINE_KUBERNETES_CONTEXT_COLOR-"26"}}"
+	fi
 }
 
 function __powerline_k8s_namespace_prompt() {
@@ -95,7 +105,9 @@ function __powerline_k8s_namespace_prompt() {
 		kubernetes_namespace="$(k8s_namespace_prompt)"
 	fi
 
-	[[ -n "${kubernetes_namespace}" ]] && echo "${KUBERNETES_NAMESPACE_THEME_CHAR-${POWERLINE_KUBERNETES_NAMESPACE_CHAR-"⎈ "}}${kubernetes_namespace}|${KUBERNETES_NAMESPACE_THEME_PROMPT_COLOR-${POWERLINE_KUBERNETES_NAMESPACE_COLOR-"60"}}"
+	if [[ -n "${kubernetes_namespace}" ]]; then
+		printf '%s%s|%s' "${KUBERNETES_NAMESPACE_THEME_CHAR-${POWERLINE_KUBERNETES_NAMESPACE_CHAR-"⎈"}}" "${kubernetes_namespace}" "${KUBERNETES_NAMESPACE_THEME_PROMPT_COLOR-${POWERLINE_KUBERNETES_NAMESPACE_COLOR-"60"}}"
+	fi
 }
 
 #Customising Python (venv) Prompt
@@ -104,12 +116,14 @@ function __powerline_python_venv_prompt() {
 
 	if [[ -n "${CONDA_DEFAULT_ENV:-}" ]]; then
 		python_venv="${CONDA_DEFAULT_ENV}"
-		local PYTHON_VENV_CHAR=${CONDA_PYTHON_VENV_CHAR-${POWERLINE_CONDA_PYTHON_VENV_CHAR-"ⓔ "}}
+		local PYTHON_VENV_CHAR=${CONDA_PYTHON_VENV_CHAR-${POWERLINE_CONDA_PYTHON_VENV_CHAR-"ⓔ"}}
 	elif [[ -n "${VIRTUAL_ENV:-}" ]]; then
 		python_venv="${VIRTUAL_ENV##*/}"
 	fi
 
-	[[ -n "${python_venv}" ]] && echo "${PYTHON_VENV_CHAR-${POWERLINE_PYTHON_VENV_CHAR-"ⓔ "}}${python_venv}|${PYTHON_VENV_THEME_PROMPT_COLOR-${POWERLINE_PYTHON_VENV_COLOR-"35"}}"
+	if [[ -n "${python_venv}" ]]; then
+		printf '%s%s|%s' "${PYTHON_VENV_CHAR-${POWERLINE_PYTHON_VENV_CHAR-"ⓔ"}}" "${python_venv}" "${PYTHON_VENV_THEME_PROMPT_COLOR-${POWERLINE_PYTHON_VENV_COLOR-"35"}}"
+	fi
 }
 
 #Customising SCM(GIT) Prompt
@@ -140,24 +154,24 @@ function __powerline_scm_prompt() {
 		elif [[ "${SCM_SVN_CHAR?}" == "${SCM_CHAR}" ]]; then
 			scm_prompt+="${SCM_CHAR}${SCM_BRANCH?}${SCM_STATE?}"
 		fi
-		echo "${scm_prompt}|${color}"
+		printf '%s|%s' "${scm_prompt}" "${color}"
 	fi
 }
 
 function __powerline_cwd_prompt() {
-	echo "\w|${CWD_THEME_PROMPT_COLOR-240}"
+	printf '%s|%s' "\w" "${CWD_THEME_PROMPT_COLOR-"240"}"
 }
 
 function __powerline_hostname_prompt() {
-	echo "\h|${HOST_THEME_PROMPT_COLOR-"0"}"
+	printf '%s|%s' "\h" "${HOST_THEME_PROMPT_COLOR-"0"}"
 }
 
 function __powerline_wd_prompt() {
-	echo "\W|${CWD_THEME_PROMPT_COLOR}"
+	printf '%s|%s' "\W" "${CWD_THEME_PROMPT_COLOR-"240"}"
 }
 
 function __powerline_clock_prompt() {
-	echo "\D{${THEME_CLOCK_FORMAT-"%H:%M:%S"}}|${CLOCK_THEME_PROMPT_COLOR-"240"}"
+	printf '%s|%s' "\D{${THEME_CLOCK_FORMAT-"%H:%M:%S"}}" "${CLOCK_THEME_PROMPT_COLOR-"240"}"
 }
 
 function __powerline_battery_prompt() {
@@ -174,26 +188,28 @@ function __powerline_battery_prompt() {
 		else
 			color="${BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR-"70"}"
 		fi
-		ac_adapter_connected && battery_status="${BATTERY_AC_CHAR-"+ "}${battery_status}"
-		echo "${battery_status}%|${color}"
+		if ac_adapter_connected; then
+			battery_status="${BATTERY_AC_CHAR-"+"}${battery_status}"
+		fi
+		printf '%s|%s' "${battery_status}%" "${color}"
 	fi
 }
 
 function __powerline_in_vim_prompt() {
 	if [[ -n "${VIMRUNTIME:-}" ]]; then
-		echo "${IN_VIM_THEME_PROMPT_TEXT-"vim"}|${IN_VIM_THEME_PROMPT_COLOR-"245"}"
+		printf '%s|%s' "${IN_VIM_THEME_PROMPT_TEXT-"vim"}" "${IN_VIM_THEME_PROMPT_COLOR-"245"}"
 	fi
 }
 
 function __powerline_aws_profile_prompt() {
 	if [[ -n "${AWS_PROFILE:-}" ]]; then
-		echo "${AWS_PROFILE_CHAR-${POWERLINE_AWS_PROFILE_CHAR-"❲aws❳ "}}${AWS_PROFILE}|${AWS_PROFILE_PROMPT_COLOR-${POWERLINE_AWS_PROFILE_COLOR-"208"}}"
+		printf '%s%s|%s' "${AWS_PROFILE_CHAR-${POWERLINE_AWS_PROFILE_CHAR-"❲aws❳"}}" "${AWS_PROFILE}" "${AWS_PROFILE_PROMPT_COLOR-${POWERLINE_AWS_PROFILE_COLOR-"208"}}"
 	fi
 }
 
 function __powerline_in_toolbox_prompt() {
-	if [[ -f /run/.containerenv ]] && [[ -f /run/.toolboxenv ]]; then
-		echo "${IN_TOOLBOX_THEME_PROMPT_TEXT-"⬢ "}|${IN_TOOLBOX_THEME_PROMPT_COLOR-"125"}"
+	if [[ -f /run/.containerenv && -f /run/.toolboxenv ]]; then
+		printf '%s|%s' "${IN_TOOLBOX_THEME_PROMPT_TEXT-"⬢"}" "${IN_TOOLBOX_THEME_PROMPT_COLOR-"125"}"
 	fi
 }
 
@@ -201,7 +217,7 @@ function __powerline_shlvl_prompt() {
 	if [[ "${SHLVL}" -gt 1 ]]; then
 		local prompt="${SHLVL_THEME_PROMPT_CHAR-"§"}"
 		local level=$((SHLVL - 1))
-		echo "${prompt}${level}|${SHLVL_THEME_PROMPT_COLOR-${HOST_THEME_PROMPT_COLOR-"0"}}"
+		printf '%s|%s' "${prompt}${level}" "${SHLVL_THEME_PROMPT_COLOR-${HOST_THEME_PROMPT_COLOR-"0"}}"
 	fi
 }
 
@@ -212,22 +228,24 @@ function __powerline_dirstack_prompt() {
 		if [[ "${depth}" -ge 2 ]]; then
 			prompt+="${depth}"
 		fi
-		echo "${prompt}|${DIRSTACK_THEME_PROMPT_COLOR-${POWERLINE_DIRSTACK_COLOR-${CWD_THEME_PROMPT_COLOR-${POWERLINE_CWD_COLOR-"240"}}}}"
+		printf '%s|%s' "${prompt}" "${DIRSTACK_THEME_PROMPT_COLOR-${POWERLINE_DIRSTACK_COLOR-${CWD_THEME_PROMPT_COLOR-${POWERLINE_CWD_COLOR-"240"}}}}"
 	fi
 }
 
 function __powerline_history_number_prompt() {
-	echo "${HISTORY_NUMBER_THEME_PROMPT_CHAR-${POWERLINE_HISTORY_NUMBER_CHAR-"#"}}\!|${HISTORY_NUMBER_THEME_PROMPT_COLOR-${POWERLINE_HISTORY_NUMBER_COLOR-"0"}}"
+	printf '%s%s|%s' "${HISTORY_NUMBER_THEME_PROMPT_CHAR-${POWERLINE_HISTORY_NUMBER_CHAR-"#"}}" '\!' "${HISTORY_NUMBER_THEME_PROMPT_COLOR-${POWERLINE_HISTORY_NUMBER_COLOR-"0"}}"
 }
 
 function __powerline_command_number_prompt() {
-	echo "${COMMAND_NUMBER_THEME_PROMPT_CHAR-${POWERLINE_COMMAND_NUMBER_CHAR-"#"}}\#|${COMMAND_NUMBER_THEME_PROMPT_COLOR-${POWERLINE_COMMAND_NUMBER_COLOR-"0"}}"
+	printf '%s%s|%s' "${COMMAND_NUMBER_THEME_PROMPT_CHAR-${POWERLINE_COMMAND_NUMBER_CHAR-"#"}}" '\#' "${COMMAND_NUMBER_THEME_PROMPT_COLOR-${POWERLINE_COMMAND_NUMBER_COLOR-"0"}}"
 }
 
 function __powerline_duration_prompt() {
 	local duration
 	duration=$(_command_duration)
-	[[ -n "$duration" ]] && echo "${duration}|${COMMAND_DURATION_PROMPT_COLOR?}"
+	if [[ -n "$duration" ]]; then
+		printf '%s|%s' "${duration}" "${COMMAND_DURATION_PROMPT_COLOR?}"
+	fi
 }
 
 function __powerline_left_segment() {
@@ -268,7 +286,9 @@ function __powerline_left_last_segment_padding() {
 }
 
 function __powerline_last_status_prompt() {
-	[[ "$1" -ne 0 ]] && echo "${1}|${LAST_STATUS_THEME_PROMPT_COLOR-"52"}"
+	if [[ "${1?}" -ne 0 ]]; then
+		printf '%s|%s' "${1}" "${LAST_STATUS_THEME_PROMPT_COLOR-"52"}"
+	fi
 }
 
 function __powerline_prompt_command() {
@@ -289,23 +309,27 @@ function __powerline_prompt_command() {
 	# shellcheck disable=SC2068 # intended behavior
 	for segment in ${POWERLINE_PROMPT[@]-"user_info" "scm" "python_venv" "ruby" "node" "cwd"}; do
 		info="$("__powerline_${segment}_prompt")"
-		[[ -n "${info}" ]] && __powerline_left_segment "${info}"
+		if [[ -n "${info}" ]]; then
+			__powerline_left_segment "${info}"
+		fi
 	done
 
-	[[ "${last_status}" -ne 0 ]] && __powerline_left_segment "$(__powerline_last_status_prompt "${last_status}")"
+	if [[ "${last_status}" -ne 0 ]]; then
+		__powerline_left_segment "$(__powerline_last_status_prompt "${last_status}")"
+	fi
 
-	if [[ -n "${LEFT_PROMPT:-}" ]] && [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT:-0}" -eq 0 ]]; then
+	if [[ -n "${LEFT_PROMPT:-}" && "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT:-0}" -eq 0 ]]; then
 		__powerline_left_last_segment_padding
 	fi
 
 	# By default we try to match the prompt to the adjacent segment's background color,
 	# but when part of the prompt exists within that segment, we instead match the foreground color.
 	prompt_color="$(set_color "${LAST_SEGMENT_COLOR?}" -)"
-	if [[ -n "${LEFT_PROMPT:-}" ]] && [[ -n "${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR:-}" ]]; then
+	if [[ -n "${LEFT_PROMPT:-}" && -n "${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR:-}" ]]; then
 		LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR}"
 		prompt_color="${normal?}"
 	fi
-	[[ -n "${LEFT_PROMPT:-}" ]] && LEFT_PROMPT+="${prompt_color}${POWERLINE_PROMPT_CHAR-\\$}${normal?}"
+	LEFT_PROMPT+="${prompt_color}${POWERLINE_PROMPT_CHAR-\\$}${normal?}"
 
 	if [[ "${POWERLINE_COMPACT_PROMPT:-0}" -eq 0 ]]; then
 		LEFT_PROMPT+=" "

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -249,22 +249,22 @@ function __powerline_left_segment() {
 
 	#for seperator character
 	if [[ "${SEGMENTS_AT_LEFT?}" -eq 0 ]]; then
-		if [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT:-0}" -ne 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT:-${POWERLINE_COMPACT:-0}}" -ne 0 ]]; then
 			pad_before_segment=""
 		fi
 	else
-		if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR:-0}" -ne 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR:-${POWERLINE_COMPACT:-0}}" -ne 0 ]]; then
 			pad_before_segment=""
 		fi
 		# Since the previous segment wasn't the last segment, add padding, if needed
 		#
-		if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR:-0}" -eq 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR:-${POWERLINE_COMPACT:-0}}" -eq 0 ]]; then
 			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}") ${normal?}"
 		fi
 		if [[ "${LAST_SEGMENT_COLOR?}" -eq "${params[1]:-}" ]]; then
-			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_SEPARATOR_SOFT:- }${normal?}"
+			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_SEPARATOR_SOFT- }${normal?}"
 		else
-			LEFT_PROMPT+="$(set_color "${LAST_SEGMENT_COLOR?}" "${params[1]:-}")${POWERLINE_LEFT_SEPARATOR:- }${normal?}"
+			LEFT_PROMPT+="$(set_color "${LAST_SEGMENT_COLOR?}" "${params[1]:-}")${POWERLINE_LEFT_SEPARATOR- }${normal?}"
 		fi
 	fi
 
@@ -287,7 +287,8 @@ function __powerline_last_status_prompt() {
 
 function __powerline_prompt_command() {
 	local last_status="$?" ## always the first
-	local info prompt_color segment
+	local beginning_of_line='\[\e[G\]'
+	local info prompt_color segment prompt
 
 	local LEFT_PROMPT=""
 	local SEGMENTS_AT_LEFT=0
@@ -312,22 +313,22 @@ function __powerline_prompt_command() {
 		__powerline_left_segment "$(__powerline_last_status_prompt "${last_status}")"
 	fi
 
-	if [[ -n "${LEFT_PROMPT:-}" && "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT:-0}" -eq 0 ]]; then
+	if [[ -n "${LEFT_PROMPT:-}" && "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT:-${POWERLINE_COMPACT:-0}}" -eq 0 ]]; then
 		__powerline_left_last_segment_padding
 	fi
 
 	# By default we try to match the prompt to the adjacent segment's background color,
 	# but when part of the prompt exists within that segment, we instead match the foreground color.
 	prompt_color="$(set_color "${LAST_SEGMENT_COLOR?}" -)"
-	if [[ -n "${LEFT_PROMPT:-}" && -n "${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR:-}" ]]; then
-		LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR}"
+	if [[ -n "${LEFT_PROMPT:-}" && -n "${POWERLINE_LEFT_LAST_SEGMENT_END_CHAR:-}" ]]; then
+		LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_LAST_SEGMENT_END_CHAR}"
 		prompt_color="${normal?}"
 	fi
-	LEFT_PROMPT+="${prompt_color}${POWERLINE_PROMPT_CHAR-\\$}${normal?}"
 
-	if [[ "${POWERLINE_COMPACT_PROMPT:-0}" -eq 0 ]]; then
-		LEFT_PROMPT+=" "
+	prompt="${prompt_color}${PROMPT_CHAR-${POWERLINE_PROMPT_CHAR-\\$}}${normal?}"
+	if [[ "${POWERLINE_COMPACT_PROMPT:-${POWERLINE_COMPACT:-0}}" -eq 0 ]]; then
+		prompt+=" "
 	fi
 
-	PS1="${LEFT_PROMPT?}"
+	PS1="${beginning_of_line}${normal?}${LEFT_PROMPT}${prompt}"
 }

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -1,6 +1,7 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2034 # Expected behavior for themes.
 
+#To set color for foreground and background
 function set_color() {
 	local fg='' bg=''
 	if [[ "${1:-}" != "-" ]]; then
@@ -13,38 +14,38 @@ function set_color() {
 	echo -e "\[\033[${fg}${bg}m\]"
 }
 
+#Customising User Info Segment
 function __powerline_user_info_prompt() {
-	local user_info=""
-	local color=${USER_INFO_THEME_PROMPT_COLOR}
+	local user_info="${SHORT_USER:-${USER}}"
+	local color=${USER_INFO_THEME_PROMPT_COLOR-${POWERLINE_USER_INFO_COLOR-"32"}}
 
-	if [[ "${THEME_CHECK_SUDO}" = true ]]; then
-		sudo -vn 1> /dev/null 2>&1 && color=${USER_INFO_THEME_PROMPT_COLOR_SUDO}
+	if [[ "${THEME_CHECK_SUDO:-false}" == true ]]; then
+		if sudo -vn 2> /dev/null; then
+			color=${USER_INFO_THEME_PROMPT_COLOR_SUDO-${POWERLINE_USER_INFO_COLOR_SUDO-"202"}}
+		fi
 	fi
 
-	case "${POWERLINE_PROMPT_USER_INFO_MODE}" in
+	case "${POWERLINE_PROMPT_USER_INFO_MODE:-}" in
 		"sudo")
-			if [[ "${color}" = "${USER_INFO_THEME_PROMPT_COLOR_SUDO}" ]]; then
+			if [[ "${color}" == "${USER_INFO_THEME_PROMPT_COLOR_SUDO-${POWERLINE_USER_INFO_COLOR_SUDO-"202"}}" ]]; then
 				user_info="!"
 			fi
 			;;
 		*)
-			local user=${SHORT_USER:-${USER}}
-			if [[ -n "${SSH_CLIENT}" ]] || [[ -n "${SSH_CONNECTION}" ]]; then
-				user_info="${USER_INFO_SSH_CHAR}${user}"
-			else
-				user_info="${user}"
+			if [[ -n "${SSH_CLIENT:-}" ]] || [[ -n "${SSH_CONNECTION:-}" ]]; then
+				user_info="${USER_INFO_SSH_CHAR-${POWERLINE_USER_INFO_SSH_CHAR-"⌁ "}}${user_info}"
 			fi
 			;;
 	esac
-	[[ -n "${user_info}" ]] && echo "${user_info}|${color}"
+	echo "${user_info}|${color}"
 }
 
 function __powerline_terraform_prompt() {
 	local terraform_workspace=""
 
-	if [ -d .terraform ]; then
+	if [[ -d .terraform ]]; then
 		terraform_workspace="$(terraform_workspace_prompt)"
-		[[ -n "${terraform_workspace}" ]] && echo "${TERRAFORM_CHAR}${terraform_workspace}|${TERRAFORM_THEME_PROMPT_COLOR}"
+		[[ -n "${terraform_workspace}" ]] && echo "${TERRAFORM_CHAR-${POWERLINE_TERRAFORM_CHAR-"❲t❳ "}}${terraform_workspace}|${TERRAFORM_THEME_PROMPT_COLOR-${POWERLINE_TERRAFORM_COLOR-"161"}}"
 	fi
 }
 
@@ -52,18 +53,19 @@ function __powerline_gcloud_prompt() {
 	local active_gcloud_account=""
 
 	active_gcloud_account="$(active_gcloud_account_prompt)"
-	[[ -n "${active_gcloud_account}" ]] && echo "${GCLOUD_CHAR}${active_gcloud_account}|${GCLOUD_THEME_PROMPT_COLOR}"
+	[[ -n "${active_gcloud_account}" ]] && echo "${GCLOUD_CHAR-${POWERLINE_GCLOUD_CHAR-"❲G❳ "}}${active_gcloud_account}|${GCLOUD_THEME_PROMPT_COLOR-${POWERLINE_GCLOUD_COLOR-"161"}}"
 }
 
 function __powerline_node_prompt() {
 	local node_version=""
 
 	node_version="$(node_version_prompt)"
-	[[ -n "${node_version}" ]] && echo "${NODE_CHAR}${node_version}|${NODE_THEME_PROMPT_COLOR}"
+	[[ -n "${node_version}" ]] && echo "${NODE_CHAR-${POWERLINE_NODE_CHAR-="❲n❳ "}}${node_version}|${NODE_THEME_PROMPT_COLOR-${POWERLINE_NODE_COLOR-"22"}}"
 }
 
+#Customising Ruby Prompt
 function __powerline_ruby_prompt() {
-	local ruby_version=""
+	local ruby_version
 
 	if _command_exists rvm; then
 		ruby_version="$(rvm_version_prompt)"
@@ -71,7 +73,9 @@ function __powerline_ruby_prompt() {
 		ruby_version=$(rbenv_version_prompt)
 	fi
 
-	[[ -n "${ruby_version}" ]] && echo "${RUBY_CHAR}${ruby_version}|${RUBY_THEME_PROMPT_COLOR}"
+	if [[ -n "${ruby_version:-}" ]]; then
+		echo "${RUBY_CHAR-${POWERLINE_RUBY_CHAR-"💎 "}}${ruby_version}|${RUBY_THEME_PROMPT_COLOR-${POWERLINE_RUBY_COLOR-"161"}}"
+	fi
 }
 
 function __powerline_k8s_context_prompt() {
@@ -81,7 +85,7 @@ function __powerline_k8s_context_prompt() {
 		kubernetes_context="$(k8s_context_prompt)"
 	fi
 
-	[[ -n "${kubernetes_context}" ]] && echo "${KUBERNETES_CONTEXT_THEME_CHAR}${kubernetes_context}|${KUBERNETES_CONTEXT_THEME_PROMPT_COLOR}"
+	[[ -n "${kubernetes_context}" ]] && echo "${KUBERNETES_CONTEXT_THEME_CHAR-${POWERLINE_KUBERNETES_CONTEXT_CHAR-"⎈ "}}${kubernetes_context}|${KUBERNETES_CONTEXT_THEME_PROMPT_COLOR-${POWERLINE_KUBERNETES_CONTEXT_COLOR-"26"}}"
 }
 
 function __powerline_k8s_namespace_prompt() {
@@ -91,57 +95,61 @@ function __powerline_k8s_namespace_prompt() {
 		kubernetes_namespace="$(k8s_namespace_prompt)"
 	fi
 
-	[[ -n "${kubernetes_namespace}" ]] && echo "${KUBERNETES_NAMESPACE_THEME_CHAR}${kubernetes_namespace}|${KUBERNETES_NAMESPACE_THEME_PROMPT_COLOR}"
+	[[ -n "${kubernetes_namespace}" ]] && echo "${KUBERNETES_NAMESPACE_THEME_CHAR-${POWERLINE_KUBERNETES_NAMESPACE_CHAR-"⎈ "}}${kubernetes_namespace}|${KUBERNETES_NAMESPACE_THEME_PROMPT_COLOR-${POWERLINE_KUBERNETES_NAMESPACE_COLOR-"60"}}"
 }
 
+#Customising Python (venv) Prompt
 function __powerline_python_venv_prompt() {
 	local python_venv=""
 
 	if [[ -n "${CONDA_DEFAULT_ENV:-}" ]]; then
 		python_venv="${CONDA_DEFAULT_ENV}"
-		PYTHON_VENV_CHAR=${CONDA_PYTHON_VENV_CHAR}
+		local PYTHON_VENV_CHAR=${CONDA_PYTHON_VENV_CHAR-${POWERLINE_CONDA_PYTHON_VENV_CHAR-"ⓔ "}}
 	elif [[ -n "${VIRTUAL_ENV:-}" ]]; then
 		python_venv="${VIRTUAL_ENV##*/}"
 	fi
 
-	[[ -n "${python_venv}" ]] && echo "${PYTHON_VENV_CHAR}${python_venv}|${PYTHON_VENV_THEME_PROMPT_COLOR}"
+	[[ -n "${python_venv}" ]] && echo "${PYTHON_VENV_CHAR-${POWERLINE_PYTHON_VENV_CHAR-"ⓔ "}}${python_venv}|${PYTHON_VENV_THEME_PROMPT_COLOR-${POWERLINE_PYTHON_VENV_COLOR-"35"}}"
 }
 
+#Customising SCM(GIT) Prompt
 function __powerline_scm_prompt() {
 	local color=""
 	local scm_prompt=""
 
 	scm_prompt_vars
 
-	if [[ "${SCM_NONE_CHAR}" != "${SCM_CHAR}" ]]; then
-		if [[ "${SCM_DIRTY}" -eq 3 ]]; then
-			color=${SCM_THEME_PROMPT_STAGED_COLOR}
-		elif [[ "${SCM_DIRTY}" -eq 2 ]]; then
-			color=${SCM_THEME_PROMPT_UNSTAGED_COLOR}
-		elif [[ "${SCM_DIRTY}" -eq 1 ]]; then
-			color=${SCM_THEME_PROMPT_DIRTY_COLOR}
+	if [[ "${SCM_NONE_CHAR?}" != "${SCM_CHAR?}" ]]; then
+		if [[ "${SCM_DIRTY?}" -eq 3 ]]; then
+			color=${SCM_THEME_PROMPT_STAGED_COLOR-${POWERLINE_SCM_STAGED_COLOR-"30"}}
+		elif [[ "${SCM_DIRTY?}" -eq 2 ]]; then
+			color=${SCM_THEME_PROMPT_UNSTAGED_COLOR-${POWERLINE_SCM_UNSTAGED_COLOR-"92"}}
+		elif [[ "${SCM_DIRTY?}" -eq 1 ]]; then
+			color=${SCM_THEME_PROMPT_DIRTY_COLOR-${POWERLINE_SCM_DIRTY_COLOR-"88"}}
+		elif [[ "${SCM_DIRTY?}" -eq 0 ]]; then
+			color=${SCM_THEME_PROMPT_CLEAN_COLOR-${POWERLINE_SCM_CLEAN_COLOR-"25"}}
 		else
-			color=${SCM_THEME_PROMPT_CLEAN_COLOR}
+			color=${SCM_THEME_PROMPT_COLOR-${POWERLINE_SCM_CLEAN_COLOR-"25"}}
 		fi
-		if [[ "${SCM_GIT_CHAR}" == "${SCM_CHAR}" ]]; then
-			scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
-		elif [[ "${SCM_P4_CHAR}" == "${SCM_CHAR}" ]]; then
-			scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
-		elif [[ "${SCM_HG_CHAR}" == "${SCM_CHAR}" ]]; then
-			scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
-		elif [[ "${SCM_SVN_CHAR}" == "${SCM_CHAR}" ]]; then
-			scm_prompt+="${SCM_CHAR}${SCM_BRANCH}${SCM_STATE}"
+		if [[ "${SCM_GIT_CHAR?}" == "${SCM_CHAR?}" ]]; then
+			scm_prompt+="${SCM_CHAR}${SCM_BRANCH?}${SCM_STATE?}"
+		elif [[ "${SCM_P4_CHAR?}" == "${SCM_CHAR}" ]]; then
+			scm_prompt+="${SCM_CHAR}${SCM_BRANCH?}${SCM_STATE?}"
+		elif [[ "${SCM_HG_CHAR?}" == "${SCM_CHAR}" ]]; then
+			scm_prompt+="${SCM_CHAR}${SCM_BRANCH?}${SCM_STATE?}"
+		elif [[ "${SCM_SVN_CHAR?}" == "${SCM_CHAR}" ]]; then
+			scm_prompt+="${SCM_CHAR}${SCM_BRANCH?}${SCM_STATE?}"
 		fi
-		echo "${scm_prompt?}|${color}"
+		echo "${scm_prompt}|${color}"
 	fi
 }
 
 function __powerline_cwd_prompt() {
-	echo "\w|${CWD_THEME_PROMPT_COLOR}"
+	echo "\w|${CWD_THEME_PROMPT_COLOR-240}"
 }
 
 function __powerline_hostname_prompt() {
-	echo "${SHORT_HOSTNAME:-$(hostname -s)}|${HOST_THEME_PROMPT_COLOR}"
+	echo "\h|${HOST_THEME_PROMPT_COLOR-"0"}"
 }
 
 function __powerline_wd_prompt() {
@@ -149,7 +157,7 @@ function __powerline_wd_prompt() {
 }
 
 function __powerline_clock_prompt() {
-	echo "$(date +"${THEME_CLOCK_FORMAT}")|${CLOCK_THEME_PROMPT_COLOR}"
+	echo "\D{${THEME_CLOCK_FORMAT-"%H:%M:%S"}}|${CLOCK_THEME_PROMPT_COLOR-"240"}"
 }
 
 function __powerline_battery_prompt() {
@@ -160,149 +168,147 @@ function __powerline_battery_prompt() {
 		true
 	else
 		if [[ "$((10#${battery_status}))" -le 5 ]]; then
-			color="${BATTERY_STATUS_THEME_PROMPT_CRITICAL_COLOR}"
+			color="${BATTERY_STATUS_THEME_PROMPT_CRITICAL_COLOR-"160"}"
 		elif [[ "$((10#${battery_status}))" -le 25 ]]; then
-			color="${BATTERY_STATUS_THEME_PROMPT_LOW_COLOR}"
+			color="${BATTERY_STATUS_THEME_PROMPT_LOW_COLOR-"208"}"
 		else
-			color="${BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR}"
+			color="${BATTERY_STATUS_THEME_PROMPT_GOOD_COLOR-"70"}"
 		fi
-		ac_adapter_connected && battery_status="${BATTERY_AC_CHAR}${battery_status}"
+		ac_adapter_connected && battery_status="${BATTERY_AC_CHAR-"+ "}${battery_status}"
 		echo "${battery_status}%|${color}"
 	fi
 }
 
 function __powerline_in_vim_prompt() {
-	if [[ -n "$VIMRUNTIME" ]]; then
-		echo "${IN_VIM_THEME_PROMPT_TEXT}|${IN_VIM_THEME_PROMPT_COLOR}"
+	if [[ -n "${VIMRUNTIME:-}" ]]; then
+		echo "${IN_VIM_THEME_PROMPT_TEXT-"vim"}|${IN_VIM_THEME_PROMPT_COLOR-"245"}"
 	fi
 }
 
 function __powerline_aws_profile_prompt() {
-	if [[ -n "${AWS_PROFILE}" ]]; then
-		echo "${AWS_PROFILE_CHAR}${AWS_PROFILE}|${AWS_PROFILE_PROMPT_COLOR}"
+	if [[ -n "${AWS_PROFILE:-}" ]]; then
+		echo "${AWS_PROFILE_CHAR-${POWERLINE_AWS_PROFILE_CHAR-"❲aws❳ "}}${AWS_PROFILE}|${AWS_PROFILE_PROMPT_COLOR-${POWERLINE_AWS_PROFILE_COLOR-"208"}}"
 	fi
 }
 
 function __powerline_in_toolbox_prompt() {
-	if [ -f /run/.containerenv ] && [ -f /run/.toolboxenv ]; then
-		echo "${IN_TOOLBOX_THEME_PROMPT_TEXT}|${IN_TOOLBOX_THEME_PROMPT_COLOR}"
+	if [[ -f /run/.containerenv ]] && [[ -f /run/.toolboxenv ]]; then
+		echo "${IN_TOOLBOX_THEME_PROMPT_TEXT-"⬢ "}|${IN_TOOLBOX_THEME_PROMPT_COLOR-"125"}"
 	fi
 }
 
 function __powerline_shlvl_prompt() {
 	if [[ "${SHLVL}" -gt 1 ]]; then
-		local prompt="${SHLVL_THEME_PROMPT_CHAR}"
+		local prompt="${SHLVL_THEME_PROMPT_CHAR-"§"}"
 		local level=$((SHLVL - 1))
-		echo "${prompt}${level}|${SHLVL_THEME_PROMPT_COLOR}"
+		echo "${prompt}${level}|${SHLVL_THEME_PROMPT_COLOR-${HOST_THEME_PROMPT_COLOR-"0"}}"
 	fi
 }
 
 function __powerline_dirstack_prompt() {
 	if [[ "${#DIRSTACK[@]}" -gt 1 ]]; then
 		local depth=$((${#DIRSTACK[@]} - 1))
-		local prompt="${DIRSTACK_THEME_PROMPT_CHAR}"
+		local prompt="${DIRSTACK_THEME_PROMPT_CHAR-${POWERLINE_DIRSTACK_CHAR-"←"}}"
 		if [[ "${depth}" -ge 2 ]]; then
 			prompt+="${depth}"
 		fi
-		echo "${prompt}|${DIRSTACK_THEME_PROMPT_COLOR}"
+		echo "${prompt}|${DIRSTACK_THEME_PROMPT_COLOR-${POWERLINE_DIRSTACK_COLOR-${CWD_THEME_PROMPT_COLOR-${POWERLINE_CWD_COLOR-"240"}}}}"
 	fi
 }
 
 function __powerline_history_number_prompt() {
-	echo "${HISTORY_NUMBER_THEME_PROMPT_CHAR}\!|${HISTORY_NUMBER_THEME_PROMPT_COLOR}"
+	echo "${HISTORY_NUMBER_THEME_PROMPT_CHAR-${POWERLINE_HISTORY_NUMBER_CHAR-"#"}}\!|${HISTORY_NUMBER_THEME_PROMPT_COLOR-${POWERLINE_HISTORY_NUMBER_COLOR-"0"}}"
 }
 
 function __powerline_command_number_prompt() {
-	echo "${COMMAND_NUMBER_THEME_PROMPT_CHAR}\#|${COMMAND_NUMBER_THEME_PROMPT_COLOR}"
+	echo "${COMMAND_NUMBER_THEME_PROMPT_CHAR-${POWERLINE_COMMAND_NUMBER_CHAR-"#"}}\#|${COMMAND_NUMBER_THEME_PROMPT_COLOR-${POWERLINE_COMMAND_NUMBER_COLOR-"0"}}"
 }
 
 function __powerline_duration_prompt() {
 	local duration
 	duration=$(_command_duration)
-	[[ -n "$duration" ]] && echo "${duration}|${COMMAND_DURATION_PROMPT_COLOR}"
+	[[ -n "$duration" ]] && echo "${duration}|${COMMAND_DURATION_PROMPT_COLOR?}"
 }
 
 function __powerline_left_segment() {
-	local params
+	local -a params
 	IFS="|" read -ra params <<< "${1}"
 	local pad_before_segment=" "
 
-	if [[ "${SEGMENTS_AT_LEFT}" -eq 0 ]]; then
-		if [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT}" -ne 0 ]]; then
+	#for seperator character
+	if [[ "${SEGMENTS_AT_LEFT?}" -eq 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_BEFORE_FIRST_SEGMENT:-0}" -ne 0 ]]; then
 			pad_before_segment=""
 		fi
 	else
-		if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR}" -ne 0 ]]; then
+		if [[ "${POWERLINE_COMPACT_AFTER_SEPARATOR:-0}" -ne 0 ]]; then
 			pad_before_segment=""
 		fi
 		# Since the previous segment wasn't the last segment, add padding, if needed
 		#
-		if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR}" -eq 0 ]]; then
-			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}") ${normal?}"
+		if [[ "${POWERLINE_COMPACT_BEFORE_SEPARATOR:-0}" -eq 0 ]]; then
+			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}") ${normal?}"
 		fi
-		if [[ "${LAST_SEGMENT_COLOR}" -eq "${params[1]}" ]]; then
-			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}")${POWERLINE_LEFT_SEPARATOR_SOFT}${normal?}"
+		if [[ "${LAST_SEGMENT_COLOR?}" -eq "${params[1]:-}" ]]; then
+			LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_SEPARATOR_SOFT:- }${normal?}"
 		else
-			LEFT_PROMPT+="$(set_color "${LAST_SEGMENT_COLOR}" "${params[1]}")${POWERLINE_LEFT_SEPARATOR}${normal?}"
+			LEFT_PROMPT+="$(set_color "${LAST_SEGMENT_COLOR?}" "${params[1]:-}")${POWERLINE_LEFT_SEPARATOR:- }${normal?}"
 		fi
 	fi
 
-	LEFT_PROMPT+="$(set_color - "${params[1]}")${pad_before_segment}${params[0]}${normal}"
-	LAST_SEGMENT_COLOR=${params[1]}
+	#change here to cahnge fg color
+	LEFT_PROMPT+="$(set_color - "${params[1]:-}")${pad_before_segment}${params[0]}${normal?}"
+	#seperator char color == current bg
+	LAST_SEGMENT_COLOR="${params[1]:-}"
 	((SEGMENTS_AT_LEFT += 1))
 }
 
 function __powerline_left_last_segment_padding() {
-	LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}") ${normal?}"
+	LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}") ${normal?}"
 }
 
 function __powerline_last_status_prompt() {
-	[[ "$1" -ne 0 ]] && echo "${1}|${LAST_STATUS_THEME_PROMPT_COLOR}"
+	[[ "$1" -ne 0 ]] && echo "${1}|${LAST_STATUS_THEME_PROMPT_COLOR-"52"}"
 }
 
 function __powerline_prompt_command() {
 	local last_status="$?" ## always the first
-	local separator_char="${POWERLINE_PROMPT_CHAR}" info prompt_color
+	local info prompt_color segment
 
-	LEFT_PROMPT=""
-	SEGMENTS_AT_LEFT=0
-	LAST_SEGMENT_COLOR=""
+	local LEFT_PROMPT=""
+	local SEGMENTS_AT_LEFT=0
+	local LAST_SEGMENT_COLOR=""
 
 	_save-and-reload-history "${HISTORY_AUTOSAVE:-0}"
 
-	if [[ -n "${POWERLINE_PROMPT_DISTRO_LOGO}" ]]; then
-		LEFT_PROMPT+="$(set_color "${PROMPT_DISTRO_LOGO_COLOR}" "${PROMPT_DISTRO_LOGO_COLORBG}")${PROMPT_DISTRO_LOGO}$(set_color - -)"
+	if [[ -n "${POWERLINE_PROMPT_DISTRO_LOGO:-}" ]]; then
+		LEFT_PROMPT+="$(set_color "${PROMPT_DISTRO_LOGO_COLOR?}" "${PROMPT_DISTRO_LOGO_COLORBG?}")${PROMPT_DISTRO_LOGO?}$(set_color - -)"
 	fi
 
 	## left prompt ##
-	for segment in $POWERLINE_PROMPT; do
-		info="$(__powerline_"${segment}"_prompt)"
+	for segment in ${POWERLINE_PROMPT-"user_info" "scm" "python_venv" "ruby" "node" "cwd"}; do
+		info="$("__powerline_${segment}_prompt")"
 		[[ -n "${info}" ]] && __powerline_left_segment "${info}"
 	done
 
 	[[ "${last_status}" -ne 0 ]] && __powerline_left_segment "$(__powerline_last_status_prompt "${last_status}")"
 
-	if [[ -n "${LEFT_PROMPT}" ]] && [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT:-}" -eq 0 ]]; then
+	if [[ -n "${LEFT_PROMPT:-}" ]] && [[ "${POWERLINE_COMPACT_AFTER_LAST_SEGMENT:-0}" -eq 0 ]]; then
 		__powerline_left_last_segment_padding
 	fi
 
 	# By default we try to match the prompt to the adjacent segment's background color,
 	# but when part of the prompt exists within that segment, we instead match the foreground color.
-	prompt_color="$(set_color "${LAST_SEGMENT_COLOR}" -)"
-	if [[ -n "${LEFT_PROMPT}" ]] && [[ -n "${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR}" ]]; then
-		LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR}")${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR}"
+	prompt_color="$(set_color "${LAST_SEGMENT_COLOR?}" -)"
+	if [[ -n "${LEFT_PROMPT:-}" ]] && [[ -n "${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR:-}" ]]; then
+		LEFT_PROMPT+="$(set_color - "${LAST_SEGMENT_COLOR?}")${POWERLINE_LEFT_LAST_SEGMENT_PROMPT_CHAR}"
 		prompt_color="${normal?}"
 	fi
-	[[ -n "${LEFT_PROMPT}" ]] && LEFT_PROMPT+="${prompt_color}${separator_char}${normal?}"
+	[[ -n "${LEFT_PROMPT:-}" ]] && LEFT_PROMPT+="${prompt_color}${POWERLINE_PROMPT_CHAR-\\$}${normal?}"
 
-	if [[ "${POWERLINE_COMPACT_PROMPT:-}" -eq 0 ]]; then
+	if [[ "${POWERLINE_COMPACT_PROMPT:-0}" -eq 0 ]]; then
 		LEFT_PROMPT+=" "
 	fi
 
-	PS1="${LEFT_PROMPT}"
-
-	## cleanup ##
-	unset LAST_SEGMENT_COLOR \
-		LEFT_PROMPT \
-		SEGMENTS_AT_LEFT
+	PS1="${LEFT_PROMPT?}"
 }

--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -24,21 +24,15 @@ function __powerline_user_info_prompt() {
 	if [[ "${THEME_CHECK_SUDO:-false}" == true ]]; then
 		if sudo -vn 2> /dev/null; then
 			color=${USER_INFO_THEME_PROMPT_COLOR_SUDO-${POWERLINE_USER_INFO_COLOR_SUDO-"202"}}
+			if [[ "${POWERLINE_PROMPT_USER_INFO_MODE:-}" == "sudo" ]]; then
+				user_info="!"
+			fi
 		fi
 	fi
 
-	case "${POWERLINE_PROMPT_USER_INFO_MODE:-}" in
-		"sudo")
-			if [[ "${color}" == "${USER_INFO_THEME_PROMPT_COLOR_SUDO-${POWERLINE_USER_INFO_COLOR_SUDO-"202"}}" ]]; then
-				user_info="!"
-			fi
-			;;
-		*)
-			if [[ -n "${SSH_CLIENT:-}" || -n "${SSH_CONNECTION:-}" ]]; then
-				user_info="${USER_INFO_SSH_CHAR-${POWERLINE_USER_INFO_SSH_CHAR-"⌁"}}${user_info}"
-			fi
-			;;
-	esac
+	if [[ -n "${SSH_CLIENT:-}" || -n "${SSH_CONNECTION:-}" ]]; then
+		user_info="${USER_INFO_SSH_CHAR-${POWERLINE_USER_INFO_SSH_CHAR-"⌁"}}${user_info}"
+	fi
 	printf '%s|%s' "${user_info}" "${color}"
 }
 


### PR DESCRIPTION
## Description
Minor cleanup and alsö apply defaults to most variables in the `theme/powerline.base` file. This should make *no* changes to any existing themes. 

## Motivation and Context
This should allow easier modificaiton/creation of powerline-based themes, as well as reduce duplicative code in existing themes. The idea is to reduce duplicate "base" files from powerline themes. 

## How Has This Been Tested?
Careful layering of includes to ensure I got the right bits. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
