### PR TITLE
check whether `dnf` command exists before aliasing

### DIFF
--- a/aliases/available/dnf.aliases.bash
+++ b/aliases/available/dnf.aliases.bash
@@ -1,17 +1,19 @@
 # shellcheck shell=bash
 about-alias 'dnf aliases for fedora 22+ distros'
 
-alias dnfl="dnf list"            # List packages
-alias dnfli="dnf list installed" # List installed packages
-alias dnfgl="dnf grouplist"      # List package groups
-alias dnfmc="dnf makecache"      # Generate metadata cache
-alias dnfp="dnf info"            # Show package information
-alias dnfs="dnf search"          # Search package
+if _command_exists dnf; then
+	alias dnfl="dnf list"            # List packages
+	alias dnfli="dnf list installed" # List installed packages
+	alias dnfgl="dnf grouplist"      # List package groups
+	alias dnfmc="dnf makecache"      # Generate metadata cache
+	alias dnfp="dnf info"            # Show package information
+	alias dnfs="dnf search"          # Search package
 
-alias dnfu="sudo dnf upgrade"       # Upgrade package
-alias dnfi="sudo dnf install"       # Install package
-alias dnfri='sudo dnf reinstall'    # Reinstall package
-alias dnfgi="sudo dnf groupinstall" # Install package group
-alias dnfr="sudo dnf remove"        # Remove package
-alias dnfgr="sudo dnf groupremove"  # Remove package group
-alias dnfc="sudo dnf clean all"     # Clean cache
+	alias dnfu="sudo dnf upgrade"       # Upgrade package
+	alias dnfi="sudo dnf install"       # Install package
+	alias dnfri='sudo dnf reinstall'    # Reinstall package
+	alias dnfgi="sudo dnf groupinstall" # Install package group
+	alias dnfr="sudo dnf remove"        # Remove package
+	alias dnfgr="sudo dnf groupremove"  # Remove package group
+	alias dnfc="sudo dnf clean all"     # Clean cache
+fi

--- a/aliases/available/dnf.aliases.bash
+++ b/aliases/available/dnf.aliases.bash
@@ -2,18 +2,18 @@
 about-alias 'dnf aliases for fedora 22+ distros'
 
 if _command_exists dnf; then
+	alias dnfp="dnf info"            # Show package information
 	alias dnfl="dnf list"            # List packages
 	alias dnfli="dnf list installed" # List installed packages
 	alias dnfgl="dnf grouplist"      # List package groups
 	alias dnfmc="dnf makecache"      # Generate metadata cache
-	alias dnfp="dnf info"            # Show package information
 	alias dnfs="dnf search"          # Search package
 
-	alias dnfu="sudo dnf upgrade"       # Upgrade package
 	alias dnfi="sudo dnf install"       # Install package
-	alias dnfri='sudo dnf reinstall'    # Reinstall package
-	alias dnfgi="sudo dnf groupinstall" # Install package group
 	alias dnfr="sudo dnf remove"        # Remove package
-	alias dnfgr="sudo dnf groupremove"  # Remove package group
+	alias dnfu="sudo dnf upgrade"       # Upgrade package
 	alias dnfc="sudo dnf clean all"     # Clean cache
+	alias dnfri="sudo dnf reinstall"    # Reinstall package
+	alias dnfgi="sudo dnf groupinstall" # Install package group
+	alias dnfgr="sudo dnf groupremove"  # Remove package group
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Enclose the aliases for `dnf` within the `_command_exists` helper function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We do not need to add aliases for package managers if the command does not exist.

This was done for other files that were already checking for commands via `command -v` in #1938.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by syncing profiles between Debian, Fedora and macos

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
