### PR TITLE
fix(ci): extend bats TAP count mismatch fix to macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,11 @@ jobs:
     - name: Install greadlink
       if: startsWith(runner.os, 'macOS')
       run: brew install coreutils
-    - name: Install parallel
-      if: startsWith(runner.os, 'macOS')
-      run: |
-        brew install parallel
-        which parallel  # Verify installation
     - name: Test code
       run: test/run
       env:
-        # Ubuntu runners ship GNU parallel, causing --tap + --jobs count mismatches.
-        # Force single-threaded on Linux; let macOS use parallel (installed above).
-        TEST_JOBS: ${{ runner.os == 'Linux' && '1' || 'detect' }}
+        # --tap + --jobs causes TAP plan count mismatches on both Linux and macOS.
+        TEST_JOBS: 1
 
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

`--tap` + `--jobs` causes bats to declare a test plan it can't fulfil on Linux, fixed by forcing `TEST_JOBS=1`. The macOS job was left on `TEST_JOBS=detect` with GNU parallel explicitly installed, hitting the same mismatch and exiting with code 1 despite all tests passing.

Removes the parallel install step and applies `TEST_JOBS=1` unconditionally, matching the existing Linux fix.

This is a split-out of #2395, isolating the CI fix from the unrelated 1Password/Herdr completion additions and local test-runner changes bundled in that PR. Commit is cherry-picked with original authorship preserved (author: @leventyalcin).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)