### PR TITLE
Issue 2151 🛂 do not give users a root shell by executing arbitrary shell commands by 'vim'

### DIFF
--- a/aliases/available/general.aliases.bash
+++ b/aliases/available/general.aliases.bash
@@ -71,10 +71,6 @@ alias rd='rmdir'
 # Shorten extract
 alias xt='extract'
 
-# sudo editors
-alias svim='sudo ${VISUAL:-vim}'
-alias snano='sudo nano'
-
 # Display whatever file is regular file or folder
 function catt() {
 	for i in "$@"; do


### PR DESCRIPTION
## Description
This PR fixes #2151 by by removing 'sudo' aliases because bash-it should not be the business of mucking about with sudo at all.

Initial purpose of this PR has changed and has been:
Use `sudoedit` instead of `sudo vim` which is a big security issue because users can get a root shell by executing arbitrary shell commands by `vim`!

## Motivation and Context
Nobody wants users to allow to become root just because they can edit any file (which would also make them root by manipulating the "right" with the "right" commands).
Issue #2151 will be fixed by this PR.

## How Has This Been Tested?
I use `sudoedit` instead  of `sudo vim` for some decades on different linux distributions and also on MacOS 😁 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly. - no change req'd.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``. - no files added
- [x] I have added tests to cover my changes, and all the new and existing tests pass. - there's nothing to add.
