### PR TITLE
 added new theme (lambda)

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -162,6 +162,7 @@ themes/candy
 themes/easy
 themes/essential
 themes/githelpers.theme.bash
+themes/lambda
 themes/modern
 themes/norbu
 themes/oh-my-posh
@@ -170,7 +171,7 @@ themes/pete
 themes/powerline
 themes/pure
 themes/purity
-themes/lambda
+
 
 # vendor init files
 #

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -170,6 +170,7 @@ themes/pete
 themes/powerline
 themes/pure
 themes/purity
+themes/lambda
 
 # vendor init files
 #

--- a/themes/lambda/lambda.theme.bash
+++ b/themes/lambda/lambda.theme.bash
@@ -1,3 +1,6 @@
+#!/bin/bash
+# shellcheck disable=SC1090,SC2034
+
 function set_prompt {
     local user_color="\[\033[1;31m\]"  # bold red for username
     local at_color="\[\033[1;37m\]"    # bold white for @ symbol

--- a/themes/lambda/lambda.theme.bash
+++ b/themes/lambda/lambda.theme.bash
@@ -1,0 +1,30 @@
+function set_prompt {
+    local user_color="\[\033[1;31m\]"  # bold red for username
+    local at_color="\[\033[1;37m\]"    # bold white for @ symbol
+    local host_color="\[\033[1;31m\]"  # bold red for hostname
+    local in_color="\[\033[1;37m\]"    # bold white for "in"
+    local dir_color="\[\033[1;35m\]"   # bold purple for current working directory
+    local git_color="\[\033[1;36m\]"   # bold cyan for Git information
+    local time_color="\[\033[1;32m\]"  # bold green for time taken
+    local reset_color="\[\033[0m\]"    # reset color
+    local prompt_symbol_color="\[\033[1;31m\]"  # bold red for the prompt symbol
+
+    local end_time=$(date +%s%3N)  # current time in milliseconds
+    local time_taken=$(( (end_time - start_time) ))  # time in milliseconds
+
+    PS1="${user_color}╭─\\u"  # username
+    PS1+="${at_color}@${host_color}\\h"  # @ symbol and hostname
+    PS1+="${in_color} in"  # "in" between hostname and current directory
+    PS1+="${dir_color} \\w"  # current working directory
+
+    # Git information (status symbol)
+    PS1+=" ${git_color}$(__git_ps1 "[%s]")${reset_color}"
+
+    if [ $time_taken -gt 0 ]; then
+        PS1+=" ${time_color}took ${time_taken}ms"  # time taken in milliseconds
+    fi
+
+    PS1+="\n${prompt_symbol_color}╰─λ${reset_color} "  # red color for the prompt symbol, reset color after
+}
+
+PROMPT_COMMAND='start_time=$(date +%s%3N); set_prompt'


### PR DESCRIPTION
# [Pull Request] New Bash Theme: Lambda

## Description
I've created a new Bash theme named "Lambda". This theme provides a clean and visually appealing command line prompt. Below, I briefly explain the configuration file and its elements.

## Configuration File
```bash
function set_prompt {
    local user_color="\[\033[1;31m\]"  # bold red for username
    local at_color="\[\033[1;37m\]"    # bold white for @ symbol
    local host_color="\[\033[1;31m\]"  # bold red for hostname
    local in_color="\[\033[1;37m\]"    # bold white for "in"
    local dir_color="\[\033[1;35m\]"   # bold purple for current working directory
    local git_color="\[\033[1;36m\]"   # bold cyan for Git information
    local time_color="\[\033[1;32m\]"  # bold green for time taken
    local reset_color="\[\033[0m\]"    # reset color
    local prompt_symbol_color="\[\033[1;31m\]"  # bold red for the prompt symbol

    local end_time=$(date +%s%3N)  # current time in milliseconds
    local time_taken=$(( (end_time - start_time) ))  # time in milliseconds

    PS1="${user_color}╭─\\u"  # username
    PS1+="${at_color}@${host_color}\\h"  # @ symbol and hostname
    PS1+="${in_color} in"  # "in" between hostname and current directory
    PS1+="${dir_color} \\w"  # current working directory

    # Git information (status symbol)
    PS1+=" ${git_color}$(__git_ps1 "[%s]")${reset_color}"

    if [ $time_taken -gt 0 ]; then
        PS1+=" ${time_color}took ${time_taken}ms"  # time taken in milliseconds
    fi

    PS1+="\n${prompt_symbol_color}╰─λ${reset_color} "  # red color for the prompt symbol, reset color after
}

PROMPT_COMMAND='start_time=$(date +%s%3N); set_prompt'
```
## Additional Information

- The theme uses color-coded elements for user, hostname, current directory, Git information, and time taken ( by cpu to execute that command ).
- Git information includes the current branch in square brackets.
- The time taken is displayed in milliseconds if it exceeds 0.

## Screenshots

I have added a screenshot of the "Lambda" theme in action to the `docs/images` folder in the `gh-pages` branch. Please refer to the Themes page for a preview.

## Note to Maintainers

Kindly review the changes and provide feedback. I am open to any adjustments or improvements to ensure compatibility and consistency with the Bash-it project. Thank you!
