### PR TITLE
Fix: __powerline_last_status_prompt to handle unset argument safely

### DIFF
--- a/themes/powerline/powerline.base.bash
+++ b/themes/powerline/powerline.base.bash
@@ -280,7 +280,7 @@ function __powerline_left_last_segment_padding() {
 }
 
 function __powerline_last_status_prompt() {
-	if [[ "${1?}" -ne 0 ]]; then
+	if [[ "${1:-0}" -ne 0 ]]; then
 		printf '%s|%s' "${1}" "${LAST_STATUS_THEME_PROMPT_COLOR-"52"}"
 	fi
 }


### PR DESCRIPTION
## Summary
This PR fixes a small bug in the `__powerline_last_status_prompt` function where
an error would occur if the function was called without an argument.

<img width="445" height="369" alt="image" src="https://github.com/user-attachments/assets/320de3ff-6878-426d-bce2-5a4131dd40f5" />


## Changes
- Replaced `${1?}` with `${1:-0}` to provide a safe default value when `$1` is unset.
- This ensures that the function no longer throws an error if no argument is passed.

## Why
The previous implementation used `${1?}`, which causes error to show up before each prompt
if `$1` is not set. This could break the prompt in certain cases. By switching to
`${1:-0}`, the function now defaults to `0` and continues safely.

## Testing
- Verified that the function behaves correctly when called with and without arguments.
- Prompt now displays the correct status without errors.