### PR TITLE
Tweaks to clean files scripts and file list

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -19,6 +19,7 @@
 aliases/
 docs/
 hooks/
+lib/
 scripts/
 
 # root files
@@ -77,18 +78,6 @@ completion/available/vault.completion.bash
 completion/available/vuejs.completion.bash
 completion/available/wpscan.completion.bash
 completion/available/yarn.completion.bash
-
-# libraries
-lib/appearance.bash
-lib/colors.bash
-lib/command_duration.bash
-lib/helpers.bash
-lib/history.bash
-lib/log.bash
-lib/preexec.bash
-lib/preview.bash
-lib/search.bash
-lib/utilities.bash
 
 # plugins
 #

--- a/lint_clean_files.sh
+++ b/lint_clean_files.sh
@@ -10,7 +10,7 @@ mapfile -t FILES < <(
 	cat clean_files.txt \
 		| grep -E -v '^\s*$' \
 		| grep -E -v '^\s*#' \
-		| xargs -n1 -I{} find "{}" -type f
+		| xargs -I{} find "{}" -type f
 )
 
 # We clear the BASH_IT variable to help the shellcheck checker


### PR DESCRIPTION
## Description

I noticed that all files under `lib/*` were manually specified in `clean_files.txt`. I refactored that to the first section.

When running the `lint_clean_files.sh` script, I receieve the following message:

```text
xargs: warning: options --max-args and --replace/-I/-i are mutually exclusive, ignoring previous --max-args value
...
```

Because the previuos `--max-args` / `-n` value is ignored anyways, and to remove the warning, I removed that option from the script.

## Motivation and Context

This simplifes the cleaning files workflow.

## How Has This Been Tested?

By executing `./lint_clean_files.sh`. And double-checking to ensure that directories are, in fact, supported by `clean_files.txt`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
