### PR TITLE
Use grep -E instead of egrep

### DIFF
--- a/completion/available/fabric.completion.bash
+++ b/completion/available/fabric.completion.bash
@@ -91,7 +91,7 @@ function __fab_completion() {
         -*)
             if [[ -z "${__FAB_COMPLETION_LONG_OPT}" ]]; then
                 export __FAB_COMPLETION_LONG_OPT=$(
-                    fab --help | egrep -o "\-\-[A-Za-z_\-]+\=?" | sort -u)
+                    fab --help | grep -E -o "\-\-[A-Za-z_\-]+\=?" | sort -u)
             fi
             opts="${__FAB_COMPLETION_LONG_OPT}"
             ;;

--- a/completion/available/gradle.completion.bash
+++ b/completion/available/gradle.completion.bash
@@ -66,7 +66,7 @@ __gradle-generate-script-cache() {
 
     if [[ ! $(find $cache_dir/$cache_name -mmin -$cache_ttl_mins 2>/dev/null) ]]; then
         # Cache all Gradle scripts
-        local gradle_build_scripts=$(find $project_root_dir -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | egrep -v "$script_exclude_pattern")
+        local gradle_build_scripts=$(find $project_root_dir -type f -name "*.gradle" -o -name "*.gradle.kts" 2>/dev/null | grep -E -v "$script_exclude_pattern")
         printf "%s\n" "${gradle_build_scripts[@]}" > $cache_dir/$cache_name
     fi
 }

--- a/lib/utilities.bash
+++ b/lib/utilities.bash
@@ -62,13 +62,13 @@ function _bash-it-array-dedup() {
 
 # Outputs a full path of the grep found on the filesystem
 function _bash-it-grep() {
-	: "${BASH_IT_GREP:=$(type -P egrep || type -P grep)}"
+	: "${BASH_IT_GREP:=$(type -P grep)}"
 	printf "%s" "${BASH_IT_GREP:-/usr/bin/grep}"
 }
 
 # Runs `grep` with extended regular expressions
 function _bash-it-egrep() {
-	: "${BASH_IT_GREP:=$(type -P egrep || type -P grep)}"
+	: "${BASH_IT_GREP:=$(type -P grep)}"
 	"${BASH_IT_GREP:-/usr/bin/grep}" -E "$@"
 }
 

--- a/plugins/available/aws.plugin.bash
+++ b/plugins/available/aws.plugin.bash
@@ -40,13 +40,13 @@ function __awskeys_help {
 function __awskeys_get {
     local ln=$(grep -n "\[ *$1 *\]" "${AWS_SHARED_CREDENTIALS_FILE}" | cut -d ":" -f 1)
     if [[ -n "${ln}" ]]; then
-        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | egrep -m 2 "aws_access_key_id|aws_secret_access_key"
-        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | egrep -m 1 "aws_session_token"
+        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | grep -E -m 2 "aws_access_key_id|aws_secret_access_key"
+        tail -n +${ln} "${AWS_SHARED_CREDENTIALS_FILE}" | grep -E -m 1 "aws_session_token"
     fi
 }
 
 function __awskeys_list {
-    local credentials_list="$((egrep '^\[ *[a-zA-Z0-9_-]+ *\]$' "${AWS_SHARED_CREDENTIALS_FILE}"; grep "\[profile" "${AWS_CONFIG_FILE}" | sed "s|\[profile |\[|g") | sort | uniq)"
+    local credentials_list="$((grep -E '^\[ *[a-zA-Z0-9_-]+ *\]$' "${AWS_SHARED_CREDENTIALS_FILE}"; grep "\[profile" "${AWS_CONFIG_FILE}" | sed "s|\[profile |\[|g") | sort | uniq)"
     if [[ -n $"{credentials_list}" ]]; then
         echo -e "Available credentials profiles:\n"
         for profile in ${credentials_list}; do

--- a/plugins/available/postgres.plugin.bash
+++ b/plugins/available/postgres.plugin.bash
@@ -50,7 +50,7 @@ function postgres_status {
 
 
 function is_postgres_running {
-  $POSTGRES_BIN/pg_ctl -D $PGDATA status | egrep -o "no server running"
+  $POSTGRES_BIN/pg_ctl -D $PGDATA status | grep -E -o "no server running"
 }
 
 

--- a/themes/rjorgenson/rjorgenson.theme.bash
+++ b/themes/rjorgenson/rjorgenson.theme.bash
@@ -50,7 +50,7 @@ function is_integer() { # helper function for todo-txt-count
 
 todo_txt_count() {
     if `hash todo.sh 2>&-`; then # is todo.sh installed
-        count=`todo.sh ls | egrep "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }'`
+        count=`todo.sh ls | grep -E "TODO: [0-9]+ of ([0-9]+) tasks shown" | awk '{ print $4 }'`
         if is_integer $count; then # did we get a sane answer back
             echo "${BRACKET_COLOR}[${STRING_COLOR}T:$count${BRACKET_COLOR}]$normal"
         fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`egrep` binary is obselete and should be replaced with `grep -E`

![Screenshot_20221007_195336](https://user-images.githubusercontent.com/28386721/194576700-17d4c52d-d194-4661-819f-3fccc3439bb2.png)


## Motivation and Context

This change will remove the annoying warning message from the console

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

After fixing it would not echo the warning

![Screenshot_20221007_195548](https://user-images.githubusercontent.com/28386721/194577399-5155d253-a99b-4694-a39a-907921514717.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
