### PR TITLE
plugin/battery: bug fix

### DIFF
--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -3,7 +3,7 @@ about-plugin 'display info about your battery charge level'
 
 function ac_adapter_connected() {
 	if _command_exists upower; then
-		upower -i "$(upower -e | grep -i BAT)" | grep 'state' | grep -q 'charging\|fully-charged'
+		upower -i "$(upower -e | grep -i BAT | head -n 1)" | grep 'state' | grep -q 'charging\|fully-charged'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "on-line"
 	elif _command_exists pmset; then
@@ -17,7 +17,7 @@ function ac_adapter_connected() {
 
 function ac_adapter_disconnected() {
 	if _command_exists upower; then
-		upower -i "$(upower -e | grep -i BAT)" | grep 'state' | grep -q 'discharging'
+		upower -i "$(upower -e | grep -i BAT | head -n 1)" | grep 'state' | grep -q 'discharging'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "off-line"
 	elif _command_exists pmset; then
@@ -36,7 +36,7 @@ function battery_percentage() {
 	local command_output="no"
 
 	if _command_exists upower; then
-		command_output=$(upower --show-info "$(upower --enumerate | grep -i BAT)" | grep percentage | grep -o "[0-9]\+" | head -1)
+		command_output=$(upower --show-info "$(upower --enumerate | grep -i BAT | head -n 1)" | grep percentage | grep -o "[0-9]\+" | head -1)
 	elif _command_exists acpi; then
 		command_output=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}')
 	elif _command_exists pmset; then

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -3,7 +3,7 @@ about-plugin 'display info about your battery charge level'
 
 function ac_adapter_connected() {
 	if _command_exists upower; then
-		upower -i "$(upower -e | grep -i BAT | head -n 1)" | grep 'state' | grep -q 'charging\|fully-charged'
+		upower -i "$(upower -e | grep --max-count=1 -i BAT)" | grep 'state' | grep -q 'charging\|fully-charged'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "on-line"
 	elif _command_exists pmset; then
@@ -17,7 +17,7 @@ function ac_adapter_connected() {
 
 function ac_adapter_disconnected() {
 	if _command_exists upower; then
-		upower -i "$(upower -e | grep -i BAT | head -n 1)" | grep 'state' | grep -q 'discharging'
+		upower -i "$(upower -e | grep --max-count=1 -i BAT)" | grep 'state' | grep -q 'discharging'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "off-line"
 	elif _command_exists pmset; then
@@ -36,7 +36,7 @@ function battery_percentage() {
 	local command_output="no"
 
 	if _command_exists upower; then
-		command_output=$(upower --show-info "$(upower --enumerate | grep -i BAT | head -n 1)" | grep percentage | grep -o "[0-9]\+" | head -1)
+		command_output=$(upower --show-info "$(upower --enumerate | grep --max-count=1 -i BAT)" | grep percentage | grep -o "[0-9]\+" | head -1)
 	elif _command_exists acpi; then
 		command_output=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}')
 	elif _command_exists pmset; then

--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -2,8 +2,10 @@
 about-plugin 'display info about your battery charge level'
 
 function ac_adapter_connected() {
+	local batteries
 	if _command_exists upower; then
-		upower -i "$(upower -e | grep --max-count=1 -i BAT)" | grep 'state' | grep -q 'charging\|fully-charged'
+		batteries="$(upower -e | grep --max-count=1 -i BAT)"
+		upower -i "${batteries}" | grep 'state' | grep -q 'charging\|fully-charged'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "on-line"
 	elif _command_exists pmset; then
@@ -16,8 +18,10 @@ function ac_adapter_connected() {
 }
 
 function ac_adapter_disconnected() {
+	local batteries
 	if _command_exists upower; then
-		upower -i "$(upower -e | grep --max-count=1 -i BAT)" | grep 'state' | grep -q 'discharging'
+		batteries="$(upower -e | grep --max-count=1 -i BAT)"
+		upower -i "${batteries}" | grep 'state' | grep -q 'discharging'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "off-line"
 	elif _command_exists pmset; then
@@ -33,16 +37,17 @@ function battery_percentage() {
 	about 'displays battery charge as a percentage of full (100%)'
 	group 'battery'
 
-	local command_output="no"
+	local command_output batteries
 
 	if _command_exists upower; then
-		command_output=$(upower --show-info "$(upower --enumerate | grep --max-count=1 -i BAT)" | grep percentage | grep -o "[0-9]\+" | head -1)
+		batteries="$(upower --enumerate | grep --max-count=1 -i BAT)"
+		command_output="$(upower --show-info "${batteries:-}" | grep percentage | grep -o '[0-9]\+' | head -1)"
 	elif _command_exists acpi; then
 		command_output=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}')
 	elif _command_exists pmset; then
-		command_output=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o "[0-9]\+" | head -1)
+		command_output=$(pmset -g ps | sed -n 's/.*[[:blank:]]+*\(.*%\).*/\1/p' | grep -o '[0-9]\+' | head -1)
 	elif _command_exists ioreg; then
-		command_output=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}' | grep -o "[0-9]\+" | head -1)
+		command_output=$(ioreg -n AppleSmartBattery -r | awk '$1~/Capacity/{c[$1]=$3} END{OFMT="%05.2f"; max=c["\"MaxCapacity\""]; print (max>0? 100*c["\"CurrentCapacity\""]/max: "?")}' | grep -o '[0-9]\+' | head -1)
 	elif _command_exists WMIC; then
 		command_output=$(WMIC PATH Win32_Battery Get EstimatedChargeRemaining /Format:List | grep -o '[0-9]\+' | head -1)
 	else

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -194,15 +194,22 @@ function setup_acpi {
 # The passed in parameter is used for the remaining battery percentage.
 function setup_upower {
 	percent="$1"
+	BAT0="/org/freedesktop/UPower/devices/battery_BAT$RANDOM"
+
 
 	function upower {
 		case $1 in
 		'-e'|'--enumerate')
-			echo "/org/freedesktop/UPower/devices/battery_BAT0"
+			echo "$BAT0"
 			echo "/org/freedesktop/UPower/devices/mouse_hid_${RANDOM}_battery"
 			;;
 		'-i'|'--show-info')
-			printf "voltage:             12.191 V\n    time to full:        57.3 minutes\n    percentage:          %s\n    capacity:            84.6964" "${percent}"
+			if [[ $2 == "$BAT0" ]]
+			then
+				printf "voltage:             12.191 V\n    time to full:        57.3 minutes\n    percentage:          %s\n    capacity:            84.6964" "${percent}"
+			else
+				false
+			fi
 			;;
 		esac
 	}

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -193,11 +193,19 @@ function setup_acpi {
 # Creates a `upower` function that simulates output like the real `upower` command.
 # The passed in parameter is used for the remaining battery percentage.
 function setup_upower {
-  percent="$1"
+	percent="$1"
 
-  function upower {
-    printf "voltage:             12.191 V\n    time to full:        57.3 minutes\n    percentage:          %s\n    capacity:            84.6964" "${percent}"
-  }
+	function upower {
+		case $1 in
+		'-e'|'--enumerate')
+			echo "/org/freedesktop/UPower/devices/battery_BAT0"
+			echo "/org/freedesktop/UPower/devices/mouse_hid_${RANDOM}_battery"
+			;;
+		'-i'|'--show-info')
+			printf "voltage:             12.191 V\n    time to full:        57.3 minutes\n    percentage:          %s\n    capacity:            84.6964" "${percent}"
+			;;
+		esac
+	}
 }
 
 @test 'plugins battery: battery-percentage with upower, 100%' {


### PR DESCRIPTION
When `upower --enumerate | grep -i BAT` returns multiple lines of results (which are file paths),
the added quotation (from commit 3cb5f3f7e66345a329cae8ad112f1ecbedc60dab) concatenates them all to provide an invalid path.
Thus to make the plugin work as before the commit,
take only the first line of the results.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `head -n 1` to filter out the rest of the result except the first line.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
