### PR TITLE
Fix bats TAP count mismatch on Ubuntu CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         which parallel  # Verify installation
     - name: Test code
       run: test/run
+      env:
+        # Ubuntu runners ship GNU parallel, causing --tap + --jobs count mismatches.
+        # Force single-threaded on Linux; let macOS use parallel (installed above).
+        TEST_JOBS: ${{ runner.os == 'Linux' && '1' || 'detect' }}
 
   build-docs:
     runs-on: ubuntu-latest

--- a/test/run
+++ b/test/run
@@ -25,7 +25,8 @@ fi
 # AND that it is the GNU version of `parallel`.
 # If that is the case, try to guess the number of CPU cores,
 # so we can run `bats` in parallel processing mode, which is a lot faster.
-if command -v parallel &> /dev/null \
+if [[ "${TEST_JOBS:-detect}" != "1" ]] \
+	&& command -v parallel &> /dev/null \
 	&& parallel -V &> /dev/null \
 	&& { parallel -V 2> /dev/null | grep -q '^GNU\>'; }; then
 	# Expect to run at least on a dual-core CPU; slightly degraded performance


### PR DESCRIPTION
## Problem

Ubuntu 24.04 GitHub Actions runners ship GNU `parallel`, so `test/run` detects it and invokes bats with `--jobs N --tap`. This combination produces a TAP plan count mismatch — e.g. `Executed 256 instead of expected 289 tests` — causing exit code 1 even when every individual test passes. Seen in the CI run for #2387.

This is the Linux-side counterpart of the issue fixed for macOS in #2379.

## Fix

Set `TEST_JOBS: 1` for Linux runners so bats falls back to single-threaded mode, sidestepping the `--tap + --jobs` count-mismatch bug. macOS keeps parallel execution as set up in #2379.

```yaml
env:
  TEST_JOBS: ${{ runner.os == 'Linux' && '1' || 'detect' }}
```

## Test plan

- [ ] CI passes on ubuntu-24.04 (no "Executed N instead of expected M tests" warning)
- [ ] macOS still runs with parallel (no regression from #2379)