### PR TITLE
Improve array handling in alias completion

### DIFF
--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -79,9 +79,9 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 			if [[ "${compl_func#_"$namespace"::}" == "$compl_func" ]]; then
 				compl_wrapper="_${namespace}::${alias_name}"
 
-				# Need to break up the alias arguments so the resulting COMP_WORDS is split correctly.
-				# Use printf to convert alias_arg_words to string that can be used in an array assignment.
-				alias_arg_words_str=$(printf "'%s' " "${alias_arg_words[@]}")
+				# Create a wrapper function for the alias
+				# The use of printf on alias_arg_words is needed to ensure each element of
+				# the array is quoted. E.X. (one two three) -> ('one' 'two' 'three')
 				echo "function $compl_wrapper {
                         local compl_word=\${2?}
                         local prec_word=\${3?}
@@ -93,7 +93,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
                             prec_word=\${prec_word#* }
                         fi
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))
-                        COMP_WORDS=(\"$alias_cmd\" ${alias_arg_words_str} \"\${COMP_WORDS[@]:1}\")
+                        COMP_WORDS=(\"$alias_cmd\" $(printf "'%s' " "${alias_arg_words[@]}") \"\${COMP_WORDS[@]:1}\")
                         (( COMP_POINT -= \${#COMP_LINE} ))
                         COMP_LINE=\${COMP_LINE/$alias_name/$alias_cmd $alias_args}
                         (( COMP_POINT += \${#COMP_LINE} ))

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -93,7 +93,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
                             prec_word=\${prec_word#* }
                         fi
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))
-                        COMP_WORDS=(\"$alias_cmd\" $(printf "\"%q\" " "${alias_arg_words[@]}") \"\${COMP_WORDS[@]:1}\")
+                        COMP_WORDS=(\"$alias_cmd\" $(printf "%q " "${alias_arg_words[@]}") \"\${COMP_WORDS[@]:1}\")
                         (( COMP_POINT -= \${#COMP_LINE} ))
                         COMP_LINE=\${COMP_LINE/$alias_name/$alias_cmd $alias_args}
                         (( COMP_POINT += \${#COMP_LINE} ))

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -91,7 +91,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
                         if [[ \$COMP_LINE == \"\$prec_word \$compl_word\" ]]; then
                             prec_word='$alias_cmd $alias_args'
                             prec_word=\${prec_word#* }
-                        fi:
+                        fi
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))
                         COMP_WORDS=(\"$alias_cmd\" $(printf "\"%q\" " "${alias_arg_words[@]}") \"\${COMP_WORDS[@]:1}\")
                         (( COMP_POINT -= \${#COMP_LINE} ))

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -91,9 +91,9 @@ function _bash-it-component-completion-callback-on-init-aliases() {
                         if [[ \$COMP_LINE == \"\$prec_word \$compl_word\" ]]; then
                             prec_word='$alias_cmd $alias_args'
                             prec_word=\${prec_word#* }
-                        fi
+                        fi:
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))
-                        COMP_WORDS=(\"$alias_cmd\" $(printf "'%s' " "${alias_arg_words[@]}") \"\${COMP_WORDS[@]:1}\")
+                        COMP_WORDS=(\"$alias_cmd\" $(printf "\"%q\" " "${alias_arg_words[@]}") \"\${COMP_WORDS[@]:1}\")
                         (( COMP_POINT -= \${#COMP_LINE} ))
                         COMP_LINE=\${COMP_LINE/$alias_name/$alias_cmd $alias_args}
                         (( COMP_POINT += \${#COMP_LINE} ))

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -78,6 +78,10 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 			# avoid recursive call loops by ignoring our own functions
 			if [[ "${compl_func#_"$namespace"::}" == "$compl_func" ]]; then
 				compl_wrapper="_${namespace}::${alias_name}"
+
+				# Need to break up the alias arguments so the resulting COMP_WORDS is split correctly.
+				# Use printf to convert alias_arg_words to string that can be used in an array assignment.
+				alias_arg_words_str=$(printf "'%s' " "${alias_arg_words[@]}")
 				echo "function $compl_wrapper {
                         local compl_word=\${2?}
                         local prec_word=\${3?}
@@ -89,7 +93,7 @@ function _bash-it-component-completion-callback-on-init-aliases() {
                             prec_word=\${prec_word#* }
                         fi
                         (( COMP_CWORD += ${#alias_arg_words[@]} ))
-                        COMP_WORDS=(\"$alias_cmd\" \"${alias_arg_words[*]}\" \"\${COMP_WORDS[@]:1}\")
+                        COMP_WORDS=(\"$alias_cmd\" ${alias_arg_words_str} \"\${COMP_WORDS[@]:1}\")
                         (( COMP_POINT -= \${#COMP_LINE} ))
                         COMP_LINE=\${COMP_LINE/$alias_name/$alias_cmd $alias_args}
                         (( COMP_POINT += \${#COMP_LINE} ))


### PR DESCRIPTION
## Description
I was seeing issues where certain aliases do not complete as expected.

For example, my `alias gbD='git branch -D'` alias should provide completions to local branches only, and it does when run without an alias. However when running completion on the alias, I get all the branches which appears to be the git default completion response.

I tracked this down to an issue where an array was being incorrectly handled. The old handling caused this result, `COMP_WORDS=[‘git’, ‘branch -D’, 'ma']` (length 3) where `branch` and `-D` were combined into a single entry. This produces the incorrect behavior. By changing the array to string handling to better maintain individual arguments the new result is `COMP_WORDS=[‘git’, ‘branch’ ,‘-D’, 'ma']` (length 4) which correctly keeps `branch` and `-D` apart.


## Motivation and Context
This improves alias completions to act more correctly.

## How Has This Been Tested?
I have been unable to create a unit test that is able to call the alias completion function. I have tested this manually on my machine and it works as expected.

An easy way to manually test this is to add the `alias biea='bash-it enable alias'` and load bash-it with the bash-it completion enabled. Without my fix the complete for this alias are the base level bash-it commands such as doctor, version etc. With my change the output is the aliases that can be enabled as would be expected.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
