### PR TITLE
plugin/battery: fix handling of multiple batteries with `upower`

### DIFF
--- a/plugins/available/battery.plugin.bash
+++ b/plugins/available/battery.plugin.bash
@@ -4,8 +4,8 @@ about-plugin 'display info about your battery charge level'
 function ac_adapter_connected() {
 	local batteries
 	if _command_exists upower; then
-		batteries="$(upower -e | grep --max-count=1 -i BAT)"
-		upower -i "${batteries}" | grep 'state' | grep -q 'charging\|fully-charged'
+		IFS=$'\n' read -d '' -ra batteries < <(upower -e | grep -i BAT)
+		upower -i "${batteries[0]:-}" | grep 'state' | grep -q 'charging\|fully-charged'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "on-line"
 	elif _command_exists pmset; then
@@ -20,8 +20,8 @@ function ac_adapter_connected() {
 function ac_adapter_disconnected() {
 	local batteries
 	if _command_exists upower; then
-		batteries="$(upower -e | grep --max-count=1 -i BAT)"
-		upower -i "${batteries}" | grep 'state' | grep -q 'discharging'
+		IFS=$'\n' read -d '' -ra batteries < <(upower -e | grep -i BAT)
+		upower -i "${batteries[0]:-}" | grep 'state' | grep -q 'discharging'
 	elif _command_exists acpi; then
 		acpi -a | grep -q "off-line"
 	elif _command_exists pmset; then
@@ -40,8 +40,8 @@ function battery_percentage() {
 	local command_output batteries
 
 	if _command_exists upower; then
-		batteries="$(upower --enumerate | grep --max-count=1 -i BAT)"
-		command_output="$(upower --show-info "${batteries:-}" | grep percentage | grep -o '[0-9]\+' | head -1)"
+		IFS=$'\n' read -d '' -ra batteries < <(upower -e | grep -i BAT)
+		command_output="$(upower --show-info "${batteries[0]:-}" | grep percentage | grep -o '[0-9]\+' | head -1)"
 	elif _command_exists acpi; then
 		command_output=$(acpi -b | awk -F, '/,/{gsub(/ /, "", $0); gsub(/%/,"", $0); print $2}')
 	elif _command_exists pmset; then

--- a/test/plugins/battery.plugin.bats
+++ b/test/plugins/battery.plugin.bats
@@ -199,8 +199,7 @@ function setup_upower {
 	function upower {
 		case $1 in
 		'-e'|'--enumerate')
-			# don't just `echo` twice because `grep` will close the pipe after matching the first line...
-			echo "$BAT0"$'\n'"/org/freedesktop/UPower/devices/mouse_hid_${RANDOM}_battery"
+			printf '%s\n' "$BAT0" "/org/freedesktop/UPower/devices/mouse_hid_${RANDOM}_battery"
 			;;
 		'-i'|'--show-info')
 			if [[ $2 == "$BAT0" ]]


### PR DESCRIPTION
## Description
This should fix both our BATS tests as well as the `battery_percentage()` (and related) function(s) to properly handle multiple attached batteries, and closes #2104.

## Motivation and Context
The previous fix for multiple batteries returned by `upower -e` just tried to snip off the first line and run with it, but this seems to have triggered a bug in _Bash_ related to `set -o pipefail` (which is enabled by BATS during testing, and elsewhere). 

This patch changes `plugin/battery` to just read all the batteries into an array, thus not cutting off the enumeration prematurely and avoiding the testing bug. 

Currently, this patch does *not* handle any batteries after the first, but at least it doesn't just trim the list.

## How Has This Been Tested?
locally, and GitHub Actions

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
