### PR TITLE
update aws_profile in base theme to work with new aws cli versions

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -590,7 +590,9 @@ if ! _command_exists battery_charge; then
 fi
 
 function aws_profile() {
-	if [[ -n "${AWS_DEFAULT_PROFILE:-}" ]]; then
+	if [[ -n "${AWS_PROFILE:-}" ]]; then
+		echo -ne "${AWS_PROFILE}"
+	elif [[ -n "${AWS_DEFAULT_PROFILE:-}" ]]; then
 		echo -ne "${AWS_DEFAULT_PROFILE}"
 	else
 		echo -ne "default"


### PR DESCRIPTION
## Description
aws cli version 2 changed the variable used to override the default profile from AWS_DEFAULT_PROFILE to AWS_PROFILE. This pr updates the aws_profile function in the base theme to work with the new variable, but will still fall back to the old one if the new one is unset.

## Motivation and Context
Custom themes using this function are useful for people who manage multiple AWS accounts. This will allow them to continue working with new versions of aws cli moving forward.

## How Has This Been Tested?
Tested with either and both variable in multiple themes on multiple machines and none of them caught fire. The change maintains backward compatibility, so the only people who could theoretically be impacted are those still using and old version of aws cli for some reason and also coincidentally setting AWS_PROFILE for some other purpose.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [na] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [na] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [na] I have added tests to cover my changes, and all the new and existing tests pass.