### PR TITLE
Add new theme - Inretio

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -162,6 +162,7 @@ themes/candy
 themes/easy
 themes/essential
 themes/githelpers.theme.bash
+themes/inretio
 themes/modern
 themes/norbu
 themes/oh-my-posh
@@ -170,7 +171,6 @@ themes/pete
 themes/powerline
 themes/pure
 themes/purity
-themes/inretio
 
 # vendor init files
 #

--- a/clean_files.txt
+++ b/clean_files.txt
@@ -170,6 +170,7 @@ themes/pete
 themes/powerline
 themes/pure
 themes/purity
+themes/inretio
 
 # vendor init files
 #

--- a/docs/themes-list/index.rst
+++ b/docs/themes-list/index.rst
@@ -221,6 +221,21 @@ Envy
 
 ----
 
+Inretio
+^^^^^^^
+
+
+.. image:: https://raw.githubusercontent.com/inretio/bash-it/gh-pages/docs/images/inretio-black.png
+   :target: https://raw.githubusercontent.com/inretio/bash-it/gh-pages/docs/images/inretio-black.png
+   :alt: Inretio theme in dark color scheme
+
+
+.. image:: https://raw.githubusercontent.com/inretio/bash-it/gh-pages/docs/images/inretio-white.png
+   :target: https://raw.githubusercontent.com/inretio/bash-it/gh-pages/docs/images/inretio-white.png
+   :alt: Inretio theme in light color scheme
+
+----
+
 Iterate
 ^^^^^^^
 

--- a/docs/themes-list/inretio.rst
+++ b/docs/themes-list/inretio.rst
@@ -1,7 +1,7 @@
 .. _inretio:
 
 Inretio Theme
-==========
+=============
 
 Simple theme showing date and time, username and hostname, current folder, Git details and as a bonus - virtual environment along with Python version available in it.
 

--- a/docs/themes-list/inretio.rst
+++ b/docs/themes-list/inretio.rst
@@ -1,0 +1,32 @@
+.. _inretio:
+
+Inretio Theme
+==========
+
+Simple theme showing date and time, username and hostname, current folder, Git details and as a bonus - virtual environment along with Python version available in it.
+
+Inspired by existing themes:
+- metal
+- bobby
+
+Examples
+--------
+
+In Git-tracked folder:
+
+.. code-block:: bash
+
+    ┌──[2024-03-20 12:05:07] 🐧 gytis 💻 gytis-legion  📂 bash-it on 🌵 theme-inretio ⌀1 ✗ 
+    └> ls
+    aliases     clean_files.txt  custom  hooks       lib      lint_clean_files.sh  profiles  template  test_lib  uninstall.sh
+    bash_it.sh  completion       docs    install.sh  LICENSE  plugins              scripts   test      themes    vendor
+
+
+In Python virtual environment:
+
+.. code-block:: bash
+
+    ┌──[2024-03-20 12:07:32] 🐧 gytis 💻 gytis-legion 🐍 3.12.2 on [general] 📂 general
+    └> ls
+    bin  include  lib  lib64  pyvenv.cfg  share
+

