### PR TITLE
Fix git info from getting stomped on when cycling through previous commands with up/down arrows

### DIFF
--- a/themes/simple/simple.theme.bash
+++ b/themes/simple/simple.theme.bash
@@ -13,7 +13,7 @@ case $TERM in
 esac
 
 function prompt_command() {
-	PS1="${TITLEBAR}${orange}${reset_color}${green}\w${bold_blue}\[$(scm_prompt_info)\]${normal} "
+	PS1="${TITLEBAR}${orange}${reset_color}${green}\w${bold_blue}$(scm_prompt_info)${normal} "
 }
 
 # scm themeing


### PR DESCRIPTION
## Description
The SCM prompt info was in a `\[ \]` block which denotes non printable characters. When pressing the up and down arrows to cycle through previous commands, the git information gets improperly emitted.

## Motivation and Context
When cycling though previous commands, occasionally the width of the prompt is incorrectly computed and it causes the command to start in the incorrect column. This is unexpected and can be confusing for users.

## How Has This Been Tested?
I'm running on Ubuntu 22.04 with gnome-terminal and tmux.
To test, I used the following procedure:
1. Open new terminal window, source `~/.bashrc` with existing config. cd into `~/.bash_it` directory to have some git prompt info.
2. Press up arrow until I observe that prompt is stomped on
3. Make proposed change, source  `~/.bashrc` again.
4. Press up arrow and observe that prompt works as expected
5. Revert proposed change, source `~/.bashrc` again.
6. Press up arrow and observe that prompt is stomped on.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/3020802/185258419-b0669e11-78a6-4c75-a858-d64501c99e0b.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.

I have run the existing tests, which all pass. I don't know how to simulate going through bash history in a unit test, nor do I understand what about the specific commands causes the prompt to get stomped on.
