### PR TITLE
remove function wrapper around kubectl aliases

### DIFF
--- a/aliases/available/kubectl.aliases.bash
+++ b/aliases/available/kubectl.aliases.bash
@@ -1,20 +1,16 @@
 # shellcheck shell=bash
 about-alias 'kubectl aliases'
 
-function _set_pkg_aliases() {
-	if _command_exists kubectl; then
-		alias kc='kubectl'
-		alias kcgp='kubectl get pods'
-		alias kcgd='kubectl get deployments'
-		alias kcgn='kubectl get nodes'
-		alias kcdp='kubectl describe pod'
-		alias kcdd='kubectl describe deployment'
-		alias kcdn='kubectl describe node'
-		alias kcgpan='kubectl get pods --all-namespaces'
-		alias kcgdan='kubectl get deployments --all-namespaces'
-		# launches a disposable netshoot pod in the k8s cluster
-		alias kcnetshoot='kubectl run netshoot-$(date +%s) --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
-	fi
-}
-
-_set_pkg_aliases
+if _command_exists kubectl; then
+	alias kc='kubectl'
+	alias kcgp='kubectl get pods'
+	alias kcgd='kubectl get deployments'
+	alias kcgn='kubectl get nodes'
+	alias kcdp='kubectl describe pod'
+	alias kcdd='kubectl describe deployment'
+	alias kcdn='kubectl describe node'
+	alias kcgpan='kubectl get pods --all-namespaces'
+	alias kcgdan='kubectl get deployments --all-namespaces'
+	# launches a disposable netshoot pod in the k8s cluster
+	alias kcnetshoot='kubectl run netshoot-$(date +%s) --rm -i --tty --image nicolaka/netshoot -- /bin/bash'
+fi


### PR DESCRIPTION
This is minor house cleaning. I saw the function name and didn't like that it's name wasn't well scoped,
and further, I see no need for wrapping this logic with a function.

Thought for the future:  maybe all alias loading should be wrapped in a callable with a predictable name?
e.g. `_bash_it_load_alias_<alias plugin name>`

## Motivation and Context
I don't like polluting the global namespace with poorly named functions

## How Has This Been Tested?
See the test output.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