--- a/themes/inretio/inretio.theme.bash
+++ b/themes/inretio/inretio.theme.bash
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Inretio theme for Bash-it
+# Contact: bashit@inretio.eu
+
+# Inspired by existing themes:
+# - metal
+# - bobby
+
+# virtualenv prompts
+VIRTUALENV_CHAR=" ⓔ"
+VIRTUALENV_THEME_PROMPT_PREFIX=""
+VIRTUALENV_THEME_PROMPT_SUFFIX=""
+
+# SCM prompts
+SCM_NONE_CHAR=""
+SCM_GIT_CHAR="[±] "
+SCM_GIT_BEHIND_CHAR="${red}↓${normal}"
+SCM_GIT_AHEAD_CHAR="${bold_green}↑${normal}"
+SCM_GIT_UNTRACKED_CHAR="⌀"
+SCM_GIT_UNSTAGED_CHAR="${bold_yellow}•${normal}"
+SCM_GIT_STAGED_CHAR="${bold_green}+${normal}"
+
+SCM_THEME_PROMPT_DIRTY=""
+SCM_THEME_PROMPT_CLEAN=""
+SCM_THEME_PROMPT_PREFIX=""
+SCM_THEME_PROMPT_SUFFIX=""
+
+# Git status prompts
+GIT_THEME_PROMPT_DIRTY=" ${red}✗${normal}"
+GIT_THEME_PROMPT_CLEAN=" ${bold_green}✓${normal}"
+GIT_THEME_PROMPT_PREFIX=""
+GIT_THEME_PROMPT_SUFFIX=""
+
+# ICONS =======================================================================
+
+icon_start="┌──"
+icon_user=" 🐧 "
+icon_host=" 💻 "
+icon_directory=" 📂 "
+icon_branch="🌵"
+icon_end="└> "
+
+# extra spaces ensure legiblity in prompt
+
+# FUNCTIONS ===================================================================
+
+# Display virtual environment info
+function _virtualenv_prompt {
+  VIRTUALENV_DETAILS=""
+  VIRTUALENV_CHAR=""
+
+  # $VIRTUAL_ENV is set and is non-zero length
+  if [[ -n "$VIRTUAL_ENV" ]]; then
+    # Check if Python 3 exists
+    if command -v python3 >/dev/null 2>&1; then
+      VIRTUALENV_DETAILS="$($VIRTUAL_ENV/bin/python --version | sed 's,Python ,,') on [$(basename $VIRTUAL_ENV)]"
+      VIRTUALENV_CHAR=" 🐍"
+    else
+      VIRTUALENV_DETAILS="[$(basename $VIRTUAL_ENV)]"
+      VIRTUALENV_CHAR=" ⓔ"
+    fi
+  fi
+
+  echo "$VIRTUALENV_CHAR $VIRTUALENV_DETAILS"
+}
+
+# Rename tab
+function tabname {
+  printf "\e]1;$1\a"
+}
+
+# Rename window
+function winname {
+  printf "\e]2;$1\a"
+}
+
+_theme_clock() {
+	printf '[%s]' "$(clock_prompt)"
+
+	if [ "${THEME_SHOW_CLOCK_CHAR}" == "true" ]; then
+		printf '%s' "$(clock_char) "
+	fi
+}
+THEME_SHOW_CLOCK_CHAR=${THEME_SHOW_CLOCK_CHAR:-"false"}
+THEME_CLOCK_CHAR_COLOR=${THEME_CLOCK_CHAR_COLOR:-"$red"}
+THEME_CLOCK_COLOR=${THEME_CLOCK_COLOR:-"$normal"}
+THEME_CLOCK_FORMAT=${THEME_CLOCK_FORMAT:-"%Y-%m-%d %H:%M:%S"}
+
+# PROMPT OUTPUT ===============================================================
+
+# Displays the current prompt
+function prompt_command() {
+  PS1="\n${icon_start}$(_theme_clock)${icon_user}${bold_green}\u${normal}${icon_host}${bold_cyan}\h${normal}${green}$(_virtualenv_prompt)${normal}${icon_directory}${bold_purple}\W${normal}\$([[ -n \$(git branch 2> /dev/null) ]] && echo \" on ${icon_branch} $(scm_prompt_info) \")${white}${normal}\n${icon_end}"
+  PS2="${icon_end}"
+}
+
+# Runs prompt (this bypasses bash_it $PROMPT setting)
+safe_append_prompt_command prompt_command

--- a/themes/inretio/inretio.theme.bash
+++ b/themes/inretio/inretio.theme.bash
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
+# shellcheck disable=SC2034 # Expected behavior for themes.
 
 # Inretio theme for Bash-it
 # Contact: bashit@inretio.eu


### PR DESCRIPTION
Add new theme called Inretio, along with documentation describing it.

## Description
Inretio theme uses inspiration from existing themes: `metal` and `bobby`, but adds more details about virtual environment - when Python is available in it, prompt will display that particular Python binary version.

## Motivation and Context
Displaying specific Python version is very useful for developers who keep multiple `venv`s for running their Python code on different runner versions, e.g.: `3.12.x` and `3.9.x` on the same machine.

## How Has This Been Tested?
Tested on usual filesystem folder, Git-tracked folder, in `venv` without Python and in `venv` with Python.

## Screenshots (if appropriate):
Added in documentation as required: https://github.com/Bash-it/bash-it/pull/2246

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
