### PR TITLE
Add more aliases for `git merge` and `git rebase`

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -97,6 +97,9 @@ fi
 
 # merge
 alias gm='git merge'
+alias gma='git merge --abort'
+alias gmc='git merge --continue'
+alias gms='git merge --squash'
 
 # mv
 alias gmv='git mv'
@@ -132,7 +135,9 @@ alias grm='git rm'
 
 # rebase
 alias grb='git rebase'
+alias grba='git rebase --abort'
 alias grbc='git rebase --continue'
+alias grbi='git rebase --interactive'
 alias grm='git rebase $(get_default_branch)'
 alias grmi='git rebase $(get_default_branch) -i'
 alias grma='GIT_SEQUENCE_EDITOR=: git rebase  $(get_default_branch) -i --autosquash'


### PR DESCRIPTION
Adds Git aliases for merging are rebasing, which are needed when conflicts occur.

## Description
For a better user experience, the same pattern for constructing the aliases is applied for merge and rebase. The aliases also largely match [the ones provided by OMZ](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git). `gms` is inspired by OMZ (I have never used it, personally).

## Motivation and Context
When working with branches conflicts can occur and need to be resolved. This may involve options like `--continue` and `--abort` for merge and rebase. Some developers may even want to perform `--interactive` rebasing.

## How Has This Been Tested?
I have the identical changes integrated in a fresh, local installation of Bash-it on my developer laptop.

To verify that the aliases don't conflict with existing ones, I have grepped the current repository HEAD for "gma", "gmc", "gms", "grba", "grbc" and "grbi". 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
