### PR TITLE
lib/helpers: Don't rm "$profile_path" before writing to it

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -511,7 +511,6 @@ function _bash-it-profile-save() {
 			case "$RESP" in
 				[yY])
 					echo -e "${echo_green?}Overwriting profile '$name'...${echo_reset_color?}"
-					rm "$profile_path"
 					break
 					;;
 				[nN] | "")


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description, Motivation and Context
<!--- Describe your changes in detail -->
When the file is being re-created, we write to it, instead of appending to
it. So, the rm here is unnecessary and prevents users from linking the profile
file to another location that is potentially under version control. For
instance, once could link to a profile file located at
"$BASH_IT_CUSTOM/profiles/*.bash_it".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I ran `bash-it profile save` to create a profile file.
- Moved it into my `$BASH_IT_CUSTOM` directory
- Linked that file into the `$BASH_IT/profiles/` directory
- Tested loading and re-saving the profile after making changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
