### PR TITLE
Verbose version of `git add` (gav)

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -8,6 +8,7 @@ alias get='git'
 alias ga='git add'
 alias gall='git add -A'
 alias gap='git add -p'
+alias gav='git add -v'
 
 # branch
 alias gb='git branch'


### PR DESCRIPTION
## Description

Provides a Git alias for `git add -v`, which lists the files being added to the staging area.

## Motivation and Context

This aligns with the idea of `grv` (short for `git remote -v`, to display remotes verbosely).

## How Has This Been Tested?

I use this alias for years on my developer laptop.

## Checklist:

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
