### PR TITLE
bug: Use en_US when fetching EPOCHREALTIME

### DIFF
--- a/plugins/available/cmd-returned-notify.plugin.bash
+++ b/plugins/available/cmd-returned-notify.plugin.bash
@@ -4,7 +4,8 @@ about-plugin 'Alert (BEL) when process ends after a threshold of seconds'
 
 function precmd_return_notification() {
 	local command_start="${COMMAND_DURATION_START_SECONDS:=0}"
-	local current_time="${EPOCHREALTIME:-$SECONDS}"
+	local current_time
+	current_time="$(_shell_duration_en)"
 	local -i command_duration="$((${current_time%.*} - ${command_start%.*}))"
 	if [[ "${command_duration}" -gt "${NOTIFY_IF_COMMAND_RETURNS_AFTER:-5}" ]]; then
 		printf '\a'

--- a/test/plugins/cmd-returned-notify.plugin.bats
+++ b/test/plugins/cmd-returned-notify.plugin.bats
@@ -9,7 +9,7 @@ function local_setup_file() {
 
 @test "plugins cmd-returned-notify: notify after elapsed time" {
 	export NOTIFY_IF_COMMAND_RETURNS_AFTER=0
-	export COMMAND_DURATION_START_SECONDS="${EPOCHREALTIME:-$SECONDS}"
+	export COMMAND_DURATION_START_SECONDS="$(_shell_duration_en)"
 	sleep 1
 	run precmd_return_notification
 	assert_success
@@ -18,7 +18,7 @@ function local_setup_file() {
 
 @test "plugins cmd-returned-notify: do not notify before elapsed time" {
 	export NOTIFY_IF_COMMAND_RETURNS_AFTER=10
-	export COMMAND_DURATION_START_SECONDS="${EPOCHREALTIME:-$SECONDS}"
+	export COMMAND_DURATION_START_SECONDS="$(_shell_duration_en)"
 	sleep 1
 	run precmd_return_notification
 	assert_success
@@ -34,7 +34,7 @@ function local_setup_file() {
 @test "lib command_duration: preexec set COMMAND_DURATION_START_SECONDS" {
 	export COMMAND_DURATION_START_SECONDS=
 	assert_equal "${COMMAND_DURATION_START_SECONDS}" ""
-	NOW="${EPOCHREALTIME:-$SECONDS}"
+	NOW="$(_shell_duration_en)"
 	_command_duration_pre_exec
 	# We need to make sure to account for nanoseconds...
 	assert_equal "${COMMAND_DURATION_START_SECONDS%.*}" "${NOW%.*}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Isolates fetching of EPOCHREALTIME to a function which sets LC_ALL=en_US.UTF-8.
This ensures that the value is in decimal format, regardless of runtime locale.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes #2171 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
