### PR TITLE
Fix dynamic clock icon

### DIFF
--- a/lib/command_duration.bash
+++ b/lib/command_duration.bash
@@ -11,7 +11,10 @@ function _command_duration_pre_exec() {
 }
 
 function _dynamic_clock_icon {
-	local -i clock_hand=$(((${1:-${SECONDS}} % 12) + 90))
+	local clock_hand
+	# clock hand value is between 90 and 9b in hexadecimal.
+	# so between 144 and 155 in base 10.
+	clock_hand=$(printf '%x' $(((${1:-${SECONDS}} % 12) + 144)))
 	printf -v 'COMMAND_DURATION_ICON' '%b' "\xf0\x9f\x95\x$clock_hand"
 }
 

--- a/lib/command_duration.bash
+++ b/lib/command_duration.bash
@@ -14,7 +14,7 @@ function _dynamic_clock_icon {
 	local clock_hand
 	# clock hand value is between 90 and 9b in hexadecimal.
 	# so between 144 and 155 in base 10.
-	clock_hand=$(printf '%x' $(((${1:-${SECONDS}} % 12) + 144)))
+	printf -v clock_hand '%x' $(( (${1:-${SECONDS}} % 12) + 144 ))
 	printf -v 'COMMAND_DURATION_ICON' '%b' "\xf0\x9f\x95\x$clock_hand"
 }
 

--- a/lib/command_duration.bash
+++ b/lib/command_duration.bash
@@ -14,7 +14,7 @@ function _dynamic_clock_icon {
 	local clock_hand
 	# clock hand value is between 90 and 9b in hexadecimal.
 	# so between 144 and 155 in base 10.
-	printf -v clock_hand '%x' $(( (${1:-${SECONDS}} % 12) + 144 ))
+	printf -v clock_hand '%x' $(((${1:-${SECONDS}} % 12) + 144))
 	printf -v 'COMMAND_DURATION_ICON' '%b' "\xf0\x9f\x95\x$clock_hand"
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

UTF8 clock value can be set between [90](https://www.fileformat.info/info/unicode/char/1f550/index.htm) and [9b](https://www.fileformat.info/info/unicode/char/1f55b/index.htm) in hexadecimal.
The current code was between 90 and 101.

## Motivation and Context

Clock icon was not correct for certain value.

## How Has This Been Tested?
```bash
for second in {1..15}; do
    clock_hand=$(printf '%x' $(((${1:-${second}} % 12) + 144)))
    printf '%b' "\xf0\x9f\x95\x$clock_hand"
done
```

## Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/64371/157426582-f6cc02e4-666e-462d-b227-88c79c16993a.png)

After:
![image](https://user-images.githubusercontent.com/64371/157426655-0eb53f04-c845-4856-a5c9-e2e43d470b58.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
