### PR TITLE
Update "preexec" from "https://github.com/rcaloras/bash-preexec@master"

### DIFF
--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -20,8 +20,8 @@ function __bp_require_not_readonly() { :; }
 # Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
 __bp_enable_subshells= # blank
 
-# Modify `$PROMPT_COMMAND` now
-__bp_install_after_session_init
+# Modify `$PROMPT_COMMAND` in finalize hook
+_bash_it_library_finalize_hook+=('__bp_install_after_session_init')
 
 ## Helper functions
 function __check_precmd_conflict() {

--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -4,9 +4,8 @@
 # Load the `bash-preexec.sh` library, and define helper functions
 
 ## Prepare, load, fix, and install `bash-preexec.sh`
-: "${PROMPT_COMMAND:=}"
 
-# Disable immediate `$PROMPT_COMMAND` modification
+# Disable `$PROMPT_COMMAND` modification for now.
 __bp_delay_install="delayed"
 
 # shellcheck source-path=SCRIPTDIR/../vendor/github.com/rcaloras/bash-preexec
@@ -20,7 +19,6 @@ function __bp_require_not_readonly() { :; }
 
 # Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
 __bp_enable_subshells= # blank
-set +T
 
 # Modify `$PROMPT_COMMAND` now
 __bp_install_after_session_init
@@ -42,7 +40,7 @@ function safe_append_prompt_command {
 	local prompt_re f
 	__bp_trim_whitespace f "${1?}"
 
-	if [ "${__bp_imported:-missing}" == "defined" ]; then
+	if [ "${bash_preexec_imported:-${__bp_imported:-missing}}" == "defined" ]; then
 		# We are using bash-preexec
 		if ! __check_precmd_conflict "${f}"; then
 			precmd_functions+=("${f}")
@@ -71,7 +69,7 @@ function safe_append_preexec {
 	local prompt_re f
 	__bp_trim_whitespace f "${1?}"
 
-	if [ "${__bp_imported:-missing}" == "defined" ]; then
+	if [ "${bash_preexec_imported:-${__bp_imported:-missing}}" == "defined" ]; then
 		# We are using bash-preexec
 		if ! __check_preexec_conflict "${f}"; then
 			preexec_functions+=("${f}")

--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -17,8 +17,9 @@ function __bp_adjust_histcontrol() { :; }
 # Don't fail on readonly variables
 function __bp_require_not_readonly() { :; }
 
-# Disable trap DEBUG on subshells - https://github.com/Bash-it/bash-it/pull/1040
-__bp_enable_subshells= # blank
+# For performance, testing, and to avoid unexpected behavior: disable DEBUG traps in subshells.
+# See bash-it/bash-it#1040 and rcaloras/bash-preexec#26
+: "${__bp_enable_subshells:=}" # blank
 
 # Modify `$PROMPT_COMMAND` in finalize hook
 _bash_it_library_finalize_hook+=('__bp_install_after_session_init')

--- a/lib/preexec.bash
+++ b/lib/preexec.bash
@@ -37,26 +37,20 @@ function __check_preexec_conflict() {
 	_bash-it-array-contains-element "${f}" "${preexec_functions[@]}"
 }
 
-function safe_append_prompt_command {
-	local prompt_re f
-	__bp_trim_whitespace f "${1?}"
+function safe_append_prompt_command() {
+	local prompt_re prompt_er f
 
-	if [ "${bash_preexec_imported:-${__bp_imported:-missing}}" == "defined" ]; then
+	if [[ "${bash_preexec_imported:-${__bp_imported:-missing}}" == "defined" ]]; then
 		# We are using bash-preexec
+		__bp_trim_whitespace f "${1?}"
 		if ! __check_precmd_conflict "${f}"; then
 			precmd_functions+=("${f}")
 		fi
 	else
-		# Set OS dependent exact match regular expression
-		if [[ ${OSTYPE} == darwin* ]]; then
-			# macOS
-			prompt_re="[[:<:]]${1}[[:>:]]"
-		else
-			# Linux, FreeBSD, etc.
-			prompt_re="\<${1}\>"
-		fi
-
-		if [[ ${PROMPT_COMMAND} =~ ${prompt_re} ]]; then
+		# Match on word-boundaries
+		prompt_re='(^|[^[:alnum:]_])'
+		prompt_er='([^[:alnum:]_]|$)'
+		if [[ ${PROMPT_COMMAND} =~ ${prompt_re}"${1}"${prompt_er} ]]; then
 			return
 		elif [[ -z ${PROMPT_COMMAND} ]]; then
 			PROMPT_COMMAND="${1}"
@@ -66,12 +60,12 @@ function safe_append_prompt_command {
 	fi
 }
 
-function safe_append_preexec {
+function safe_append_preexec() {
 	local prompt_re f
-	__bp_trim_whitespace f "${1?}"
 
-	if [ "${bash_preexec_imported:-${__bp_imported:-missing}}" == "defined" ]; then
+	if [[ "${bash_preexec_imported:-${__bp_imported:-missing}}" == "defined" ]]; then
 		# We are using bash-preexec
+		__bp_trim_whitespace f "${1?}"
 		if ! __check_preexec_conflict "${f}"; then
 			preexec_functions+=("${f}")
 		fi

--- a/vendor/github.com/rcaloras/bash-preexec/bash-preexec.sh
+++ b/vendor/github.com/rcaloras/bash-preexec/bash-preexec.sh
@@ -32,11 +32,20 @@
 #  using: the "DEBUG" trap, and the "PROMPT_COMMAND" variable. If you override
 #  either of these after bash-preexec has been installed it will most likely break.
 
+# Make sure this is bash that's running and return otherwise.
+if [[ -z "${BASH_VERSION:-}" ]]; then
+    return 1;
+fi
+
 # Avoid duplicate inclusion
-if [[ "${__bp_imported:-}" == "defined" ]]; then
+if [[ -n "${bash_preexec_imported:-}" ]]; then
     return 0
 fi
-__bp_imported="defined"
+bash_preexec_imported="defined"
+
+# WARNING: This variable is no longer used and should not be relied upon.
+# Use ${bash_preexec_imported} instead.
+__bp_imported="${bash_preexec_imported}"
 
 # Should be available to each precmd and preexec
 # functions, should they want it. $? and $_ are available as $? and $_, but
@@ -70,7 +79,8 @@ __bp_require_not_readonly() {
 # history even if it starts with a space.
 __bp_adjust_histcontrol() {
     local histcontrol
-    histcontrol="${HISTCONTROL//ignorespace}"
+    histcontrol="${HISTCONTROL:-}"
+    histcontrol="${histcontrol//ignorespace}"
     # Replace ignoreboth with ignoredups
     if [[ "$histcontrol" == *"ignoreboth"* ]]; then
         histcontrol="ignoredups:${histcontrol//ignoreboth}"
@@ -84,6 +94,10 @@ __bp_adjust_histcontrol() {
 # run interactively by the user; it's set immediately after the prompt hook,
 # and unset as soon as the trace hook is run.
 __bp_preexec_interactive_mode=""
+
+# These arrays are used to add functions to be run before, or after, prompts.
+declare -a precmd_functions
+declare -a preexec_functions
 
 # Trims leading and trailing whitespace from $2 and writes it to the variable
 # name passed as $1
@@ -154,7 +168,7 @@ __bp_set_ret_value() {
 __bp_in_prompt_command() {
 
     local prompt_command_array
-    IFS=$'\n;' read -rd '' -a prompt_command_array <<< "$PROMPT_COMMAND"
+    IFS=$'\n;' read -rd '' -a prompt_command_array <<< "${PROMPT_COMMAND:-}"
 
     local trimmed_arg
     __bp_trim_whitespace trimmed_arg "${1:-}"
@@ -292,7 +306,8 @@ __bp_install() {
 
     local existing_prompt_command
     # Remove setting our trap install string and sanitize the existing prompt command string
-    existing_prompt_command="${PROMPT_COMMAND//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
+    existing_prompt_command="${PROMPT_COMMAND:-}"
+    existing_prompt_command="${existing_prompt_command//$__bp_install_string[;$'\n']}" # Edge case of appending to PROMPT_COMMAND
     existing_prompt_command="${existing_prompt_command//$__bp_install_string}"
     __bp_sanitize_string existing_prompt_command "$existing_prompt_command"
 
@@ -318,17 +333,12 @@ __bp_install() {
 # after our session has started. This allows bash-preexec to be included
 # at any point in our bash profile.
 __bp_install_after_session_init() {
-    # Make sure this is bash that's running this and return otherwise.
-    if [[ -z "${BASH_VERSION:-}" ]]; then
-        return 1;
-    fi
-
     # bash-preexec needs to modify these variables in order to work correctly
     # if it can't, just stop the installation
     __bp_require_not_readonly PROMPT_COMMAND HISTCONTROL HISTTIMEFORMAT || return
 
     local sanitized_prompt_command
-    __bp_sanitize_string sanitized_prompt_command "$PROMPT_COMMAND"
+    __bp_sanitize_string sanitized_prompt_command "${PROMPT_COMMAND:-}"
     if [[ -n "$sanitized_prompt_command" ]]; then
         PROMPT_COMMAND=${sanitized_prompt_command}$'\n'
     fi;


### PR DESCRIPTION
## Description
git-vendor-name: preexec
git-vendor-dir: vendor/github.com/rcaloras/bash-preexec
git-vendor-repository: https://github.com/rcaloras/bash-preexec
git-vendor-ref: fd2ffa8876d3940c97ffdc3cc807e43277cf72da

## Motivation and Context
A few upstream changes, notably proper handling of previously-undefined `$PROMPT_COMMAND` and properly handling `extdebug` to prevent subshells from inheriting the `DEBUG` trap.

Alsö, use `_bash_it_library_finalize_hook` to avoid touching `$PROMPT_COMMAND` until the last possible moment, which fixes #2070. 

## How Has This Been Tested?
Live on my main branch for ages.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
