### PR TITLE
check whether `brew` command exists before aliasing

### DIFF
--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -1,13 +1,15 @@
 # shellcheck shell=bash
 about-alias 'Some aliases for Homebrew'
 
-alias bup='brew update && brew upgrade'
-alias bout='brew outdated'
-alias bin='brew install'
-alias brm='brew uninstall'
-alias bcl='brew cleanup'
-alias bls='brew list'
-alias bsr='brew search'
-alias binf='brew info'
-alias bdr='brew doctor'
-alias bed='brew edit'
+if _command_exists brew; then
+	alias bup='brew update && brew upgrade'
+	alias bout='brew outdated'
+	alias bin='brew install'
+	alias brm='brew uninstall'
+	alias bcl='brew cleanup'
+	alias bls='brew list'
+	alias bsr='brew search'
+	alias binf='brew info'
+	alias bdr='brew doctor'
+	alias bed='brew edit'
+fi

--- a/aliases/available/homebrew.aliases.bash
+++ b/aliases/available/homebrew.aliases.bash
@@ -2,14 +2,14 @@
 about-alias 'Some aliases for Homebrew'
 
 if _command_exists brew; then
-	alias bup='brew update && brew upgrade'
-	alias bout='brew outdated'
-	alias bin='brew install'
-	alias brm='brew uninstall'
-	alias bcl='brew cleanup'
+	alias bed='brew edit'
 	alias bls='brew list'
 	alias bsr='brew search'
-	alias binf='brew info'
 	alias bdr='brew doctor'
-	alias bed='brew edit'
+	alias bin='brew install'
+	alias bcl='brew cleanup'
+	alias brm='brew uninstall'
+	alias bout='brew outdated'
+	alias binf='brew info'
+	alias bup='brew update && brew upgrade'
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enclose the aliases for `brew` within the `_command_exists` helper function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We do not need to add aliases for package managers if the command does not exist.

This was done for other files that were already checking for commands via `command -v` in #1938.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by syncing profiles between Debian, Fedora and macos

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
