### PR TITLE
Fix SSH completion to preserve @ sign in user@host format

### DIFF
--- a/completion/available/ssh.completion.bash
+++ b/completion/available/ssh.completion.bash
@@ -2,8 +2,7 @@
 # Bash completion support for ssh.
 
 # Remove : and @ from COMP_WORDBREAKS to support user@host completion
-export COMP_WORDBREAKS=${COMP_WORDBREAKS//:/}
-export COMP_WORDBREAKS=${COMP_WORDBREAKS//@/}
+export COMP_WORDBREAKS=${COMP_WORDBREAKS//[:@]/}
 
 _sshcomplete() {
 	local line CURRENT_PROMPT="${COMP_WORDS[COMP_CWORD]}"

--- a/completion/available/ssh.completion.bash
+++ b/completion/available/ssh.completion.bash
@@ -1,7 +1,9 @@
 # shellcheck shell=bash
 # Bash completion support for ssh.
 
-export COMP_WORDBREAKS=${COMP_WORDBREAKS/\:/}
+# Remove : and @ from COMP_WORDBREAKS to support user@host completion
+export COMP_WORDBREAKS=${COMP_WORDBREAKS//:/}
+export COMP_WORDBREAKS=${COMP_WORDBREAKS//@/}
 
 _sshcomplete() {
 	local line CURRENT_PROMPT="${COMP_WORDS[COMP_CWORD]}"


### PR DESCRIPTION
## Summary

Fixes SSH completion to preserve the @ sign when completing user@host combinations.

## Problem

When typing `ssh root@ser<TAB>`, the completion would incorrectly produce:
```
ssh rootserver
```

Instead of the expected:
```
ssh root@server
```

## Root Cause

The @ character was in `COMP_WORDBREAKS`, causing bash to treat it as a word boundary and strip it during completion.

## Solution

Remove @ from `COMP_WORDBREAKS` (in addition to `:` which was already removed).

**Changes:**
```bash
export COMP_WORDBREAKS=${COMP_WORDBREAKS//:/}
export COMP_WORDBREAKS=${COMP_WORDBREAKS//@/}
```

This allows completion to preserve the full `user@host` format for:
- ssh
- scp
- sftp
- slogin

## Testing

- ✅ Passes shellcheck with no warnings
- ✅ Passes shfmt formatting checks
- ✅ Passes all pre-commit hooks
- ✅ Completion now preserves user@host format

## Related

Closes #2260

🤖 Generated with [Claude Code](https://claude.com/claude-code)