### PR TITLE
Allow for longer command min duration

### DIFF
--- a/lib/command_duration.bash
+++ b/lib/command_duration.bash
@@ -59,16 +59,16 @@ function _command_duration() {
 		command_duration=0
 	fi
 
-	if ((command_duration > 0)); then
+	if ((command_duration >= COMMAND_DURATION_MIN_SECONDS)); then
 		minutes=$((command_duration / 60))
 		seconds=$((command_duration % 60))
-	fi
 
-	_dynamic_clock_icon "${command_duration}"
-	if ((minutes > 0)); then
-		printf "%s %s%dm %ds" "${COMMAND_DURATION_ICON:-}" "${COMMAND_DURATION_COLOR:-}" "$minutes" "$seconds"
-	elif ((seconds >= COMMAND_DURATION_MIN_SECONDS)); then
-		printf "%s %s%d.%01ds" "${COMMAND_DURATION_ICON:-}" "${COMMAND_DURATION_COLOR:-}" "$seconds" "$deciseconds"
+		_dynamic_clock_icon "${command_duration}"
+		if ((minutes > 0)); then
+			printf "%s %s%dm %ds" "${COMMAND_DURATION_ICON:-}" "${COMMAND_DURATION_COLOR:-}" "$minutes" "$seconds"
+		else
+			printf "%s %s%d.%01ds" "${COMMAND_DURATION_ICON:-}" "${COMMAND_DURATION_COLOR:-}" "$seconds" "$deciseconds"
+		fi
 	fi
 }
 


### PR DESCRIPTION
## Description
Allows for setting "COMMAND_DURATION_MIN_SECONDS" to more than 60 seconds without adding to the prompt. Previously always showed with lengths over 60 seconds regardless of setting. The documentation does not mention that it would always show when over 1 minute so no change is necessary.

## Motivation and Context
Allows setting minimum duration for prompts longer than 60 seconds.

## How Has This Been Tested?
Tested locally on Ubuntu 22.04 and Debian 11 using sleep of various lengths.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
