### PR TITLE
Fix duplicate declaration of `grm`, update `grb<*>`

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -21,7 +21,6 @@ alias gblr='git branch --list --remotes'
 alias gbm='git branch --move'
 alias gbr='git branch --remotes'
 alias gbt='git branch --track'
-alias gdel='git branch -D'
 
 # for-each-ref
 alias gbc='git for-each-ref --format="%(authorname) %09 %(if)%(HEAD)%(then)*%(else)%(refname:short)%(end) %09 %(creatordate)" refs/remotes/ --sort=authorname DESC' # FROM https://stackoverflow.com/a/58623139/10362396
@@ -133,9 +132,9 @@ alias grm='git rm'
 # rebase
 alias grb='git rebase'
 alias grbc='git rebase --continue'
-alias grm='git rebase $(get_default_branch)'
-alias grmi='git rebase $(get_default_branch) -i'
-alias grma='GIT_SEQUENCE_EDITOR=: git rebase  $(get_default_branch) -i --autosquash'
+alias grbm='git rebase $(get_default_branch)'
+alias grbmi='git rebase $(get_default_branch) -i'
+alias grbma='GIT_SEQUENCE_EDITOR=: git rebase  $(get_default_branch) -i --autosquash'
 alias gprom='git fetch origin $(get_default_branch) && git rebase origin/$(get_default_branch) && git update-ref refs/heads/$(get_default_branch) origin/$(get_default_branch)' # Rebase with latest remote
 
 # reset


### PR DESCRIPTION
## Description
Consolidates the `git rebase` aliases thus fixing the unintended overloading of `grm`. `gdel` is outphased as an unclear, non-intuitive sibling of `gbD` (git branch --delete --force).

## Motivation and Context
`grm` is an alias for `git rebase` due to being [redeclared](https://github.com/Bash-it/bash-it/blob/master/aliases/available/git.aliases.bash#L125-L131) after the first `grm` (git rm). The redeclaration is a bug.

Closes #2160.

## How Has This Been Tested?
n/a

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
