### PR TITLE
Fix grep path when a grep alias exists

### DIFF
--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -62,13 +62,13 @@ function _bash-it-array-dedup() {
 
 # Outputs a full path of the grep found on the filesystem
 function _bash-it-grep() {
-	: "${BASH_IT_GREP:=$(type -p egrep || type -p grep)}"
+	: "${BASH_IT_GREP:=$(type -P egrep || type -P grep)}"
 	printf "%s" "${BASH_IT_GREP:-/usr/bin/grep}"
 }
 
 # Runs `grep` with extended regular expressions
 function _bash-it-egrep() {
-	: "${BASH_IT_GREP:=$(type -p egrep || type -p grep)}"
+	: "${BASH_IT_GREP:=$(type -P egrep || type -P grep)}"
 	"${BASH_IT_GREP:-/usr/bin/grep}" -E "$@"
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix function that try to find a full path for grep.

## Motivation and Context

When a grep alias exists, `_bash-it-grep` and `_bash-it-egrep` are using `/usr/bin/grep` by default.
This break bash-it on debian based distribution, where grep is `/bin/grep`.

```bash
$ type -t grep
alias

$ type grep
grep is aliased to `grep --color=auto'

$ type -p egrep || type -p grep
# Output nothing
```

The fix is to use `type -P`:
```
-P	force a PATH search for each NAME, even if it is an alias,
    		builtin, or function, and returns the name of the disk file
    		that would be executed
-p	returns either the name of the disk file that would be executed,
    		or nothing if `type -t NAME' would not return `file'
```

## How Has This Been Tested?

When using bash-it on a debian system, I have this error before each prompt command
```
-bash: /usr/bin/grep: No such file or directory
```

After the change, no more error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [X] I have added tests to cover my changes, and all the new and existing tests pass.
