### PR TITLE
Do not replace already existing completions

### DIFF
--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -40,6 +40,12 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 		line="${line#alias -- }"
 		line="${line#alias }"
 		alias_name="${line%%=*}"
+
+		if complete -p "$alias_name" &> /dev/null; then
+			# skip aliases that already have completion functions
+			continue
+		fi
+
 		alias_defn="${line#*=\'}" # alias definition
 		alias_defn="${alias_defn%\'}"
 		alias_cmd="${alias_defn%%[[:space:]]*}" # first word of alias

--- a/completion/available/aliases.completion.bash
+++ b/completion/available/aliases.completion.bash
@@ -52,6 +52,10 @@ function _bash-it-component-completion-callback-on-init-aliases() {
 			if [[ "$aliasCommandFunction" != "_${namespace}::"* ]]; then
 				continue
 			fi
+
+			# Remove existing completion. It will be replaced by the new one. We need to
+			# delete it in case the new alias does not support having completion added.
+			complete -r "$alias_name"
 		fi
 
 		alias_defn="${line#*=\'}" # alias definition


### PR DESCRIPTION
## Description
If a user has a completion defined for an alias, the alias completion script should not replace it.

## Motivation and Context
I ad a completion for one of my alias and could not figure out why it was not working. Turns out the alias completion logic was replacing my completion. This is helpful for uses who make their own completions.

## Technical Explanation
The end goal is for the alias completion script to not replace user provided completions for aliases that otherwise would have completion added by the alias completion script.

This requires a few core changes to achieve and support reload commands such as `bash-it reload`.
1. Before this change, only some completions added by this script used a wrapper function. Now all completions added by this script use a wrapper.
    - This is needed as the wrapper contains identifying data to tell if this completion was added by the alias completion script. This allows telling the difference between a completion from this script vs one from something else.
2. When running the script, check if the alias being worked on has an existing completion.
    - For those completions defined by the alias completion script, they are removed.
        - While most completions will be replaced by the rest of the script, the old completion does need to be removed first in case the alias has changed and no longer supports a completion function being generated for it. Otherwise an outdated or invalid completion function for the alias will exist on reload.
    - Completions for aliases that are not from the alias completion script will be skipped and the script will not replace it.
        - The assumption here is that if the user, or some other source, has defined a completion for an alias, that completion is more correct than what could be dynamically generated by the script.

## How Has This Been Tested?
I verified this with an alias that I had defined a completion for and the alias completion script was adding a completion for. Now it does not replace the one I defined.

This could also be tested by any setup where an alias has a custom completion and the alias script would add a completion for it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
