### PR TITLE
Fix git get_default_branch remote

### DIFF
--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -245,6 +245,6 @@ function get_default_branch() {
 	fi
 
 	if [ -n "$default_remote" ] && branch=$(git symbolic-ref --quiet --short refs/remotes/"${default_remote}"/HEAD); then
-		echo "${branch#${default_remote}/}"
+		echo "${branch#"${default_remote}"/}"
 	fi
 }

--- a/aliases/available/git.aliases.bash
+++ b/aliases/available/git.aliases.bash
@@ -234,6 +234,17 @@ function gdv() {
 }
 
 function get_default_branch() {
-	branch=$(git symbolic-ref refs/remotes/origin/HEAD)
-	echo "${branch#refs/remotes/origin/}"
+	local default_remote branch
+
+	# Try origin first (most common)
+	if git remote | grep -q "^origin$"; then
+		default_remote="origin"
+	else
+		# Fall back to the first available remote
+		default_remote=$(git remote | head -n 1)
+	fi
+
+	if [ -n "$default_remote" ] && branch=$(git symbolic-ref --quiet --short refs/remotes/"${default_remote}"/HEAD); then
+		echo "${branch#${default_remote}/}"
+	fi
 }

--- a/test/aliases/git.bats
+++ b/test/aliases/git.bats
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Shine Nelson <bash-it@shinenelson.com>
+# SPDX-License-Identifier: MIT
+
 # shellcheck shell=bats
 
 load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"

--- a/test/aliases/git.bats
+++ b/test/aliases/git.bats
@@ -28,13 +28,13 @@ function local_setup() {
 	assert_output "main"
 }
 
-@test "get_default_branch: returns master when origin points to master" {
+@test "get_default_branch: returns trunk when origin points to trunk" {
 	git remote add origin "https://github.com/test/repo.git"
-	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/trunk
 
 	run get_default_branch
 	assert_success
-	assert_output "master"
+	assert_output "trunk"
 }
 
 @test "get_default_branch: falls back to first remote when origin doesn't exist" {
@@ -63,20 +63,20 @@ function local_setup() {
 
 @test "get_default_branch: properly strips remote prefix from branch name" {
 	git remote add origin "https://github.com/test/repo.git"
-	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/trunk
 
 	run get_default_branch
 	assert_success
-	assert_output "develop"
+	assert_output "trunk"
 }
 
 @test "get_default_branch: uses origin when both origin and another remote exist" {
 	git remote add upstream "https://github.com/upstream/repo.git"
 	git remote add origin "https://github.com/test/repo.git"
 	git symbolic-ref refs/remotes/upstream/HEAD refs/remotes/upstream/main
-	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/trunk
 
 	run get_default_branch
 	assert_success
-	assert_output "master"
+	assert_output "trunk"
 }

--- a/test/aliases/git.bats
+++ b/test/aliases/git.bats
@@ -1,0 +1,79 @@
+# shellcheck shell=bats
+
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup_file() {
+	setup_libs ""
+}
+
+function local_setup() {
+	TEST_REPO="${BATS_FILE_TMPDIR}/test-repo-${BATS_TEST_NUMBER}"
+	mkdir -p "${TEST_REPO}"
+	cd "${TEST_REPO}" || false
+	git init . 2>&1 | grep -v "Reinitialized" || true
+
+	source "${BASH_IT?}/aliases/available/git.aliases.bash"
+}
+
+@test "get_default_branch: returns main when origin points to main" {
+	# Set up a local remote-like structure
+	git remote add origin "https://github.com/test/repo.git"
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+
+	run get_default_branch
+	assert_success
+	assert_output "main"
+}
+
+@test "get_default_branch: returns master when origin points to master" {
+	git remote add origin "https://github.com/test/repo.git"
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+
+	run get_default_branch
+	assert_success
+	assert_output "master"
+}
+
+@test "get_default_branch: falls back to first remote when origin doesn't exist" {
+	git remote add upstream "https://github.com/upstream/repo.git"
+	git symbolic-ref refs/remotes/upstream/HEAD refs/remotes/upstream/main
+
+	run get_default_branch
+	assert_success
+	assert_output "main"
+}
+
+@test "get_default_branch: returns empty when no remotes exist" {
+	run get_default_branch
+	assert_success
+	assert_output ""
+}
+
+@test "get_default_branch: returns empty when remote has no HEAD ref" {
+	git remote add origin "https://github.com/test/repo.git"
+	# Don't set a HEAD ref, so the git symbolic-ref command will fail
+
+	run get_default_branch
+	assert_success
+	assert_output ""
+}
+
+@test "get_default_branch: properly strips remote prefix from branch name" {
+	git remote add origin "https://github.com/test/repo.git"
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop
+
+	run get_default_branch
+	assert_success
+	assert_output "develop"
+}
+
+@test "get_default_branch: uses origin when both origin and another remote exist" {
+	git remote add upstream "https://github.com/upstream/repo.git"
+	git remote add origin "https://github.com/test/repo.git"
+	git symbolic-ref refs/remotes/upstream/HEAD refs/remotes/upstream/main
+	git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+
+	run get_default_branch
+	assert_success
+	assert_output "master"
+}

--- a/test/run
+++ b/test/run
@@ -16,7 +16,7 @@ fi
 
 # Which tests do we run?
 if [[ $# -eq '0' ]]; then
-	test_dirs=("${test_directory}"/{bash_it,completion,install,lib,plugins,themes})
+	test_dirs=("${test_directory}"/{aliases,bash_it,completion,install,lib,plugins,themes})
 else
 	test_dirs=("$@")
 fi


### PR DESCRIPTION
## Description
This change-set improves the get_default_branch function in
git.aliases.bash to pick any configured remote if origin is
unavailable.

## Motivation and Context
Previously, the get_default_branch function assumed 'origin' as the
remote and tried to get the symbolic-ref of that remote. For people
whose [defaultRemoteName] is custom and not 'origin', the function is
broken which in turn breaks all aliases calling the function.

Instead of assuming the default remote is always 'origin', the
function now:
- Checks if origin exists and uses it as the default remote
- Falls back to the first available remote if origin doesn't exist
- Properly detects the default branch for the selected remote

[defaultRemoteName]: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-clonedefaultRemoteName

## How Has This Been Tested?
There were no tests that existed because this was a function within
aliases. New tests has been added for the function.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
