### PR TITLE
Add alias for `git reset --hard` and `grh` like OMZ

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -139,7 +139,9 @@ alias grma='GIT_SEQUENCE_EDITOR=: git rebase  $(get_default_branch) -i --autosqu
 alias gprom='git fetch origin $(get_default_branch) && git rebase origin/$(get_default_branch) && git update-ref refs/heads/$(get_default_branch) origin/$(get_default_branch)' # Rebase with latest remote
 
 # reset
-alias gus='git reset HEAD'
+alias gus='git reset HEAD'  # read as: 'git unstage'
+alias grh='git reset'  # equivalent to: git reset HEAD
+alias grh!='git reset --hard'
 alias gpristine='git reset --hard && git clean -dfx'
 
 # status


### PR DESCRIPTION
Adds two aliases for `git reset`, which are [inspired by OMZ](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git).

## Description
- `grh` is a natural acronym for `git reset HEAD`.
- `grh!` is the "dangerous" version of `git reset`, which throws away everything, hence the exclamation mark.

## Motivation and Context
The existing Git alias for `git reset` is not immediately obvious, unless you are used to think in terms of "stage" and "unstage".

## How Has This Been Tested?
I use this on a daily basis, having it integrated identically in a fresh installation of Bash-it on my developer laptop.

The new aliases don't clash with existing ones, as verified manually by a simple text search in the file and a grep over the repository HEAD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
