### PR TITLE
Rewrite wpscan completion with sub-completions

### DIFF
--- a/completion/available/wpscan.completion.bash
+++ b/completion/available/wpscan.completion.bash
@@ -1,16 +1,36 @@
 # shellcheck shell=bash
 
-_command_exists wpscan || return
+if _command_exists wpscan; then
+	function __wpscan_completion() {
+		local prev
+		prev=$(_get_pword)
 
-function __wpscan_completion() {
-	local _opt_
-	local OPTS=('--help' '--hh' '--version' '--url' '--ignore-main-redirect' '--verbose' '--output' '--format' '--detection-mode' '--scope' '--headers' '--user-agent' '--vhost' '--random-user-agent' '--user-agents-list' '--http-auth' '--max-threads' '--throttle' '--request-timeout' '--connect-timeout' '--disable-tlc-checks' '--proxy' '--proxy-auth' '--cookie-string' '--cookie-jar' '--cache-ttl' '--clear-cache' '--server' '--cache-dir' '--update' '--no-update' '--wp-content-dir' '--wp-plugins-dir' '--wp-version-detection' '--main-theme-detection' '--enumerate' '--exclude-content-based' '--plugins-list' '--plugins-detection' '--plugins-version-all' '--plugins-version-detection' '--themes-list' '--themes-detection' '--themes-version-all' '--themes-version-detection' '--timthumbs-list' '--timthumbs-detection' '--config-backups-list' '--config-backups-detection' '--db-exports-list' '--db-exports-detection' '--medias-detection' '--users-list' '--users-detection' '--passwords' '--usernames' '--multicall-max-passwords' '--password-attack' '--stealthy')
-	COMPREPLY=()
-	for _opt_ in "${OPTS[@]}"; do
-		if [[ "$_opt_" == "$2"* ]]; then
-			COMPREPLY+=("$_opt_")
-		fi
-	done
-}
+		case $prev in
+			-f | --format)
+				COMPREPLY=(cli cli-no-colour cli-no-color json)
+				;;
+			--server)
+				COMPREPLY=(apache iis nginx)
+				;;
+			*-detection)
+				COMPREPLY=(mixed passive aggressive)
+				;;
+			-e | --enumerate)
+				COMPREPLY=({a,v,}{p,t} tt cb dbe u m)
+				;;
+			--password-attack)
+				COMPREPLY=(wp-login xmlrpc xmlrpc-multicall)
+				;;
+			*)
+				COMPREPLY=(--url -h --help --hh --version --ignore-main-redirect -v --verbose --{no-,}banner --max-scan-duration -o --output --detection-mode
+					--scope --user-agent --ua --headers --vhost --random-user-agent --rua --user-agents-list --http-auth -t --max-threads --throttle --{request,connect}-timeout
+					--disable-tls --proxy{,-auth} --cookie-{string,jar} --cache-{ttl,dir} --clear-cache --server --{no-,}update --api-token --wp-{content,plugins}-dir
+					--interesting-findings-detection --wp-version-{all,detection} --main-theme-detection -e --enumerate --exclude-content-based --plugins-{list,detection,version-{all,detection},threshold}
+					--themes-{list,detection,version-{all,detection},threshold} --timthumbs-{detection,list} --config-backups-{detection,list} --db-exports-{detection,list}
+					--medias-detection --users-{list,detection} --exclude-usernames -P --passwords -U --usernames --multicall-max-passwords --password-attack --login-uri --stealthy)
+				;;
 
-complete -F __wpscan_completion wpscan
+		esac
+	}
+	complete -F __wpscan_completion -X '!&*' wpscan
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The old completions were outdated and didn't handle repeated completion and sub-command completions.


## Motivation and Context

Approach used in  #2107
 
## How Has This Been Tested?

Locally in macOS

## Screenshots (if appropriate):
<img width="1124" alt="Screenshot 2022-03-08 at 11 24 11 PM" src="https://user-images.githubusercontent.com/28386721/157296974-2d29aa31-6072-47fc-b965-ee4c5e41dc9d.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
