### PR TITLE
Fix bash-it preview

### DIFF
--- a/lib/preview.bash
+++ b/lib/preview.bash
@@ -24,7 +24,7 @@ function _bash-it-preview() {
 	# shellcheck disable=SC2034
 	for BASH_IT_THEME in "${themes[@]}"; do
 		BASH_IT_LOG_LEVEL=0
-		bash --init-file "${BASH_IT_BASHRC:-${BASH_IT?}/bash_it.sh}" -i <<< '_bash-it-flash-term "${#BASH_IT_THEME}" "${BASH_IT_THEME}"'
+		bash --init-file "${BASH_IT?}/bash_it.sh" -i <<< '_bash-it-flash-term "${#BASH_IT_THEME}" "${BASH_IT_THEME}"'
 	done
 }
 

--- a/lib/search.bash
+++ b/lib/search.bash
@@ -347,7 +347,7 @@ function _bash-it-flash-term() {
 	local -i len="${1:-0}" # redundant
 	local term="${2:-}"
 	# as currently implemented, `$match` has already been printed to screen the first time
-	local delay=0.1
+	local delay=0.2
 	local color
 	[[ "${#term}" -gt 0 ]] && len="${#term}"
 


### PR DESCRIPTION
- lib: preview: Load only bash-it.sh when previewing
- lib: search: Increase delay in _bash-it-flash-term to 0.2 secs

Hi @gaelicWizard, seems like I bumped into a problem with bash-it preview. Please take a look!
