### PR TITLE
tests: Use git worktree correctly

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -41,7 +41,7 @@ function common_setup_file() {
 	BASH_IT="${BATS_FILE_TMPDIR//\/\///}/.bash_it"
 
 	# This sets up a local test fixture, i.e. a completely fresh and isolated Bash-it directory. This is done to avoid messing with your own Bash-it source directory.
-	git --git-dir="${MAIN_BASH_IT_GITDIR?}" worktree add -d "${BASH_IT}"
+	git --git-dir="${MAIN_BASH_IT_GITDIR?}" worktree add --detach "${BASH_IT}"
 
 	load "${BASH_IT?}/vendor/github.com/erichs/composure/composure.sh"
 	# support 'plumbing' metadata


### PR DESCRIPTION
git worktree -d does not work on all versions of git worktree

this seems to resolve my problems running the tests locally

## Description
<!--- Describe your changes in detail -->
After debugging the tests_setup a bit, I found out that git worktree call failed. After further testing, it seems like the `-d` flag was responsible for the failures

## Motivation and Context
Closes #2115 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running the tests :)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

