### PR TITLE
Fix clock_hand to display correct hour hand

### DIFF
--- a/lib/command_duration.bash
+++ b/lib/command_duration.bash
@@ -26,7 +26,7 @@ function _dynamic_clock_icon {
 	local clock_hand
 	# clock hand value is between 90 and 9b in hexadecimal.
 	# so between 144 and 155 in base 10.
-	printf -v clock_hand '%x' $((((${1:-${SECONDS}} -1 ) % 12) + 144))
+	printf -v clock_hand '%x' $((((${1:-${SECONDS}} - 1) % 12) + 144))
 	printf -v 'COMMAND_DURATION_ICON' '%b' "\xf0\x9f\x95\x$clock_hand"
 }
 

--- a/lib/command_duration.bash
+++ b/lib/command_duration.bash
@@ -26,7 +26,7 @@ function _dynamic_clock_icon {
 	local clock_hand
 	# clock hand value is between 90 and 9b in hexadecimal.
 	# so between 144 and 155 in base 10.
-	printf -v clock_hand '%x' $(((${1:-${SECONDS}} % 12) + 144))
+	printf -v clock_hand '%x' $((((${1:-${SECONDS}} -1 ) % 12) + 144))
 	printf -v 'COMMAND_DURATION_ICON' '%b' "\xf0\x9f\x95\x$clock_hand"
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using the lib to display the command duration, the dynamic clock is off by 1.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This change is required to have a dynamic clock that output the correct clock hand.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Before:

```bash
for second in {1..15}; do     
  clock_hand=$(printf '%x' $(((${1:-${second}} % 12) + 144)))
  printf '%b' "\xf0\x9f\x95\x$clock_hand"
done

🕑🕒🕓🕔🕕🕖🕗🕘🕙🕚🕛🕐🕑🕒🕓
```

After:

```bash
for second in {1..15}; do     
  clock_hand=$(printf '%x' $((((${1:-${second}} -1 ) % 12) + 144)))
  printf '%b' "\xf0\x9f\x95\x$clock_hand"
done

🕐🕑🕒🕓🕔🕕🕖🕗🕘🕙🕚🕛🕐🕑🕒
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
