### PR TITLE
Update variable name to match projects.plugin.bash

### DIFF
--- a/completion/available/projects.completion.bash
+++ b/completion/available/projects.completion.bash
@@ -7,7 +7,7 @@ _is_function _rl_enabled ||
 _pj() {
   _is_function _init_completion || return
   _is_function _rl_enabled || return
-  [ -n "$PROJECT_PATHS" ] || return
+  [ -n "$BASH_IT_PROJECT_PATHS" ] || return
   shift
   [ "$1" == "open" ] && shift
 
@@ -21,7 +21,7 @@ _pj() {
   local -r mark_dirs=$(_rl_enabled mark-directories && echo y)
   local -r mark_symdirs=$(_rl_enabled mark-symlinked-directories && echo y)
 
-  for i in ${PROJECT_PATHS//:/$'\n'}; do
+  for i in ${BASH_IT_PROJECT_PATHS//:/$'\n'}; do
     # create an array of matched subdirs
     k="${#COMPREPLY[@]}"
     for j in $( compgen -d $i/$cur ); do


### PR DESCRIPTION
## Description
The projects plugin was changed to reference `BASH_IT_PROJECT_PATHS` but the completion was still using `PROJECT_PATHS`

## Motivation and Context

This fixes a regression in the project completion code due to a refactor in the project plugin code

## How Has This Been Tested?

Tested locally

## Screenshots (if appropriate):

n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
