### PR TITLE
Support conda environement for bira theme

### DIFF
--- a/themes/bira/bira.theme.bash
+++ b/themes/bira/bira.theme.bash
@@ -6,6 +6,8 @@ SCM_THEME_PROMPT_SUFFIX="›${reset_color?}"
 
 VIRTUALENV_THEME_PROMPT_PREFIX=" ${cyan?}‹"
 VIRTUALENV_THEME_PROMPT_SUFFIX="›${reset_color?}"
+CONDAENV_THEME_PROMPT_PREFIX=" ${cyan?}‹"
+CONDAENV_THEME_PROMPT_SUFFIX="›${reset_color?}"
 
 bold="\[\e[1m\]"
 
@@ -18,7 +20,7 @@ fi
 function prompt_command() {
 	local current_dir=" ${bold_blue?}\w${normal?}${reset_color?}"
 	local virtualenv_prompt scm_prompt_info
-	virtualenv_prompt="$(virtualenv_prompt)"
+	virtualenv_prompt="${virtualenv_prompt:-$(condaenv_prompt)}"
 	scm_prompt_info="$(scm_prompt_info)"
 	PS1="╭─${user_host?}${current_dir}${virtualenv_prompt}${scm_prompt_info}\n╰─${bold?}\\$ ${normal?}"
 }


### PR DESCRIPTION


## Description

Support for the showing the conda environment for the bira theme. This will prioritise the virtualenv prompt. 

## Motivation and Context

I usually got confused whether conda is activated or not, then found that it is in fact activated but theme doesn't handle `CONDA_DEFAULT_ENV` variable.

## How Has This Been Tested?

Locally, sourcing the new script with new changes and activating the environment

## Screenshots (if appropriate):

![image](https://github.com/Bash-it/bash-it/assets/28386721/93e60928-150e-4f41-baf2-440a658141f8)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
