### PR TITLE
Add git alias `gshn` (`git show --name-only`)

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -152,6 +152,8 @@ alias gsl='git shortlog -sn'
 
 # show
 alias gsh='git show'
+alias gshn='git show --name-only'
+alias gshns='git show --name-status'
 
 # svn
 alias gsd='git svn dcommit'


### PR DESCRIPTION
Adds a short Git alias for `git show --name-only`, which list the files affected by the changes only (instead of the full diff).

## Description
The Git command `git show --name-only` list only the files affected by the changes instead of showing the full diff, which comes in handy when you need to know which files were affected w/o being distracted by the full diff of the changes.

The additional `git show --name-status` shows the current version control status of the listed files. (Maybe interesting to note, this is like a light version of `git whatchanged -1`.)

## Motivation and Context
Just two convenient aliases in addition to `gsh` (`git show`) to avoid the need for typing and remembering the lengthy `--name-only` and `--name-status` options.

## How Has This Been Tested?
I tried it out locally, applied the identical change to my local Bash-it setup.

Verified that there are no alias conflicts by grepping for "gsh" over the repository HEAD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
