### PR TITLE
Fix loading of nvm for brew-installed nvm

### DIFF
--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -20,7 +20,7 @@ fi
 # This loads nvm
 if [[ -n "$NVM_BREW_PREFIX" && -s "${NVM_BREW_PREFIX}/nvm.sh" ]]
 then
-  source "$(brew --prefix nvm)/nvm.sh"
+  source "${NVM_BREW_PREFIX}/nvm.sh"
 else
   [[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
 fi

--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -9,8 +9,16 @@ cite about-plugin
 about-plugin 'node version manager configuration'
 
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+
+# first check if NVM is managed by brew
+NVM_BREW_PREFIX=""
+if _bash_it_homebrew_check
+then
+  NVM_BREW_PREFIX=$(brew --prefix nvm 2>/dev/null)
+fi
+
 # This loads nvm
-if _bash_it_homebrew_check && [[ -s "$(brew --prefix nvm)/nvm.sh" ]]
+if [[ -n "$NVM_BREW_PREFIX" && -s "${NVM_BREW_PREFIX}/nvm.sh" ]]
 then
   source "$(brew --prefix nvm)/nvm.sh"
 else

--- a/plugins/available/nvm.plugin.bash
+++ b/plugins/available/nvm.plugin.bash
@@ -10,9 +10,9 @@ about-plugin 'node version manager configuration'
 
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 # This loads nvm
-if _bash_it_homebrew_check && [[ -s "${BASH_IT_HOMEBREW_PREFIX}/nvm.sh" ]]
+if _bash_it_homebrew_check && [[ -s "$(brew --prefix nvm)/nvm.sh" ]]
 then
-  source "${BASH_IT_HOMEBREW_PREFIX}/nvm.sh"
+  source "$(brew --prefix nvm)/nvm.sh"
 else
   [[ -s "$NVM_DIR/nvm.sh" ]] && source "$NVM_DIR/nvm.sh"
 fi


### PR DESCRIPTION
Loading a brew-installed `nvm` was previously broken. This PR fixes it.

## Description

This reverts to the original (working) version from 2017. During the most recent refactor to use the `_bash_it_homebrew_check` helper method, it was overlooked that `${BASH_IT_HOMEBREW_PREFIX}/nvm.sh` is not the equivalent to `$(brew --prefix nvm)/nvm.sh` since `BASH_IT_HOMEBREW_PREFIX` is set from `brew --prefix` instead of `brew --prefix nvm`.

## Motivation and Context

This fixes a regression caused by 65ef8e2e8be9fc6ded3611751725a32548c933c2.

## How Has This Been Tested?

I've tested this on my local instance where I have `nvm` installed via `brew`.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
