### PR TITLE
bash_profile.template.bash: fix theme location

### DIFF
--- a/template/bash_profile.template.bash
+++ b/template/bash_profile.template.bash
@@ -11,7 +11,7 @@ export BASH_IT="{{BASH_IT}}"
 
 # Lock and Load a custom theme file.
 # Leave empty to disable theming.
-# location /.bash_it/themes/
+# location "$BASH_IT"/themes/
 export BASH_IT_THEME='bobby'
 
 # Some themes can show whether `sudo` has a current token or not.


### PR DESCRIPTION
bash_profile.template.bash: fix theme location

## Description
Fix theme location

## Motivation and Context
`/.bash_it` is not a valid location.

## How Has This Been Tested?
Just a comment

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
