### PR TITLE
Clean `aliases.completion.bash`

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -31,6 +31,7 @@ lint_clean_files.sh
 
 # completions
 #
+completion/available/aliases.completion.bash
 completion/available/apm.completion.bash
 completion/available/awless.completion.bash
 completion/available/awscli.completion.bash

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -20,7 +20,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 	completions=("${completions[@]##complete -* * -}") # strip all but last option plus trigger(s)
 	completions=("${completions[@]#complete -}")       # strip anything missed
 	completions=("${completions[@]#? * }")             # strip last option and arg, leaving only trigger(s)
-	completions=("${completions[@]#? }")       # strip anything missed
+	completions=("${completions[@]#? }")               # strip anything missed
 	#TODO: this will fail on some completions...
 
 	# create temporary file for wrapper functions and completions
@@ -40,10 +40,10 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 		line="${line#alias -- }"
 		line="${line#alias }"
 		alias_name="${line%%=*}"
-		alias_defn="${line#*=\'}"                 # alias definition
+		alias_defn="${line#*=\'}" # alias definition
 		alias_defn="${alias_defn%\'}"
 		alias_cmd="${alias_defn%%[[:space:]]*}" # first word of alias
-		if [[ ${alias_defn} == ${alias_cmd} ]]; then
+		if [[ ${alias_defn} == "${alias_cmd}" ]]; then
 			alias_args=''
 		else
 			alias_args="${alias_defn#*[[:space:]]}" # everything after first word
@@ -89,7 +89,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
                             prec_word=\${prec_word#* }
                         fi
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))
-                        COMP_WORDS=(\"$alias_cmd\" \"${alias_arg_words[@]}\" \"\${COMP_WORDS[@]:1}\")
+                        COMP_WORDS=(\"$alias_cmd\" \"${alias_arg_words[*]}\" \"\${COMP_WORDS[@]:1}\")
                         (( COMP_POINT -= \${#COMP_LINE} ))
                         COMP_LINE=\${COMP_LINE/$alias_name/$alias_cmd $alias_args}
                         (( COMP_POINT += \${#COMP_LINE} ))


### PR DESCRIPTION
## Description

Followed instructions in #1696 to cleanup `aliases.completion.bash`

## Motivation and Context

Addresses #1696

## How Has This Been Tested?

Ran `./lint_clean_files.sh`

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Clean

## Checklist:

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
