### PR TITLE
Improve uninstall script to preserve current config

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -49,10 +49,18 @@ if [[ ! -e "${HOME?}/$BACKUP_FILE" ]]; then
 		&& mv "${HOME?}/$CONFIG_FILE" "${HOME?}/$CONFIG_FILE.uninstall" \
 		&& printf '\e[0;32m%s\e[0m\n' "Moved your ~/$CONFIG_FILE to ~/$CONFIG_FILE.uninstall."
 else
+	# Create a backup of the current config before restoring the old one
+	if [[ -e "${HOME?}/$CONFIG_FILE" ]]; then
+		cp -a "${HOME?}/$CONFIG_FILE" "${HOME?}/$CONFIG_FILE.pre-uninstall.bak"
+		printf '\e[0;33m%s\e[0m\n' "Current ~/$CONFIG_FILE backed up to ~/$CONFIG_FILE.pre-uninstall.bak"
+	fi
+
 	test -w "${HOME?}/$BACKUP_FILE" \
 		&& cp -a "${HOME?}/$BACKUP_FILE" "${HOME?}/$CONFIG_FILE" \
 		&& rm "${HOME?}/$BACKUP_FILE" \
 		&& printf '\e[0;32m%s\e[0m\n' "Your original ~/$CONFIG_FILE has been restored."
+
+	printf '\e[0;33m%s\e[0m\n' "NOTE: If you had made changes since installing Bash-it, they are preserved in ~/$CONFIG_FILE.pre-uninstall.bak"
 fi
 
 printf '\n\e[0;32m%s\e[0m\n\n' "Uninstallation finished successfully! Sorry to see you go!"


### PR DESCRIPTION
## Summary

Improves the uninstall script to preserve user's current configuration before restoring the old backup.

## Problem

The uninstall script was blindly restoring from a backup file created during initial installation, potentially overwriting months or years of changes with no way to recover them.

Example scenario:
1. User installs bash-it in 2023
2. User makes extensive customizations to .bashrc over the next year
3. User runs uninstall.sh in 2024
4. All 2024 changes are lost, replaced with 2023 backup

## Solution

Before restoring the old backup, create a new backup of the current config:
- Saves current config to `~/.bashrc.pre-uninstall.bak` (or `~/.bash_profile.pre-uninstall.bak`)
- Clear messaging about where the backup is saved
- Users can review and merge changes if needed
- Fully backwards compatible

## Changes

```bash
# Create a backup of the current config before restoring the old one
if [[ -e "${HOME?}/$CONFIG_FILE" ]]; then
    cp -a "${HOME?}/$CONFIG_FILE" "${HOME?}/$CONFIG_FILE.pre-uninstall.bak"
    printf "Current ~/$CONFIG_FILE backed up to ~/$CONFIG_FILE.pre-uninstall.bak"
fi
```

## Testing

- ✅ Passes shellcheck with no warnings
- ✅ Passes shfmt formatting checks
- ✅ Passes all pre-commit hooks
- ✅ Backwards compatible with existing uninstall flow

## Related

Closes #2238

🤖 Generated with [Claude Code](https://claude.com/claude-code)