### PR TITLE
bug: Use C style strings when checking for invalid alias characters

### DIFF
--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -50,7 +50,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 		fi
 
 		# skip aliases to pipes, boolean control structures and other command lists
-		chars='\|\&\;\)\(\n\<\>'
+		chars=$'\|\&\;\)\(\n\<\>'
 		if [[ "${alias_defn}" =~ [$chars] ]]; then
 			continue
 		fi

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -50,7 +50,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 		fi
 
 		# skip aliases to pipes, boolean control structures and other command lists
-		chars=$'|&;)(n<>'
+		chars=$'|&;()<>\n'
 		if [[ "${alias_defn}" =~ [$chars] ]]; then
 			continue
 		fi

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -50,7 +50,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 		fi
 
 		# skip aliases to pipes, boolean control structures and other command lists
-		chars=$'\|\&\;\)\(\n\<\>'
+		chars=$'|&;)(n<>'
 		if [[ "${alias_defn}" =~ [$chars] ]]; then
 			continue
 		fi


### PR DESCRIPTION
## Description
Before, the '\n' in the characters being checked would be interpreted as 'n' rather than newline meaning that any alias who's command contained the letter 'n' would be incorrectly skipped.

## Motivation and Context
This bug is annoying as certain aliases will appear to randomly not have completion for them.

## How Has This Been Tested?
- Tests pass locally.
- My `alias gb='git branch'` alias now shows the correct completion
- Tested that the C style string usage still correctly identifies aliases with disallowed characters

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
