### PR TITLE
Fix for cases in the virtualenv plugin where pyenv is present but pyenv virtualenvwrapper isn't

### DIFF
--- a/plugins/available/virtualenv.plugin.bash
+++ b/plugins/available/virtualenv.plugin.bash
@@ -7,7 +7,7 @@ about-plugin 'virtualenvwrapper and pyenv-virtualenvwrapper helper functions'
 
 # Check for whole command instead of just pyenv
 if [ -n "$(command pyenv virtualenvwrapper --help 2> /dev/null)" ]; then
-	command pyenv virtualenvwrapper
+	pyenv virtualenvwrapper
 elif _command_exists virtualenvwrapper.sh; then
 	# shellcheck disable=SC1091
 	source virtualenvwrapper.sh

--- a/plugins/available/virtualenv.plugin.bash
+++ b/plugins/available/virtualenv.plugin.bash
@@ -5,11 +5,14 @@
 cite about-plugin
 about-plugin 'virtualenvwrapper and pyenv-virtualenvwrapper helper functions'
 
-if _command_exists pyenv; then
+# Check for whole command instead of just pyenv
+if [ -n "$(pyenv virtualenvwrapper --help 2> /dev/null)" ]; then
 	pyenv virtualenvwrapper
 elif _command_exists virtualenvwrapper.sh; then
 	# shellcheck disable=SC1091
 	source virtualenvwrapper.sh
+else
+	log_debug "${2:-'virtualenvwrapper' was not found}"
 fi
 
 function mkvenv {

--- a/plugins/available/virtualenv.plugin.bash
+++ b/plugins/available/virtualenv.plugin.bash
@@ -12,7 +12,7 @@ elif _command_exists virtualenvwrapper.sh; then
 	# shellcheck disable=SC1091
 	source virtualenvwrapper.sh
 else
-	log_debug "${2:-'virtualenvwrapper' was not found}"
+	_log_debug "${2:-'virtualenvwrapper' was not found}"
 fi
 
 function mkvenv {

--- a/plugins/available/virtualenv.plugin.bash
+++ b/plugins/available/virtualenv.plugin.bash
@@ -6,8 +6,8 @@ cite about-plugin
 about-plugin 'virtualenvwrapper and pyenv-virtualenvwrapper helper functions'
 
 # Check for whole command instead of just pyenv
-if [ -n "$(pyenv virtualenvwrapper --help 2> /dev/null)" ]; then
-	pyenv virtualenvwrapper
+if [ -n "$(command pyenv virtualenvwrapper --help 2> /dev/null)" ]; then
+	command pyenv virtualenvwrapper
 elif _command_exists virtualenvwrapper.sh; then
 	# shellcheck disable=SC1091
 	source virtualenvwrapper.sh


### PR DESCRIPTION
## Description
Check for the whole `pyenv virtualenvwrapper` command when loading virtualenv, instead of checking for `pyenv only`
<!--- Describe your changes in detail -->

## Motivation and Context
This is useful if the system has `pyenv` installed but not `pyenv virtulenvwrapper`. The previous version just printed out  

```text
pyenv: no such command `sh-virtualenvwrapper'
```

which is just the pyenv stderr output.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested both with and `pyenv virtualenvwrapper` present. In both cases virtualenvwrapper.sh was also present. In poth cases ´ _virtualenvwrapper_version´ returned with the verion value. I  renamed the plugins in enabled, to ensure that pyenv gets loaded first during debugging. I don't remember the original loading order, but pyenv must be loaded first so that the plugin would work. Otherwise pyenv prints the following: 
```
Failed to initialize virtualenvwrapper.

Perhaps pyenv-virtualenvwrapper has not been loaded into your shell properly.
Please restart current shell and try again.
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
