### PR TITLE
completion/system: correctly load version when not linked

### DIFF
--- a/completion/available/system.completion.bash
+++ b/completion/available/system.completion.bash
@@ -14,31 +14,24 @@ else
 	__bash_it_restore_nounset=false
 fi
 
+# shellcheck disable=SC1090 disable=SC1091
 if [[ -r "${BASH_COMPLETION:-}" ]]; then
-	# shellcheck disable=SC1090
 	source "${BASH_COMPLETION}"
-
 elif [[ -r /etc/bash_completion ]]; then
-	# shellcheck disable=SC1091
 	source /etc/bash_completion
-
 # Some distribution makes use of a profile.d script to import completion.
 elif [[ -r /etc/profile.d/bash_completion.sh ]]; then
-	# shellcheck disable=SC1091
 	source /etc/profile.d/bash_completion.sh
-
 elif _bash_it_homebrew_check; then
-	: "${BASH_COMPLETION_COMPAT_DIR:=$BASH_IT_HOMEBREW_PREFIX/etc/bash_completion.d}"
-
+	: "${BASH_COMPLETION_COMPAT_DIR:=${BASH_IT_HOMEBREW_PREFIX}/etc/bash_completion.d}"
 	case "${BASH_VERSION}" in
 		1* | 2* | 3.0* | 3.1*)
 			_log_warning "Cannot load completion due to version of shell. Are you using Bash 3.2+?"
 			;;
 		3.2* | 4.0* | 4.1*)
 			# Import version 1.x of bash-completion, if installed.
-			BASH_COMPLETION="$BASH_IT_HOMEBREW_PREFIX/opt/bash-completion@1/etc/bash_completion"
+			BASH_COMPLETION="${BASH_IT_HOMEBREW_PREFIX}/opt/bash-completion@1/etc/bash_completion"
 			if [[ -r "$BASH_COMPLETION" ]]; then
-				# shellcheck disable=SC1090
 				source "$BASH_COMPLETION"
 			else
 				unset BASH_COMPLETION
@@ -46,9 +39,8 @@ elif _bash_it_homebrew_check; then
 			;;
 		4.2* | 5* | *)
 			# homebrew/versions/bash-completion2 (required for projects.completion.bash) is installed to this path
-			if [[ -r "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh" ]]; then
-				# shellcheck disable=SC1091
-				source "${BASH_IT_HOMEBREW_PREFIX}/etc/profile.d/bash_completion.sh"
+			if [[ -r "${BASH_IT_HOMEBREW_PREFIX}/opt/bash-completion@2/etc/profile.d/bash_completion.sh" ]]; then
+				source "${BASH_IT_HOMEBREW_PREFIX}/opt/bash-completion@2/etc/profile.d/bash_completion.sh"
 			fi
 			;;
 	esac


### PR DESCRIPTION
## Description
- Load the correct version of `bash-completion` even when not "linked".

## Motivation and Context
I realized my completions were not working and realized I had `brew unlink`'d my `bash-completion`, since I have both v1 and v2 installed. This fixes `completion/system` to look for v1 and v2 *both* under their versioned directories. My previous version of this had looked for v1 in it's version'd directory, but looked for v2 only under the main directory. Shot my own foot there.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
