### PR TITLE
New tab completions: 1password-cli and herdr

### DIFF
--- a/completion/available/herdr.completion.bash
+++ b/completion/available/herdr.completion.bash
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+about-completion "Herdr Terminal Multiplexer tab completion"
+
+if ! _binary_exists herdr; then
+	_log_error "herdr not found in PATH — completion not loaded. (${BASH_SOURCE[0]})"
+	return 1
+else
+	if ! _bash-it-completion-helper-sufficient herdr; then
+		_log_warning "The completion is set for 'herdr' externally. Activation will be skipped. (${BASH_SOURCE[0]})"
+	else
+		eval "$(herdr completion bash)"
+	fi
+fi

--- a/completion/available/op.completion.bash
+++ b/completion/available/op.completion.bash
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+about-completion "1Password CLI tab completion"
+
+if ! _binary_exists op; then
+	_log_error "op not found in PATH — completion not loaded. (${BASH_SOURCE[0]})"
+	return 1
+else
+	if ! _bash-it-completion-helper-sufficient op; then
+		_log_warning "The completion is set for 'op' externally. Activation will be skipped. (${BASH_SOURCE[0]})"
+	else
+		eval "$(op completion bash)"
+	fi
+fi

--- a/test/completion/herdr.completion.bats
+++ b/test/completion/herdr.completion.bats
@@ -1,0 +1,47 @@
+# shellcheck shell=bats
+
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup_file() {
+	setup_libs "helpers"
+	load "${BASH_IT?}/lib/completion.bash"
+}
+
+function local_setup() {
+	MOCK_BIN="${BATS_TEST_TMPDIR}/mock-bin"
+	mkdir -p "${MOCK_BIN}"
+	_SAVED_PATH="${PATH}"
+}
+
+function local_teardown() {
+	PATH="${_SAVED_PATH}"
+	complete -r herdr 2> /dev/null || true
+}
+
+function _mock_herdr() {
+	printf '%s\n' \
+		'#!/usr/bin/env bash' \
+		'[[ "$*" == "completion bash" ]] && echo "complete -o nospace herdr"' \
+		> "${MOCK_BIN}/herdr"
+	chmod +x "${MOCK_BIN}/herdr"
+	PATH="${MOCK_BIN}:${PATH}"
+}
+
+@test "completion herdr: fails to load when herdr is not in PATH" {
+	PATH="${MOCK_BIN}" run source "${BASH_IT?}/completion/available/herdr.completion.bash"
+	assert_failure
+}
+
+@test "completion herdr: loads successfully when herdr is available" {
+	_mock_herdr
+	run source "${BASH_IT?}/completion/available/herdr.completion.bash"
+	assert_success
+}
+
+@test "completion herdr: skips eval when completion is already managed externally" {
+	_mock_herdr
+	complete -F : herdr
+	source "${BASH_IT?}/completion/available/herdr.completion.bash"
+	run complete -p herdr
+	assert_output "complete -F : herdr"
+}

--- a/test/completion/op.completion.bats
+++ b/test/completion/op.completion.bats
@@ -1,0 +1,47 @@
+# shellcheck shell=bats
+
+load "${MAIN_BASH_IT_DIR?}/test/test_helper.bash"
+
+function local_setup_file() {
+	setup_libs "helpers"
+	load "${BASH_IT?}/lib/completion.bash"
+}
+
+function local_setup() {
+	MOCK_BIN="${BATS_TEST_TMPDIR}/mock-bin"
+	mkdir -p "${MOCK_BIN}"
+	_SAVED_PATH="${PATH}"
+}
+
+function local_teardown() {
+	PATH="${_SAVED_PATH}"
+	complete -r op 2> /dev/null || true
+}
+
+function _mock_op() {
+	printf '%s\n' \
+		'#!/usr/bin/env bash' \
+		'[[ "$*" == "completion bash" ]] && echo "complete -o nospace op"' \
+		> "${MOCK_BIN}/op"
+	chmod +x "${MOCK_BIN}/op"
+	PATH="${MOCK_BIN}:${PATH}"
+}
+
+@test "completion op: fails to load when op is not in PATH" {
+	PATH="${MOCK_BIN}" run source "${BASH_IT?}/completion/available/op.completion.bash"
+	assert_failure
+}
+
+@test "completion op: loads successfully when op is available" {
+	_mock_op
+	run source "${BASH_IT?}/completion/available/op.completion.bash"
+	assert_success
+}
+
+@test "completion op: skips eval when completion is already managed externally" {
+	_mock_op
+	complete -F : op
+	source "${BASH_IT?}/completion/available/op.completion.bash"
+	run complete -p op
+	assert_output "complete -F : op"
+}


### PR DESCRIPTION
## Description

Adds bash-it completion wrappers for:

- **[1Password CLI](https://developer.1password.com/docs/cli/)** (`op`)
- **[Herdr](https://herdr.io/)** (`herdr`)

Both tools natively expose `<tool> completion bash`, which these wrappers plug into bash-it's completion lifecycle.

### Why not the standard pattern?

A common completion pattern uses `|| return` as the fallback on binary or existing completion checks, meaning the `eval` call is skipped silently when the binary is missing, and things easily go unnoticed.

These completions instead check the binary explicitly and stop early with a clear message: No silent failures. Users get an actionable message telling them exactly what didn't load and where the file lives — without needing to enable full debug mode.

This is a split-out of #2395, isolating the completion scripts and their tests from the unrelated CI fix and local test-runner changes bundled in that PR. Commits are cherry-picked with original authorship preserved (author: @leventyalcin).

## Types of changes
- [x] New feature (non-breaking change which adds functionality)