### PR TITLE
Clean capistrano completions and add options completions

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -35,6 +35,7 @@ completion/available/apm.completion.bash
 completion/available/awless.completion.bash
 completion/available/bash-it.completion.bash
 completion/available/brew.completion.bash
+completion/available/capistrano.completion.bash
 completion/available/cargo.completion.bash
 completion/available/composer.completion.bash
 completion/available/conda.completion.bash

--- a/completion/available/capistrano.completion.bash
+++ b/completion/available/capistrano.completion.bash
@@ -1,24 +1,36 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 # Bash completion support for Capistrano.
 
 export COMP_WORDBREAKS=${COMP_WORDBREAKS/\:/}
 
-_capcomplete() {
-    if [ -f Capfile ]; then
-        recent=`ls -t .cap_tasks~ Capfile **/*.cap 2> /dev/null | head -n 1`
-        if [[ $recent != '.cap_tasks~' ]]; then
-            cap --version | grep 'Capistrano v2.' > /dev/null
-            if [ $? -eq 0 ]; then
-              # Capistrano 2.x
-              cap --tool --verbose --tasks | cut -d " " -f 2 > .cap_tasks~
-            else
-              # Capistrano 3.x
-              cap --all --tasks | cut -d " " -f 2 > .cap_tasks~
-            fi
-        fi
-        COMPREPLY=($(compgen -W "`cat .cap_tasks~`" -- ${COMP_WORDS[COMP_CWORD]}))
-        return 0
-    fi
-}
+if _command_exists cap; then
+	function __cap_completions() {
+		[[ ! -f Capfile ]] && return 1
 
-complete -o default -o nospace -F _capcomplete cap
+		local cword
+		cword=$(_get_cword)
+
+		case $cword in
+			-*)
+				# Complete options
+				COMPREPLY=(--{suppress-,}backtrace --comments --job-stats --rules -A --all -B --build-all -C --directory -D --describe -e -E --execute{,-continue,-print} -f --rakefile
+					-G --{no{-,},}system -g -I --libdir -j --jobs -m --multitask -N --no{-,}search -P --prereqs --require -R --rakelib{dir,} -t --trace -T --tasks -W --where -X --no-deprecation-warning
+					-V --version -n --dry-run -r --roles -z --hosts -p --print-config-variables -h -H --help)
+				;;
+
+			*)
+				# Complete tasks
+				if cap --version | grep 'Capistrano v2.' > /dev/null; then
+					# Capistrano 2.x
+					read -ra COMPREPLY < <(cap --tool --verbose --tasks | awk '{print $2}' | tr '\n' ' ')
+				else
+					# Capistrano 3.x
+					read -ra COMPREPLY < <(cap --all --tasks | awk '{print $2}' | tr '\n' ' ')
+				fi
+				;;
+
+		esac
+	}
+
+	complete -F __cap_completions -X "!&*" cap
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This pull request fixes the following

1. `.cap_tasks~` file dependencies for the completion of the task
2. Fixed SC2006, SC2207, SC2012, SC2035, SC2181 and SC2086 shellcheck warnings
3. Added completions for `-*` options
4. Added condition to check the existence of the `cap` command
5. Implemented the use of filters `-X "!&*"` 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clean bashit #1696 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally on the Linux

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
