### PR TITLE
bug:CI Lint - Install shellcheck via wget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,17 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+    # - name: Update APT Package Lists
+      # run: sudo apt-get update
     - name: Install shfmt
       run: GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
     - name: Install shellcheck
-      run: brew install shellcheck
+      env:
+        scversion: stable # Or latest, vxx, etc
+      run: |
+        wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv "shellcheck-${scversion}/shellcheck"
+        sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
+        shellcheck --version
     - name: Install pre-commit
       run: python3 -m pip install -r test/lint-requirements.txt
     - name: Run lint


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes breaking 'lint' ci job

## Description
<!--- Describe your changes in detail -->
replaces use of `brew` when installing shellcheck.

Now fetches pre-compiled stable linux version from project's github releases

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Brew stopped being installed by default on github ubuntu images, breaking the ability to use it to install shellcheck.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This PR's lint pipeline task runs successfully !

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
