### PR TITLE
bash_it.sh: source `reloader.bash` without arguments for the default enabling

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -38,6 +38,7 @@ done
 # "_bash_it_main_file_type" param is empty so that files get sourced in glob order
 for _bash_it_main_file_type in "" "aliases" "plugins" "completion"; do
 	BASH_IT_LOG_PREFIX="core: reloader: "
+	# shellcheck disable=SC2140
 	source "${BASH_IT}/scripts/reloader.bash" ${_bash_it_main_file_type:+"skip" "$_bash_it_main_file_type"}
 	BASH_IT_LOG_PREFIX="core: main: "
 done

--- a/bash_it.sh
+++ b/bash_it.sh
@@ -38,7 +38,7 @@ done
 # "_bash_it_main_file_type" param is empty so that files get sourced in glob order
 for _bash_it_main_file_type in "" "aliases" "plugins" "completion"; do
 	BASH_IT_LOG_PREFIX="core: reloader: "
-	source "${BASH_IT}/scripts/reloader.bash" "${_bash_it_main_file_type:+skip}" "$_bash_it_main_file_type"
+	source "${BASH_IT}/scripts/reloader.bash" ${_bash_it_main_file_type:+"skip" "$_bash_it_main_file_type"}
 	BASH_IT_LOG_PREFIX="core: main: "
 done
 

--- a/plugins/available/blesh.plugin.bash
+++ b/plugins/available/blesh.plugin.bash
@@ -10,7 +10,7 @@ fi
 _bash_it_ble_path=${XDG_DATA_HOME:-$HOME/.local/share}/blesh/ble.sh
 if [[ -f $_bash_it_ble_path ]]; then
 	# shellcheck disable=1090
-	source "$_bash_it_ble_path"
+	source "$_bash_it_ble_path" --attach=prompt
 else
 	_log_error "Could not find ble.sh in $_bash_it_ble_path"
 	_log_error "Please install using the following command:"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The recent change 23f9b741 has broken `plugin/blesh`. Because `ble.sh` now receives garbage arguments, it fails to interpret the arguments and cancels its loading.
- First, it should be noted that `source FILE` without arguments will inherit the arguments of the caller context.
- Originally, [`reloader.bash` has been called without arguments](https://github.com/Bash-it/bash-it/commit/23f9b7416a2db3290f27b1e45fab591218ba460c#diff-967b08ada7d8c340b3414a24e456ea88cd3e551147acfefa26a6cf2079f1fd36L58) for the current mechanism of enabling modules. The arguments have been [only supplied for the legacy loading](https://github.com/Bash-it/bash-it/commit/23f9b7416a2db3290f27b1e45fab591218ba460c#diff-967b08ada7d8c340b3414a24e456ea88cd3e551147acfefa26a6cf2079f1fd36L63). However, now the arguments are always specified to `reloader.bash` and are inherited by descendant sources including the external configurations. The unwanted arguments are `'' ''` for the current mechanism of loading modules.

In this PR,

- I explicitly specify an option to as `source ble.sh --attach=prompt` to override the arguments inherited by `realoder.bash`. 
- The arguments are specified to `reloader.bash` only for the leagcy loading.

Additionally, maybe we should separate the call of `reloader.bash` for the current enabling mechanism and the calls of `reloader.bash` for the legacy enabling as we have been doing originally before 23f9b741. I think the reason that they were originally separated is that these codes are considered deprecated. Mixing the up-to-date codes and the deprecated codes doesn't seem to be an improvement.

## Motivation and Context

All the plugins and other modules in `bash-it` are supposed to be correctly loaded by `bash-it`. This change is required to prevent all `source` in `bash-it` and external configurations (called from `reloader.bash` and its descendants) from receiving unexpected arguments that were originally specified to `reloader.bash`. This becomes a problem when there is any configuration that interprets its arguments. This solves possible problems caused by these unexpected arguments. At least, this solves the problem that `ble.sh` fails to start with `blesh` plugin in the current `master` (187916d90318e1fa2197a459b4caf78f553fa05c).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is not related to any open issue as far as I know. The problem is introduced in `master` just five days ago by merge commit 23f9b7416a2db3290f27b1e45fab591218ba460c. I have also checked recent pull requests but could not find related ones.

## How Has This Been Tested?

- Only the `blesh` plugin is enabled (disabled any other plugins, aliases, completions).
- The latest version of ble.sh (https://github.com/akinomyoga/ble.sh/commit/5015cb56075119d59c051a9852db035b8bd3ed12) is installed in `$HOME/.local`.
- Use the following commands to see if `ble.sh` is correctly loaded.

```bash
$ bash --norc
$ export BASH_IT="/path/to/bash-it"
$ source "$BASH_IT/bash-it.sh"
```

Before the fix (i.e., the current `master` 187916d90318e1fa2197a459b4caf78f553fa05c), the plugin produces the following error messages, and ble.sh is not enabled.

```
ble.sh: unrecognized argument ''
ble.sh: unrecognized argument ''
ble.sh: cancel initialization.
```

After the fix, the session normally starts without any error messages and with ble.sh being enabled correctly.

This PR may affect the arguments that other plugins, aliases, and completions receive, but will just make the behavior the one before the merge commit 23f9b741, so I don't think there will be any problems. Nevertheless, in principle, if there are any new plugins, aliases, or completions that assume the arguments `'' ''`, they can be broken.

## Screenshots (if appropriate):

The left panel shows the behavior in the current master (187916d9) where ble.sh isn't enabled. The right panel shows the behavior after the fix where ble.sh is correctly loaded and working.
<!-- ![image](https://user-images.githubusercontent.com/8982192/154791388-a1b87675-29b8-4411-aaaa-fb47ad593924.png) -->
<img width="45%" src="https://user-images.githubusercontent.com/8982192/154791441-62fdf465-a11e-4858-8ff5-8e0061935f6a.png" > <img width="45%" src="https://user-images.githubusercontent.com/8982192/154791411-7bf68ad0-152f-4772-8b7f-b28761cca3cb.png" >

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
