### PR TITLE
lib/helpers: eliminate assumptions about login shells

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -654,14 +654,9 @@ function _bash-it-restart() {
 	_about 'restarts the shell in order to fully reload it'
 	_group 'lib'
 
-	local saved_pwd="${PWD}" init_file
+	local saved_pwd="${PWD}" init_file="${BASH_IT_BASHRC:-${HOME?}/.bashrc}"
 
-	if shopt -q login_shell; then
-		init_file=.bash_profile
-	else
-		init_file=.bashrc
-	fi
-	exec "${0/-/}" --rcfile <(echo "source \"$HOME/$init_file\"; cd \"$saved_pwd\"")
+	exec "${0/-/}" --rcfile <(echo "source \"${init_file}\"; cd \"$saved_pwd\"")
 }
 
 function _bash-it-reload() {
@@ -669,15 +664,8 @@ function _bash-it-reload() {
 	_group 'lib'
 
 	pushd "${BASH_IT?}" > /dev/null || return
-
 	# shellcheck disable=SC1090
-	if shopt -q login_shell; then
-		# shellcheck source-path=$HOME
-		source ~/.bash_profile
-	else
-		# shellcheck source-path=$HOME
-		source ~/.bashrc
-	fi
+	source "${BASH_IT_BASHRC:-${HOME?}/.bashrc}"
 	popd > /dev/null || return
 }
 


### PR DESCRIPTION
## Description
Bash loads initialization files on Mac just the same as it does on Linux or WSL. Our previous assumptions were wrong, and my fix was alsö wrong because I made more assumptions!

This patch eliminates the assumptions. Literally just load either the startup file the shell started with, or fall back to `~/.bashrc`. Don't check `shopt -q login_shell` and don't check `$OSTYPE` or anything else.

## Motivation and Context
I broke @NoahGorny's WSL shell. WSL runs shells as login shells, just like on Mac. But, since it loads an entire Linux distribution under the hood, WSL includes workarounds for _Bash_'s weird startup file behaviours and, therefore, my assumption that the startup file for a login must always be `~/.bash_profile` (or `~/.profile`) was quickly proven wrong. 😞 

## How Has This Been Tested?
By Noah. 😆 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
