### PR TITLE
Revert "Revert "bash_it: source reloader.bash without arguments for the default enabling""

### DIFF
--- a/bash_it.sh
+++ b/bash_it.sh
@@ -38,7 +38,8 @@ done
 # "_bash_it_main_file_type" param is empty so that files get sourced in glob order
 for _bash_it_main_file_type in "" "aliases" "plugins" "completion"; do
 	BASH_IT_LOG_PREFIX="core: reloader: "
-	source "${BASH_IT}/scripts/reloader.bash" "${_bash_it_main_file_type:+skip}" "$_bash_it_main_file_type"
+	# shellcheck disable=SC2140
+	source "${BASH_IT}/scripts/reloader.bash" ${_bash_it_main_file_type:+"skip" "$_bash_it_main_file_type"}
 	BASH_IT_LOG_PREFIX="core: main: "
 done
 


### PR DESCRIPTION
Reverts Bash-it/bash-it#2097 - seems like it was prematurely merged.