### PR TITLE
Fix call to liquidprompt function

### DIFF
--- a/themes/liquidprompt/liquidprompt.theme.bash
+++ b/themes/liquidprompt/liquidprompt.theme.bash
@@ -48,7 +48,7 @@ _lp_git_branch()
     local commit branch ret
 
     commit="$(\git rev-parse --short -q HEAD 2>/dev/null)"
-    
+
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then

--- a/themes/liquidprompt/liquidprompt.theme.bash
+++ b/themes/liquidprompt/liquidprompt.theme.bash
@@ -40,10 +40,11 @@ _lp_git_branch()
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
         __lp_escape "$(\git rev-parse --short=5 -q HEAD 2>/dev/null):${branch#refs/heads/}"
+        lp_vcs_branch="$ret"
     else
         # In detached head state, use commit instead
         # No escape needed
-        \git rev-parse --short -q HEAD 2>/dev/null
+        lp_vcs_branch="$(\git rev-parse --short -q HEAD 2>/dev/null)"
     fi
 }
 

--- a/themes/liquidprompt/liquidprompt.theme.bash
+++ b/themes/liquidprompt/liquidprompt.theme.bash
@@ -39,7 +39,7 @@ _lp_git_branch()
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
-        _lp_escape "$(\git rev-parse --short=5 -q HEAD 2>/dev/null):${branch#refs/heads/}"
+        __lp_escape "$(\git rev-parse --short=5 -q HEAD 2>/dev/null):${branch#refs/heads/}"
     else
         # In detached head state, use commit instead
         # No escape needed

--- a/themes/liquidprompt/liquidprompt.theme.bash
+++ b/themes/liquidprompt/liquidprompt.theme.bash
@@ -35,7 +35,7 @@ _lp_git_branch()
 
     \git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
 
-    local branch
+    local branch ret
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then

--- a/themes/liquidprompt/liquidprompt.theme.bash
+++ b/themes/liquidprompt/liquidprompt.theme.bash
@@ -21,7 +21,7 @@ export LP_BATTERY_THRESHOLD=${LP_BATTERY_THRESHOLD:-75}
 export LP_LOAD_THRESHOLD=${LP_LOAD_THRESHOLD:-60}
 export LP_TEMP_THRESHOLD=${LP_TEMP_THRESHOLD:-80}
 
-
+unset _lp_legacy _lp_escape __lp_escape
 source "$targetdir/liquidprompt"
 prompt() { true; }
 export PS2=" ┃ "
@@ -29,23 +29,37 @@ export LP_PS1_PREFIX="┌─"
 export LP_PS1_POSTFIX="\n└▪ "
 export LP_ENABLE_RUNTIME=0
 
+_lp_legacy()
+{
+    type -t _lp_escape &> /dev/null
+}
+
+_lp_legacy && __lp_escape()
+{
+    ret="$(_lp_escape "$@")"
+}
+
 _lp_git_branch()
 {
     (( LP_ENABLE_GIT )) || return
 
     \git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return
 
-    local branch ret
+    local commit branch ret
+
+    commit="$(\git rev-parse --short -q HEAD 2>/dev/null)"
+    
     # Recent versions of Git support the --short option for symbolic-ref, but
     # not 1.7.9 (Ubuntu 12.04)
     if branch="$(\git symbolic-ref -q HEAD)"; then
-        __lp_escape "$(\git rev-parse --short=5 -q HEAD 2>/dev/null):${branch#refs/heads/}"
+        __lp_escape "$commit:${branch#refs/heads/}"
         lp_vcs_branch="$ret"
     else
         # In detached head state, use commit instead
         # No escape needed
-        lp_vcs_branch="$(\git rev-parse --short -q HEAD 2>/dev/null)"
+        lp_vcs_branch="$commit"
     fi
+    _lp_legacy && echo $lp_vcs_branch || return 0
 }
 
 _lp_time() {


### PR DESCRIPTION
Missing leading underscore in `_lp_escape`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Without this - presumably - the code fails silently, never presenting the branch name in the PS1 prompt.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Forgive me if there are tests for themes, but I could not find any; I personally tested this by cd'ing into and out of Git clone directories with and without the fix.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
