### PR TITLE
fix broken reload/restart and preexec

### DIFF
--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -29,13 +29,13 @@ __bp_install_after_session_init
 function __check_precmd_conflict() {
 	local f
 	__bp_trim_whitespace f "${1?}"
-	! _bash-it-array-contains-element "${f}" "${precmd_functions[@]}"
+	_bash-it-array-contains-element "${f}" "${precmd_functions[@]}"
 }
 
 function __check_preexec_conflict() {
 	local f
 	__bp_trim_whitespace f "${1?}"
-	! _bash-it-array-contains-element "${f}" "${preexec_functions[@]}"
+	_bash-it-array-contains-element "${f}" "${preexec_functions[@]}"
 }
 
 function safe_append_prompt_command {


### PR DESCRIPTION
- lib: helpers: Dont reload .bash_profile in login shells
- lib: preexec: Properly return if there was a conflict in check_*_conflict

<!--- Provide a general summary of your changes in the Title above -->
We broke some things in our recent merges!

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
