### PR TITLE
plugin(dirs): Create backup file parent directory

### DIFF
--- a/plugins/available/dirs.plugin.bash
+++ b/plugins/available/dirs.plugin.bash
@@ -63,12 +63,15 @@ function dirs-help() {
 if [[ -f "${BASH_IT_DIRS_BKS?}" ]]; then
 	# shellcheck disable=SC1090
 	source "${BASH_IT_DIRS_BKS?}"
-elif [[ -f ~/.dirs ]]; then
-	mv -vn ~/.dirs "${BASH_IT_DIRS_BKS?}"
-	# shellcheck disable=SC1090
-	source "${BASH_IT_DIRS_BKS?}"
 else
-	touch "${BASH_IT_DIRS_BKS?}"
+	mkdir -p "${BASH_IT_DIRS_BKS%/*}"
+	if [[ -f ~/.dirs ]]; then
+		mv -vn ~/.dirs "${BASH_IT_DIRS_BKS?}"
+		# shellcheck disable=SC1090
+		source "${BASH_IT_DIRS_BKS?}"
+	else
+		touch "${BASH_IT_DIRS_BKS?}"
+	fi
 fi
 
 alias L='cat "${BASH_IT_DIRS_BKS?}"'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes #2143 

Creates parent directory for dirs plugin backup file.

## Description
<!--- Describe your changes in detail -->
Adds a mkdir commend to create the parent directory for the backup file before trying to touch the file itself.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Plugin currently assumes the parent directory exists and causes a failure with error msg during plugin initialization.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
