### PR TITLE
Add alias for `git pull --prune`

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -117,6 +117,7 @@ alias gpuoc='git push --set-upstream origin $(git symbolic-ref --short HEAD)'
 
 # pull
 alias gl='git pull'
+alias glp='git pull --prune'
 alias glum='git pull upstream $(get_default_branch)'
 alias gpl='git pull'
 alias gpp='git pull && git push'


### PR DESCRIPTION
Adds a new alias for pulling changes with Git.

## Description
From the `git-pull` man page:

> -p, --prune
> Before fetching, remove any remote-tracking references that no longer exist on the remote.

## Motivation and Context
When working with feature branches it's necessary to clean up branches from time to time. The alias makes this recurring task easier.

## How Has This Been Tested?
I have the exact same changes integrated in a local, fresh installation of Bash-it on my developer laptop.

I grepped for "glp" over the current repository HEAD to verify that there are no conflicting aliases.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.