### PR TITLE
fix(barbuk): Handle podman as docker_host in docker segment

### DIFF
--- a/themes/barbuk/barbuk.theme.bash
+++ b/themes/barbuk/barbuk.theme.bash
@@ -246,7 +246,12 @@ function __docker_prompt() {
 		if [ -n "$DOCKER_CONTEXT" ]; then
 			docker_context="$DOCKER_CONTEXT"
 		elif [ -n "$DOCKER_HOST" ]; then
-			docker_context="$DOCKER_HOST"
+			if [[ $DOCKER_HOST = *podman.sock ]]; then
+				DOCKER_CHAR=" "
+				docker_context="podman"
+			else
+				docker_context="$DOCKER_HOST"
+			fi
 		elif [ -f .env ] && grep -qF COMPOSE_PROJECT_NAME .env; then
 			docker_context=$(awk -F'[ \t\n=]+' '/COMPOSE_PROJECT_NAME/ {print $2; exit}' .env)
 		fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The docker segment will now detect if a podman socket is present and display the information.

## Motivation and Context

Migrated to podman, wanted to have the correct information displayed.
Before that, podman was not considered at all.

## How Has This Been Tested?

On a directory that contain a dockerfile or dockercompose, this will now display a podman logo + test.

## Screenshots (if appropriate):

<img width="932" height="96" alt="image" src="https://github.com/user-attachments/assets/7b71c1f5-b9d8-4ed8-b711-64e666d762d6" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [X] I have added tests to cover my changes, and all the new and existing tests pass.
