### PR TITLE
lib/log: //echo/printf

### DIFF
--- a/lib/log.bash
+++ b/lib/log.bash
@@ -55,8 +55,15 @@ function _bash-it-log-message() {
 	param '3: message to log'
 	group 'log'
 
-	message="$2${BASH_IT_LOG_PREFIX:-default: }$3"
-	_has_colors && echo -e "$1${message}${echo_normal:-}" || echo -e "${message}"
+	local prefix="${BASH_IT_LOG_PREFIX:-default}"
+	local color="${1-${echo_cyan:-}}"
+	local level="${2:-TRACE}"
+	local message="${level%: }: ${prefix%: }: ${3?}"
+	if _has_colors; then
+		printf '%b%s%b\n' "${color}" "${message}" "${echo_normal:-}"
+	else
+		printf '%s\n' "${message}"
+	fi
 }
 
 function _log_debug() {
@@ -65,8 +72,9 @@ function _log_debug() {
 	example '$ _log_debug "Loading plugin git..."'
 	group 'log'
 
-	[[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_INFO?}" ]] || return 0
-	_bash-it-log-message "${echo_green:-}" "DEBUG: " "$1"
+	if [[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_INFO?}" ]]; then
+		_bash-it-log-message "${echo_green:-}" "DEBUG: " "$1"
+	fi
 }
 
 function _log_warning() {
@@ -75,8 +83,9 @@ function _log_warning() {
 	example '$ _log_warning "git binary not found, disabling git plugin..."'
 	group 'log'
 
-	[[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_WARNING?}" ]] || return 0
-	_bash-it-log-message "${echo_yellow:-}" " WARN: " "$1"
+	if [[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_WARNING?}" ]]; then
+		_bash-it-log-message "${echo_yellow:-}" " WARN: " "$1"
+	fi
 }
 
 function _log_error() {
@@ -85,6 +94,7 @@ function _log_error() {
 	example '$ _log_error "Failed to load git plugin..."'
 	group 'log'
 
-	[[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_ERROR?}" ]] || return 0
-	_bash-it-log-message "${echo_red:-}" "ERROR: " "$1"
+	if [[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_ERROR?}" ]]; then
+		_bash-it-log-message "${echo_red:-}" "ERROR: " "$1"
+	fi
 }

--- a/lib/log.bash
+++ b/lib/log.bash
@@ -49,11 +49,11 @@ function _has_colors() {
 }
 
 function _bash-it-log-message() {
-	about 'Internal function used for logging, uses BASH_IT_LOG_PREFIX as a prefix'
-	param '1: color of the message'
-	param '2: log level to print before the prefix'
-	param '3: message to log'
-	group 'log'
+	: _about 'Internal function used for logging, uses BASH_IT_LOG_PREFIX as a prefix'
+	: _param '1: color of the message'
+	: _param '2: log level to print before the prefix'
+	: _param '3: message to log'
+	: _group 'log'
 
 	local prefix="${BASH_IT_LOG_PREFIX:-default}"
 	local color="${1-${echo_cyan:-}}"
@@ -67,10 +67,10 @@ function _bash-it-log-message() {
 }
 
 function _log_debug() {
-	about 'log a debug message by echoing to the screen. needs BASH_IT_LOG_LEVEL >= BASH_IT_LOG_LEVEL_INFO'
-	param '1: message to log'
-	example '$ _log_debug "Loading plugin git..."'
-	group 'log'
+	: _about 'log a debug message by echoing to the screen. needs BASH_IT_LOG_LEVEL >= BASH_IT_LOG_LEVEL_INFO'
+	: _param '1: message to log'
+	: _example '$ _log_debug "Loading plugin git..."'
+	: _group 'log'
 
 	if [[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_INFO?}" ]]; then
 		_bash-it-log-message "${echo_green:-}" "DEBUG: " "$1"
@@ -78,10 +78,10 @@ function _log_debug() {
 }
 
 function _log_warning() {
-	about 'log a message by echoing to the screen. needs BASH_IT_LOG_LEVEL >= BASH_IT_LOG_LEVEL_WARNING'
-	param '1: message to log'
-	example '$ _log_warning "git binary not found, disabling git plugin..."'
-	group 'log'
+	: _about 'log a message by echoing to the screen. needs BASH_IT_LOG_LEVEL >= BASH_IT_LOG_LEVEL_WARNING'
+	: _param '1: message to log'
+	: _example '$ _log_warning "git binary not found, disabling git plugin..."'
+	: _group 'log'
 
 	if [[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_WARNING?}" ]]; then
 		_bash-it-log-message "${echo_yellow:-}" " WARN: " "$1"
@@ -89,10 +89,10 @@ function _log_warning() {
 }
 
 function _log_error() {
-	about 'log a message by echoing to the screen. needs BASH_IT_LOG_LEVEL >= BASH_IT_LOG_LEVEL_ERROR'
-	param '1: message to log'
-	example '$ _log_error "Failed to load git plugin..."'
-	group 'log'
+	: _about 'log a message by echoing to the screen. needs BASH_IT_LOG_LEVEL >= BASH_IT_LOG_LEVEL_ERROR'
+	: _param '1: message to log'
+	: _example '$ _log_error "Failed to load git plugin..."'
+	: _group 'log'
 
 	if [[ "${BASH_IT_LOG_LEVEL:-0}" -ge "${BASH_IT_LOG_LEVEL_ERROR?}" ]]; then
 		_bash-it-log-message "${echo_red:-}" "ERROR: " "$1"


### PR DESCRIPTION
## Description
- Replace `echo -e` with `printf` in `_bash-it-log-message()`.
- `local` positional parameters to allow for defaults.
- Use new `composure.sh` feature to reduce load order dependency.
- Use `if`/`then` properly.
- Clean up use of `$BASH_IT_LOG_PREFIX` slightly (eliminate duplicate colons).

## Motivation and Context
Misuse of `&&`/`||` can cause unexpected return status, so I'm just fixing to use `if`/`then` wherever I see them. `echo -e` is unreliable and has differing behaviour in different contexts, such as in subshells and when `xpg_echo` is enabled. `printf` does exactly what it says on the tin. The parameter `$message` was leaking from every log function, so I `local`'d it. Alsö, `local` the rest of the parameters and fill in a default color, default log level, and strip duplicate colons from the message and level. 

## How Has This Been Tested?
Now that #1902 is merged, I can start a whole shell straight off `master`!! So, anyway, I have my `$BASH_IT_LOG_LEVEL` set to max in my `~/.bashrc` so I see all the messages and everything still works. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
