### PR TITLE
fix #2261 #2289 - $LESS is no longer clobbered globally

### DIFF
--- a/plugins/available/man.plugin.bash
+++ b/plugins/available/man.plugin.bash
@@ -1,14 +1,9 @@
 # shellcheck shell=bash
 about-plugin 'colorize man pages for better readability'
 
-: "${LESS_TERMCAP_mb:=$'\e[1;32m'}"
-: "${LESS_TERMCAP_md:=$'\e[1;32m'}"
-: "${LESS_TERMCAP_me:=$'\e[0m'}"
-: "${LESS_TERMCAP_se:=$'\e[0m'}"
-: "${LESS_TERMCAP_so:=$'\e[01;33m'}"
-: "${LESS_TERMCAP_ue:=$'\e[0m'}"
-: "${LESS_TERMCAP_us:=$'\e[1;4;31m'}"
-
-: "${LESS:=}"
-export "${!LESS_TERMCAP@}"
-export LESS="--RAW-CONTROL-CHARS ${LESS}"
+alias man="\
+LESS_TERMCAP_mb=$'\e[1;32m' \
+LESS_TERMCAP_md=$'\e[1;32m' LESS_TERMCAP_me=$'\e[0m' \
+LESS_TERMCAP_se=$'\e[0m'    LESS_TERMCAP_so=$'\e[01;33m' \
+LESS_TERMCAP_ue=$'\e[0m'    LESS_TERMCAP_us=$'\e[1;4;31m' \
+LESS=--RAW-CONTROL-CHARS \man"


### PR DESCRIPTION
it's a bit ugly but less ugly than before.  man is now an alias (imperfect) bit the LESS value and colours are not changing for everyone.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
