### PR TITLE
FEAT: Add Aptitude aliases

### DIFF
--- a/aliases/available/aptitude.aliases.bash
+++ b/aliases/available/aptitude.aliases.bash
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+#
+# -binaryanomaly
+
+cite 'about-alias'
+about-alias 'Aptitude and dpkg aliases for Ubuntu and Debian distros.'
+
+# set apt aliases
+function _set_pkg_aliases() {
+	if _command_exists aptitude; then
+		alias apts='aptitude search'
+		alias aptshow='aptitude show'
+		alias aptinst='sudo aptitude install -V'
+		alias aptupd='sudo aptitude update'
+		alias aptsupg='sudo aptitude safe-upgrade'
+		alias aptupg='sudo apt-get dist-upgrade -V && sudo apt-get autoremove'
+		alias aptupgd='sudo apt-get update && sudo apt-get dist-upgrade -V && sudo apt-get autoremove'
+		alias aptrm='sudo aptitude remove'
+		alias aptpurge='sudo aptitude purge'
+		alias aptclean='sudo aptitude clean && sudo aptitude autoclean'
+		alias apty='aptitude why'
+		alias aptyn='aptitude why-not'
+
+		alias chkup='/usr/lib/update-notifier/apt-check -p --human-readable'
+		alias chkboot='cat /var/run/reboot-required'
+
+		alias pkgfiles='dpkg --listfiles'
+		alias listinstalled='aptitude search "~i!~M"'
+	fi
+}
+
+_set_pkg_aliases


### PR DESCRIPTION
Why?:
- Aptitude is an alternative to apt with a great user interface, so there should also be some aliases that make using it as easy as with the apt aliases.

This change addresses the need by:
- Add new alias file aptitude.aliases.bash with most of the same Apt aliases instead using Aptitude
- Also add some new aliases for Aptitude specific features like "why-not"


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
