### PR TITLE
fix projects plugin regression

### DIFF
--- a/plugins/available/projects.plugin.bash
+++ b/plugins/available/projects.plugin.bash
@@ -21,7 +21,7 @@ function pj() {
 	# with the same name in project directories
 	IFS=':' read -ra dests <<< "${BASH_IT_PROJECT_PATHS?${FUNCNAME[0]}: project working folders must be configured}"
 	for d in "${!dests[@]}"; do
-		if [[ ! -d "${dests[d]}" ]]; then
+		if [[ ! -d "${dests[d]}/${proj}" ]]; then
 			unset 'dests[d]'
 		fi
 	done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix regression introduced in ea2002a.

Before this commit, when the provided project was unique under all the
project paths, the command automatically change the directory to it.
Currently this is no more the case.
If there are many project paths set, then the project path menu is shown
at every call.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Get the same behavior than before the regression was introduced.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
