### PR TITLE
Add NODE_VERSION_CHECK_PROJECT option for conditional node version display

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -400,7 +400,7 @@ function node_command_version_prompt() {
 
 	# If NODE_VERSION_CHECK_PROJECT is enabled, only show version in Node.js projects
 	if [[ "${NODE_VERSION_CHECK_PROJECT}" == "true" ]] && ! _is_node_project; then
-		return
+		return 0
 	fi
 
 	local node_version
@@ -453,7 +453,7 @@ function node_version_prompt() {
 
 	# If NODE_VERSION_CHECK_PROJECT is enabled, only show version in Node.js projects
 	if [[ "${NODE_VERSION_CHECK_PROJECT}" == "true" ]] && ! _is_node_project; then
-		return
+		return 0
 	fi
 
 	if [ "$NODE_VERSION_STRATEGY" == "nvm" ]; then


### PR DESCRIPTION
## Summary

Adds the ability to only show node version in the prompt when inside a Node.js project directory.

## Problem

The node version is always displayed in the prompt regardless of context. This wastes valuable prompt space when working on:
- Python projects
- Ansible playbooks
- Ruby projects
- Documentation directories
- Any non-Node.js work

## Solution

New environment variable `NODE_VERSION_CHECK_PROJECT`:
- **Default**: `false` (maintains current behavior)
- **When `true`**: Node version only shows in directories containing `package.json`
- Searches current directory and all parent directories up to `$HOME`

## Usage

Add to `~/.bashrc` or `~/.bash_profile` before sourcing bash-it:
```bash
export NODE_VERSION_CHECK_PROJECT=true
```

## Implementation Details

**New Helper Function:**
```bash
_is_node_project() {
  # Searches for package.json in current and parent directories
}
```

**Modified Functions:**
- `node_version_prompt()` - Main version display function
- `node_command_version_prompt()` - Legacy version display

**Compatibility:**
- Fully backwards compatible (off by default)
- Works with all node version strategies: `nvm`, `node`, `command`
- No impact on existing configurations

## Example Behavior

**Without `NODE_VERSION_CHECK_PROJECT` (current behavior):**
```bash
~/python-project $ # Shows: v20.10.0
~/ansible-playbooks $ # Shows: v20.10.0
~/nodejs-app $ # Shows: v20.10.0
```

**With `NODE_VERSION_CHECK_PROJECT=true`:**
```bash
~/python-project $ # No node version shown
~/ansible-playbooks $ # No node version shown
~/nodejs-app $ # Shows: v20.10.0 (has package.json)
```

## Testing

- ✅ Passes shellcheck with no warnings
- ✅ Passes shfmt formatting checks
- ✅ Passes all pre-commit hooks
- ✅ Maintains backwards compatibility

## Related

Closes #2216

## Inspiration

Similar to [Powerlevel10k's approach](https://github.com/romkatv/powerlevel10k/issues/373) referenced in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)