### PR TITLE
fix: lint :green_heart:

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.21.0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
@@ -52,7 +52,7 @@ jobs:
     # - name: Update APT Package Lists
       # run: sudo apt-get update
     - name: Install shfmt
-      run: GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
+      run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
     - name: Install shellcheck
       env:
         scversion: stable # Or latest, vxx, etc


### PR DESCRIPTION
## Description

This commit bumps `go` version to 1.21.0 and changes `go get` to `go install`.


## Motivation and Context

Current workflow for PRs is broken because the tool that is invoked to format the code, `shfmt`, requires `go` >= 1.19.

## How Has This Been Tested?

Workflow was launched again after fix and it doesn't fail anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
