### PR TITLE
Fix down4me function URL malformation

### DIFF
--- a/plugins/available/base.plugin.bash
+++ b/plugins/available/base.plugin.bash
@@ -16,10 +16,16 @@ function ips() {
 
 function down4me() {
 	about 'checks whether a website is down for you, or everybody'
-	param '1: website url'
+	param '1: website url or domain'
 	example '$ down4me http://www.google.com'
+	example '$ down4me google.com'
 	group 'base'
-	curl -Ls "http://downforeveryoneorjustme.com/$1" | sed '/just you/!d;s/<[^>]*>//g'
+	# Strip protocol (http:// or https://) if present
+	local site="${1#http://}"
+	site="${site#https://}"
+	# Strip trailing slash if present
+	site="${site%/}"
+	command curl -Ls "http://downforeveryoneorjustme.com/${site}" | command sed '/just you/!d;s/<[^>]*>//g'
 }
 
 function myip() {


### PR DESCRIPTION
## Summary

Fixes the `down4me` function which was failing when users passed URLs with protocols (http:// or https://).

## Problem

When users ran `down4me http://google.com`, the function would create a malformed URL:
```
http://downforeveryoneorjustme.com/http://google.com
```

This resulted in curl error:
```
curl: (3) URL rejected: Malformed input to a URL function
```

## Solution

- Strip `http://` and `https://` protocols from input
- Strip trailing slashes
- Use `command` prefix to bypass user aliases
- Support both URL and domain formats

## Testing

- ✅ Passes shellcheck with no warnings
- ✅ Passes shfmt formatting checks
- ✅ Passes all pre-commit hooks
- ✅ Works with `down4me http://google.com`
- ✅ Works with `down4me google.com`

## Related

Closes #2296

🤖 Generated with [Claude Code](https://claude.com/claude-code)