### PR TITLE
Add heuristic for finding default remote name

### DIFF
--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -234,7 +234,7 @@ function _bash-it-update-() {
 	fi
 
 	if [[ -z "$BASH_IT_REMOTE" ]]; then
-		BASH_IT_REMOTE="origin"
+		BASH_IT_REMOTE=$(_remote_name)
 	fi
 
 	git fetch "$BASH_IT_REMOTE" --tags &> /dev/null
@@ -352,7 +352,7 @@ function _bash-it-version() {
 	pushd "${BASH_IT?}" > /dev/null || return
 
 	if [[ -z "${BASH_IT_REMOTE:-}" ]]; then
-		BASH_IT_REMOTE="origin"
+		BASH_IT_REMOTE=$(_remote_name)
 	fi
 
 	BASH_IT_GIT_REMOTE="$(git remote get-url "$BASH_IT_REMOTE")"
@@ -948,6 +948,24 @@ function pathmunge() {
 		else
 			export PATH="${1}:$PATH"
 		fi
+	fi
+}
+
+function _remote_name() {
+	local branch
+	branch=$(git branch --show-current)
+
+	local remote_name=
+	remote_name=$(git config --get --default '' "branch.$branch.remote")
+	if [[ -n "$remote_name" ]]; then
+		printf '%s\n' "$remote_name"
+		return
+	fi
+
+	if remote_name=$(git remote -v | awk 'NR==1 { name=$1; print name } $1 != name { exit 1 }'); then
+		printf '%s\n' "$remote_name"
+	else
+		printf '%s\n' 'origin'
 	fi
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description, Motivation and Context

Fixes #2317

Implementation:

- If `HEAD` is not detached, it infers the remote name by the current branch
- If `HEAD` is detached, then it infers the remote name by parsing `git remote -v`, but only if every entry has the same remote name

I've made [similar](https://github.com/sindresorhus/awesome-lint/pull/170) PRs in other projects, so this does work in general.

## How Has This Been Tested?

Manual testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
