### PR TITLE
Make the ls color available for macos

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -1,13 +1,18 @@
 cite about-alias
 about-alias 'general aliases'
 
-if ls --color -d . &> /dev/null
-then
-  alias ls="ls --color=auto"
-elif ls -G -d . &> /dev/null
-then
-  alias ls='ls -G'        # Compact view, show colors
-fi
+# color support for darwin and non-darwin os
+# special thanks https://stackoverflow.com/a/27776822/10362396
+case "$(uname -s)" in
+
+   Darwin)
+     alias ls='ls -G'
+     ;;
+
+   *)
+     alias ls='ls --color=auto'
+     ;;
+esac
 
 # List directory contents
 alias sl=ls


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The old condition was not letting set `ls -G` option because of `ls --color=auto` was exiting with 0 exit code. In case of macos, it is required to have -G flag in the ls cmdline ([here](https://superuser.com/questions/183876/how-do-i-get-ls-color-auto-to-work-on-mac-os-x))

## Motivation and Context

In the current patch, I am checking for the kernel name instead and if it is **Darwin**, then add `-G` flag, otherwise `--color=auto`

## How Has This Been Tested?

Tested on linux and macos, working fine. 

## Screenshots (if appropriate):

<img width="1015" alt="Screenshot 2022-02-08 at 2 32 50 PM" src="https://user-images.githubusercontent.com/28386721/152953431-395e2132-7e80-4caf-9c91-ce91704eff3e.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
